### PR TITLE
fixes-hLinux; Linux for HPE

### DIFF
--- a/xml/installation-installation-configure_lbaas.xml
+++ b/xml/installation-installation-configure_lbaas.xml
@@ -21,7 +21,7 @@
   <para>
    If you are planning to upgrade from earlier versions, please contact your
 	 driver providers to determine which drivers have been certified for use with
-	 Helion OpenStack. Loading drivers not certified by HPE may cause serious
+	 &productname;. Loading drivers not certified by HPE may cause serious
 	 issues with your cloud deployment.
   </para>
  </warning>

--- a/xml/installation-installation-gui_installer.xml
+++ b/xml/installation-installation-gui_installer.xml
@@ -7,6 +7,8 @@
  xmlns:xi="http://www.w3.org/2001/XInclude"
  xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>Installing via the GUI</title>
+ <!--FIXME: GUI installation will be completely redone. Waiting on new
+ Input Model descriptions and instructions to do any edits here. -->
  <para>
   &kw-hos-phrase; comes with a UI installer for installing your cloud the first
   time. Rather than searching through and editing a number of YAML files to
@@ -50,7 +52,7 @@
  <itemizedlist xml:id="ul_hsd_bym_tt">
   <listitem>
    <para>
-    servers (including Linux for HPE Helion installation configuration)
+    servers (including SLES 12 SP3 installation configuration)
    </para>
   </listitem>
   <listitem>
@@ -196,12 +198,12 @@
   <listitem>
    <para>
     Before you use the GUI to install your cloud, you may install the operating
-    system, Linux for HPE Helion, on your nodes (servers) if you prefer.
+    system, SLES 12 SP3, on your nodes (servers) if you prefer.
     Otherwise, the installer will install it for you.
    </para>
    <para>
     If you are installing the operating system on all your nodes yourself, note
-    that you must do so using the Linux for HPE Helion image that is included
+    that you must do so using the SLES 12 SP3 image that is included
     in the &kw-hos-phrase; package. You may find the instructions on the
     following pages helpful even when using your own tools to install the
     operating systems:

--- a/xml/installation-installation-installation_troubleshooting.xml
+++ b/xml/installation-installation-installation_troubleshooting.xml
@@ -282,7 +282,7 @@ ansible-playbook -i hosts/localhost cobbler-deploy.yml</screen>
   </para>
   <bridgehead xml:id="sec.install-trouble.reimage">How to re-image an existing node</bridgehead>
   <para>
-   Once Linux for HPE Helion has been successfully installed on a node, that
+   Once SLES 12 SP3 has been successfully installed on a node, that
    node will be marked as "installed" and subsequent runs of
    <literal>bm-reimage.yml</literal> (and related playbooks) will not target
    it. This is deliberate so that you can't reimage the node by accident. If

--- a/xml/installation-installation-rhel-install_rhel.xml
+++ b/xml/installation-installation-rhel-install_rhel.xml
@@ -45,8 +45,9 @@
  <section>
   <title>Deploying UEFI RHEL compute nodes</title>
   <para>
+<!-- FIXME: reference to Linux for HPE Helion needs to be replaced with whatever is appropriate for RHEL. -->
    Before you attempt to use the lifecycle manager to install RHEL on UEFI
-   nodes, you should install any Linux for HPE Helion nodes or any RHEL on
+   nodes, you should install any <!-- FIXME: Linux for HPE Helion --> nodes or any RHEL on
    legacy BIOS nodes first.
   </para>
   <para>
@@ -61,7 +62,7 @@
     <itemizedlist xml:id="ul_eqk_vng_zx">
      <listitem>
       <para>
-       All of your nodes using Linux for HPE Helion (controller, VSA, etc
+       All of your nodes using <!-- FIXME: Linux for HPE Helion --> (controller, VSA, etc
        nodes) must already be installed, either manually for via Cobbler.
       </para>
      </listitem>

--- a/xml/planning-planning-hw_support_scaling.xml
+++ b/xml/planning-planning-hw_support_scaling.xml
@@ -12,7 +12,7 @@
                         <para>VMware ESX</para>
                 </listitem>
                 <listitem>
-                        <para>Linux for HPE Helion/KVM</para>
+                        <para>SLES 12 SP3/KVM</para>
                 </listitem>
                 <listitem vendor="hpe">
                         <para>Red Hat Enterprise Linux/KVM</para>


### PR DESCRIPTION
fix hLinux references according to bsc#1076357 - hLinux got replaced by SLES 12 SP3