### PR TITLE
Add SLEShammer to the glossary

### DIFF
--- a/xml/glossary.xml
+++ b/xml/glossary.xml
@@ -10,7 +10,7 @@
  the other terms it might make more sense to include the upstream glossary that is appended to all
  upstream manuals -->
 <glossary xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.0" xml:id="gl.cloud">
-    <title>Terminology: A glossary of terms and product names</title>
+    <title>Glossary of Terminology and Product Names</title>
      <info>
  <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
     <dm:maintainer>fs</dm:maintainer>
@@ -965,7 +965,8 @@
   <glossentry xml:id="gloss.hammer"><glossterm>SLEShammer</glossterm>
   <glossdef>
    <para>
-    When you first boot a node in Cloud via PXE, it is booted with the SLEShammer image. This performs the initial hardware discovery, and  registers the node with crowbar. Once you allocate the node, it is rebooted with a regular SLES installation image.
+    When you first boot a node in &productname; via PXE, it is booted with the SLEShammer image. This performs the initial hardware discovery, and registers the node with &crow;.
+    After you allocate the node, it is rebooted with a regular SLES installation image.
    </para>
   </glossdef>
  </glossentry> 

--- a/xml/glossary.xml
+++ b/xml/glossary.xml
@@ -10,9 +10,9 @@
  the other terms it might make more sense to include the upstream glossary that is appended to all
  upstream manuals -->
 <glossary xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.0" xml:id="gl.cloud">
- <title>Terminology</title>
- <info>
-<dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
+    <title>Terminology: A glossary of terms and product names</title>
+     <info>
+ <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
     <dm:maintainer>fs</dm:maintainer>
     <dm:status>editing</dm:status>
     <dm:deadline/>
@@ -962,6 +962,13 @@
    </para>
   </glossdef>
  </glossentry>
+  <glossentry xml:id="gloss.hammer"><glossterm>SLEShammer</glossterm>
+  <glossdef>
+   <para>
+    When you first boot a node in Cloud via PXE, it is booted with the SLEShammer image. This performs the initial hardware discovery, and  registers the node with crowbar. Once you allocate the node, it is rebooted with a regular SLES installation image.
+   </para>
+  </glossdef>
+ </glossentry> 
  <glossentry><glossterm>Snapshot</glossterm>
   <glossdef>
    <para>


### PR DESCRIPTION
I also added the subtitle 'A glossary of terms and product names' so that searches for 'glossary' would find it, and make it more prominent in the TOC