### PR TITLE
ironic: Update driver information

### DIFF
--- a/xml/depl_nodes.xml
+++ b/xml/depl_nodes.xml
@@ -6002,15 +6002,11 @@ Apply the &barcl; to a Control Node.
     Intelligent Platform Management Interface (IPMI) to control the power state
     of your bare metal machines, creates the appropriate PXE configurations
     to start them, and then performs the steps to provision and configure the machines.</para>
-    <para>
-     <literal>pxe_ssh</literal> enables Ironic to simulate physical machines in
-     virtual machines.
-    </para>
 
-    <screen>"enabled_drivers": ["pxe_ipmitool", "pxe_ssh"],</screen>
+    <screen>"enabled_drivers": ["pxe_ipmitool"],</screen>
     <para>
      See <link
-     xlink:href="https://wiki.openstack.org/wiki/Ironic/Drivers">Ironic
+     xlink:href="https://docs.openstack.org/ironic/latest/admin/drivers.html">Ironic
      Drivers</link> for more information.
     </para>
   </sect2>


### PR DESCRIPTION
The pxe_ssh driver was deprecated in the Newton release of OpenStack
ironic and it is likely to be removed in the Pike release. This patch
removes reference to it as a recommended driver, leaving only the
pxe_ipmitool driver as recommended. Additionally, change the upstream
driver reference to point to the official documentation rather than the
wiki, which not rigorously maintained and is outdated.