### PR TITLE
Fix nova barclamp paths for Cloud 5

### DIFF
--- a/xml/depl_troubleshooting.xml
+++ b/xml/depl_troubleshooting.xml
@@ -568,7 +568,7 @@ EOF</screen>
        To activate changes to these files, the following command needs to be
        executed:
       </para>
-<screen>barclamp_install.rb --rpm /opt/dell/barclamps/openstack/</screen>
+<screen>barclamp_install.rb --rpm /opt/dell/barclamps/nova/</screen>
      </answer>
     </qandaentry>
     <qandaentry id="sec.depl.trouble.faq.misc.keymap">
@@ -597,7 +597,7 @@ EOF</screen>
         <para>
          Run the following command on the &admserv;:
         </para>
-<screen>barclamp_install.rb --rpm /opt/dell/barclamps/openstack/</screen>
+<screen>barclamp_install.rb --rpm /opt/dell/barclamps/nova/</screen>
        </step>
       </procedure>
      </answer>


### PR DESCRIPTION
It was introduced by dd4ad5129e4a16b0ea82fcd0dd6c7fac4b266d76