### PR TITLE
ch 11.8 proofread; several guimenu corrections

### DIFF
--- a/xml/depl_nodes.xml
+++ b/xml/depl_nodes.xml
@@ -2297,7 +2297,7 @@ getent group postgres | cut -d: -f3</screen>
     </listitem>
    </varlistentry>
    <varlistentry>
-    <term><guimenu>User Name</guimenu> / <guimenu>Password for accessing the ECOM server</guimenu>
+    <term><guimenu>Username for accessing the ECOM server</guimenu> / <guimenu>Password for accessing the ECOM server</guimenu>
     </term>
     <listitem>
      <para>
@@ -2372,7 +2372,7 @@ getent group postgres | cut -d: -f3</screen>
     </listitem>
    </varlistentry>
    <varlistentry>
-    <term><guimenu>IP</guimenu> / <guimenu>Port for SMI-S</guimenu></term>
+    <term><guimenu>IP for SMI-S</guimenu> / <guimenu>Port for SMI-S</guimenu></term>
     <listitem>
      <para>
       IP address and port of the ETERNUS SMI-S Server.
@@ -2380,7 +2380,7 @@ getent group postgres | cut -d: -f3</screen>
     </listitem>
    </varlistentry>
    <varlistentry>
-    <term><guimenu>Username</guimenu> / <guimenu>Password for SMI-S</guimenu></term>
+    <term><guimenu>Username for SMI-S</guimenu> / <guimenu>Password for SMI-S</guimenu></term>
     <listitem>
      <para>
       Login credentials for the ETERNUS SMI-S Server.
@@ -2457,7 +2457,7 @@ getent group postgres | cut -d: -f3</screen>
     </listitem>
    </varlistentry>
    <varlistentry>
-    <term><guimenu>User Name</guimenu> / <guimenu>Password for Accessing NetApp</guimenu>
+    <term><guimenu>Username for accessing NetApp</guimenu> / <guimenu>Password for Accessing NetApp</guimenu>
     </term>
     <listitem>
      <para>

--- a/xml/depl_nodes.xml
+++ b/xml/depl_nodes.xml
@@ -2225,14 +2225,14 @@ getent group postgres | cut -d: -f3</screen>
   <para>
    &o_blockstore;, the successor of Nova Volume, provides volume block
    storage. It adds persistent storage to an &vmguest; that will persist
-   until deleted (contrary to ephemeral volumes that will only persist while
-   the &vmguest; is running).
+   until deleted, contrary to ephemeral volumes that only persist while
+   the &vmguest; is running.
   </para>
 
   <para>
    &o_blockstore; can provide volume storage by using different back-ends
-   such as local file, one or more local disks, &ceph; (RADOS), VMware or
-   network storage solutions from EMC, EqualLogic, Fujitsu or NetApp. Since
+   such as local file, one or more local disks, &ceph; (RADOS), VMware, or
+   network storage solutions from EMC, EqualLogic, Fujitsu, or NetApp. Since
    &productname; 5, &o_blockstore; supports using several back-ends
    simultaneously. It is also possible to deploy the same network storage
    back-end multiple times and therefore use different installations at the
@@ -2250,16 +2250,7 @@ getent group postgres | cut -d: -f3</screen>
   <tip>
    <title>Adding or Changing a Back-End</title>
    <para>
-    When first opening the &o_blockstore; &barcl;, the default
-    proposal&mdash;<guimenu>Raw Devices</guimenu>&mdash; is already available
-    for configuration. To optionally add a back-end, go to the section
-    <guimenu>Add New Cinder Back-End</guimenu> and choose a <guimenu>Type Of
-    Volume</guimenu> from the drop-down box. Optionally, specify the
-    <guimenu>Name for the Backend</guimenu>. This is recommended when
-    deploying the same volume type more than once. Existing back-end
-    configurations (including the default one) can be deleted by clicking the
-    trashcan icon if no longer needed. Note that at least one back-end must be
-    configured.
+    When first opening the &o_blockstore; &barcl;, the default proposal&mdash;<guimenu>Raw Devices</guimenu>&mdash;is already available for configuration. To optionally add a back-end, go to the section <guimenu>Add New Cinder Back-End</guimenu> and choose a <guimenu>Type Of Volume</guimenu> from the drop-down box. Optionally, specify the <guimenu>Name for the Backend</guimenu>. This is recommended when deploying the same volume type more than once. Existing back-end configurations (including the default one) can be deleted by clicking the trashcan icon if no longer needed. Note that you must configure at least one back-end.
    </para>
   </tip>
 
@@ -2272,9 +2263,9 @@ getent group postgres | cut -d: -f3</screen>
     </term>
     <listitem>
      <para>
-      Choose whether to only use the <guimenu>First Available</guimenu> disk
+      Choose whether to use the <guimenu>First Available</guimenu> disk
       or <guimenu>All Available</guimenu> disks. <quote>Available
-      disks</quote> are all disks, currently not used by the system. Note
+      disks</quote> are all disks currently not used by the system. Note
       that one disk (usually <filename>/dev/sda</filename>) of every block
       storage node is already used for the operating system and is not
       available for &o_blockstore;.
@@ -2295,7 +2286,7 @@ getent group postgres | cut -d: -f3</screen>
   <bridgehead renderas="sect3"><guimenu>EMC</guimenu> (EMC² Storage)
   </bridgehead>
 
-  <variablelist>
+    <variablelist>
    <varlistentry>
     <term><guimenu>IP address of the ECOM server</guimenu> / <guimenu>Port of the ECOM server</guimenu>
     </term>
@@ -2306,7 +2297,7 @@ getent group postgres | cut -d: -f3</screen>
     </listitem>
    </varlistentry>
    <varlistentry>
-    <term><guimenu>User Name / Password for accessing the ECOM server</guimenu>
+    <term><guimenu>User Name</guimenu> / <guimenu>Password for accessing the ECOM server</guimenu>
     </term>
     <listitem>
      <para>
@@ -2381,7 +2372,7 @@ getent group postgres | cut -d: -f3</screen>
     </listitem>
    </varlistentry>
    <varlistentry>
-    <term>IP / Port for SMI-S</term>
+    <term><guimenu>IP</guimenu> / <guimenu>Port for SMI-S</guimenu></term>
     <listitem>
      <para>
       IP address and port of the ETERNUS SMI-S Server.
@@ -2389,7 +2380,7 @@ getent group postgres | cut -d: -f3</screen>
     </listitem>
    </varlistentry>
    <varlistentry>
-    <term>Username / Password for SMI-S</term>
+    <term><guimenu>Username</guimenu> / <guimenu>Password for SMI-S</guimenu></term>
     <listitem>
      <para>
       Login credentials for the ETERNUS SMI-S Server.
@@ -2397,13 +2388,12 @@ getent group postgres | cut -d: -f3</screen>
     </listitem>
    </varlistentry>
    <varlistentry>
-    <term>Snapshot (Thick/RAID Group) Pool Name</term>
+    <term><guimenu>Snapshot (Thick/RAID Group) Pool Name</guimenu></term>
     <listitem>
      <para>
       Storage pool (RAID group) in which the volumes are created. Make sure
-      to have created that RAID group on the server in advance. If a RAID
-      group that does not exist is specified, the RAID group is created by
-      using unused disk drives. The RAID level is automatically determined
+      that the RAID group on the server has already been created. If a RAID
+      group that does not exist is specified, the RAID group is built from unused disk drives. The RAID level is automatically determined
       by the ETERNUS DX Disk storage system.
      </para>
     </listitem>
@@ -2421,15 +2411,15 @@ getent group postgres | cut -d: -f3</screen>
 
   <variablelist>
    <varlistentry>
-    <term><guimenu>Storage Family Type/Storage Protocol</guimenu>
+    <term><guimenu>Storage Family Type</guimenu> / <guimenu>Storage Protocol</guimenu>
     </term>
     <listitem>
      <para>
-      &cloud; can either use <quote>Data ONTAP</quote> in
-      <guimenu>7-Mode</guimenu> or in <guimenu>Clustered Mode</guimenu>. In
+      &cloud; can use <quote>Data ONTAP</quote> in
+      <guimenu>7-Mode</guimenu>, or in <guimenu>Clustered Mode</guimenu>. In
       <guimenu>7-Mode</guimenu> vFiler will be configured, in
       <guimenu>Clustered Mode</guimenu> vServer will be configured. The
-      <guimenu>Storage Protocoll</guimenu> can either be set to
+      <guimenu>Storage Protocol</guimenu> can be set to either
       <guimenu>iSCSI</guimenu> or <guimenu>NFS</guimenu>. Choose the driver
       and the protocol your NetApp is licensed for.
      </para>
@@ -2440,7 +2430,7 @@ getent group postgres | cut -d: -f3</screen>
     </term>
     <listitem>
      <para>
-      The management IP address for the 7-Mode storage controller or the
+      The management IP address for the 7-Mode storage controller, or the
       cluster management IP address for the clustered Data ONTAP.
      </para>
     </listitem>
@@ -2467,7 +2457,7 @@ getent group postgres | cut -d: -f3</screen>
     </listitem>
    </varlistentry>
    <varlistentry>
-    <term><guimenu>User Name/Password for Accessing NetApp</guimenu>
+    <term><guimenu>User Name</guimenu> / <guimenu>Password for Accessing NetApp</guimenu>
     </term>
     <listitem>
      <para>
@@ -2493,7 +2483,7 @@ getent group postgres | cut -d: -f3</screen>
     </term>
     <listitem>
      <para>
-      Provide a list of comma-separated volumes names to be used for
+      Provide a list of comma-separated volume names to be used for
       provisioning. This setting is only available when using iSCSI as
       storage protocol.
      </para>
@@ -2506,7 +2496,7 @@ getent group postgres | cut -d: -f3</screen>
 
   <variablelist>
     <varlistentry>
-      <term>List of NFS Exports</term>
+      <term><guimenu>List of NFS Exports</guimenu></term>
       <listitem>
         <para>
           A list of accessible physical file systems on an NFS server.<remark>2016-12-29 - dpopov: DEVS FIXME Please check whether this is correct.</remark>
@@ -2514,7 +2504,7 @@ getent group postgres | cut -d: -f3</screen>
       </listitem>
     </varlistentry>
     <varlistentry>
-      <term>Mount Options</term>
+      <term><guimenu>Mount Options</guimenu></term>
       <listitem>
         <para>
           Additional options for mounting NFS exports.<remark>2016-12-29 - dpopov: DEVS FIXME Please check whether this is correct.</remark>
@@ -2533,7 +2523,7 @@ getent group postgres | cut -d: -f3</screen>
     <listitem>
      <para>
       Select <guimenu>true</guimenu> if you have deployed &ceph; with
-      &cloud;. In case you are using an external &ceph; cluster (see
+      &cloud;. If you are using an external &ceph; cluster (see
       <xref linkend="sec.depl.inst.nodes.post.ceph_ext"/> for setup
       instructions), select <guimenu>false</guimenu>.
      </para>
@@ -2675,7 +2665,7 @@ getent group postgres | cut -d: -f3</screen>
 
   <para>
    Lets you manually pick and configure a driver. Only use this option for
-   testing purposes, it is not supported.
+   testing purposes, as it is not supported.
   </para>
 
   <figure>
@@ -2712,9 +2702,9 @@ getent group postgres | cut -d: -f3</screen>
     <listitem>
      <para>
       The virtual block storage service. It can be installed on a
-      &contrnode;. However, it is recommended to deploy it on one or more
+      &contrnode;. However, we recommend deploying it on one or more
       dedicated nodes supplied with sufficient networking capacity to handle
-      the increased in  network traffic.
+      the increase in network traffic.
      </para>
     </listitem>
    </varlistentry>
@@ -2756,11 +2746,11 @@ getent group postgres | cut -d: -f3</screen>
      or cluster that has a <guimenu>cinder-volume</guimenu> role applied to it.
     </para>
    </note>
-   <para>In addition with &ceph; or a network storage solution,
-    such a setup minimizes the potential downtime.
+   <para>In combination with &ceph; or a network storage solution,
+    deploying &o_blockstore; in a cluster minimizes the potential downtime.
     If using &ceph; or a network storage is not an option, you need to
     set up a shared storage directory (for example, with NFS), mount it on
-    all cinder volume nodes and use the <guimenu>Local File</guimenu>
+    all cinder volume nodes, and use the <guimenu>Local File</guimenu>
     back-end with this shared directory. Using <guimenu>Raw
     Devices</guimenu> is not an option, since local disks cannot be shared.
    </para>


### PR DESCRIPTION
Re guimenus and slashes. In most circumstances it is grammatically correct to use slashes with no surrounding spaces, like either/or, red/blue, foo/fie. However, when combining GUI form fields, e.g. <guimenu>vCenter Username</guimenu> / <guimenu>vCenter Password</guimenu>, inserting spaces makes sense as an indicator that it is two separate fields. There are no grammar rules for this (that I know of), so we can do what we want. For consistency, I enclosed each field name in guimenu tags, rather than combining them. I have no preference between <guimenu>vCenter Username</guimenu> / <guimenu>vCenter Password</guimenu> and <guimenu>vCenter Username / vCenter Password</guimenu>, I just like using a single convention.