### PR TITLE
clarify why compute HA needs shared storage for instances

### DIFF
--- a/xml/depl_nodes.xml
+++ b/xml/depl_nodes.xml
@@ -3572,10 +3572,16 @@ getent group postgres | cut -d: -f3</screen>
     <title>Shared Storage</title>
     <para>
      It is recommended to use shared storage for the
-     <filename>/var/lib/nova/instances</filename> directory. If an external NFS
-     server is used, enable the following option in the &o_comp; &barcl;
-     proposal: <guimenu>Shared Storage for Nova instances has been manually
-      configured</guimenu>.
+     <filename>/var/lib/nova/instances</filename> directory, in order
+     to ensure that ephemeral disks will be preserved during recovery
+     of VMs from failed compute nodes.  Without shared storage, any
+     ephemeral disks will be lost, and recovery will rebuild the VM
+     from its original image.
+    </para>
+    <para>
+     If an external NFS server is used, enable the following option in
+     the &o_comp; &barcl; proposal: <guimenu>Shared Storage for Nova
+     instances has been manually configured</guimenu>.
     </para>
    </tip>
   </sect2>


### PR DESCRIPTION
What do you guys think about this?  Does this shared storage consideration actually belong in [the Considerations and Requirements section of the Architecture and Requirements chapter](http://docserv.nue.suse.com/documents/Cloud7/suse-openstack-cloud-deployment/single-html/#sec.depl.reg.ha.compute) instead?