### PR TITLE
Revert "Update crowbar_join description"

### DIFF
--- a/xml/depl_troubleshooting.xml
+++ b/xml/depl_troubleshooting.xml
@@ -406,7 +406,7 @@ EOF</screen>
        What to do if a node is reported to be in the state
        <literal>Problem</literal>? What to do if a node hangs at
        <quote>Executing AutoYast script:
-           /usr/sbin/crowbar_join --setup</quote> after the installation has been finished?
+       /var/adm/autoinstall/init.d/crowbar_join</quote> after the installation has been finished?
       </para>
      </question>
      <answer>
@@ -418,14 +418,10 @@ EOF</screen>
        <filename>/var/log/crowbar/crowbar_join/chef.log</filename>. Fix the
        errors and restart the &ay; script by running the following command:
       </para>
-      <screen>crowbar_join --start</screen>
+      <screen>rccrowbar_join start</screen>
       <para>
        If successful, the node will be listed in state
        <literal>Ready</literal>, when the script has finished.
-      </para>
-      <para>
-       In cases where the initial --setup wasn't able to complete successfully,
-       you can rerun that once after the previous issue is solved.
       </para>
       <para>
        If that does not help or if the log does not provide useful


### PR DESCRIPTION
Reverts SUSE-Cloud/doc-cloud#108

I merged too quickly-- step 4 doesn't make sense:

1.  /usr/sbin/crowbar_join --setup hangs
2.  Check the log on the node, fix stuff
3.  run crowbar_join --start to restart and complete  /usr/sbin/crowbar_join --setup
4. "In cases where the initial --setup wasn't able to complete successfully, you can rerun that once after the previous issue is solved."

Steps 2 & 3 are the answer to step 4, aren't they? 


