### PR TITLE
Replace lbaasv1 commands with lbaasv2 commands in admin guide

### DIFF
--- a/xml/bk_openstack_admin.xml
+++ b/xml/bk_openstack_admin.xml
@@ -23620,28 +23620,28 @@ created with default provider for LBaaS service. You should configure
 the default provider in the <literal>[service_providers]</literal> section of the
 <literal>neutron.conf</literal> file. If no default provider is specified for LBaaS,
 the <literal>--provider</literal> parameter is required for pool creation.</para>
-            <screen>$ neutron lb-pool-create --lb-method ROUND_ROBIN --name mypool \
+            <screen>$ neutron lbaas-pool-create --lb-algorithm ROUND_ROBIN --name mypool \
   --protocol HTTP --subnet-id SUBNET_UUID --provider PROVIDER_NAME</screen>
           </listitem>
           <listitem>
             <para>Associates two web servers with pool.</para>
-            <screen>$ neutron lb-member-create --address  WEBSERVER1_IP --protocol-port 80 mypool
-$ neutron lb-member-create --address  WEBSERVER2_IP --protocol-port 80 mypool</screen>
+            <screen>$ neutron lbaas-member-create --address  WEBSERVER1_IP --protocol-port 80 mypool
+$ neutron lbaas-member-create --address  WEBSERVER2_IP --protocol-port 80 mypool</screen>
           </listitem>
           <listitem>
             <para>Creates a health monitor that checks to make sure our instances are
 still running on the specified protocol-port.</para>
-            <screen>$ neutron lb-healthmonitor-create --delay 3 --type HTTP --max-retries 3 \
+            <screen>$ neutron lbaas-healthmonitor-create --delay 3 --type HTTP --max-retries 3 \
   --timeout 3</screen>
           </listitem>
           <listitem>
             <para>Associates a health monitor with pool.</para>
-            <screen>$ neutron lb-healthmonitor-associate  HEALTHMONITOR_UUID mypool</screen>
+            <screen>$ neutron lbaas-healthmonitor-associate HEALTHMONITOR_UUID mypool</screen>
           </listitem>
           <listitem>
             <para>Creates a virtual IP (VIP) address that, when accessed through the
 load balancer, directs the requests to one of the pool members.</para>
-            <screen>$ neutron lb-vip-create --name myvip --protocol-port 80 --protocol \
+            <screen>$ neutron lbaas-vip-create --name myvip --protocol-port 80 --protocol \
   HTTP --subnet-id SUBNET_UUID mypool</screen>
           </listitem>
         </itemizedlist>


### PR DESCRIPTION
re bug #1031679. soc 7 uses openstac newton  which supports only lbaasv2
refs: https://media.readthedocs.org/pdf/f5-openstack-lbaasv2-driver/master/f5-openstack-lbaasv2-driver.pdf
https://docs.openstack.org/newton/networking-guide/config-lbaas.html