### PR TITLE
Fix paragraph about admin node requirements

### DIFF
--- a/xml/depl_require.xml
+++ b/xml/depl_require.xml
@@ -1338,7 +1338,10 @@
     </listitem>
     <listitem>
      <para>
-      RAM: at least 4 GB, 8 GB recommended
+      RAM: at least 4 GB, 8 GB recommended. The demand for memory depends on
+      the total number of nodes managed by the &admserv; the higher the number
+      of nodes, the more RAM is needed. A deployment with 50 nodes requires
+      a minimum of 24 GB RAM.
      </para>
     </listitem>
     <listitem>
@@ -1376,10 +1379,7 @@
     </listitem>
     <listitem>
      <para>
-      RAM: at least 6 GB, 12 GB when deploying a single &contrnode;. The demand
-      for memory depends on the total number of nodes in &cloud;&mdash;the
-      higher the number of nodes, the more RAM is needed. A deployment with 50
-      nodes requires a minimum of 24 GB RAM for each &contrnode;.
+      RAM: at least 6 GB, 12 GB when deploying a single &contrnode;.
      </para>
     </listitem>
     <listitem>


### PR DESCRIPTION
The paragraph about the dynamic RAM requirements belongs to the admin
server.

@fsundermeyer This was probably my fault, sorry for the inconvenience.