### PR TITLE
make interface parameter names match list

### DIFF
--- a/xml/depl_network_json.xml
+++ b/xml/depl_network_json.xml
@@ -512,7 +512,7 @@ lrwxrwxrwx 1 0 Jun 19 08:43 eth3 -&gt; ../../devices/pci0000:00/0000:00:1c.0/000
     <para>
      The physical interfaces definition needs to fit the following pattern:
     </para>
-<screen>[Quantifier][Speed][Interface Number]</screen>
+<screen>[Quantifier][Speed][Order]</screen>
     <para>
      Valid examples are <literal>+1g2</literal>, <literal>10g1</literal> or
      <literal>?1g2</literal>.


### PR DESCRIPTION
Each component in physical interface definitions (e.g. "10g2") should
the the parameter name correspond to the subtitle of its long
description in the list below it, otherwise it's confusing.