### PR TITLE
Change book titles to include Crowbar/Cloud Lifecycle Manager

### DIFF
--- a/xml/MAIN.installation.xml
+++ b/xml/MAIN.installation.xml
@@ -10,7 +10,7 @@
 <book xml:id="book.install" xml:lang="en"
  xmlns="http://docbook.org/ns/docbook" version="5.1"
  xmlns:xi="http://www.w3.org/2001/XInclude">
- <title>Installation Guide</title>
+ <title>&soclcminstall;</title>
  <info>
   <productname>&productname;</productname>
   <productnumber>&productnumber;</productnumber>

--- a/xml/MAIN.planning.xml
+++ b/xml/MAIN.planning.xml
@@ -7,7 +7,7 @@
  <!ENTITY % entitydecl SYSTEM "entity-decl.ent"> %entitydecl;
 ]>
 <book xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en" xml:id="book.planning" version="5.1">
- <title>Planning</title>
+ <title>&soclcmplan;</title>
  <info>
   <productname>&productname;</productname>
   <productnumber>&productnumber;</productnumber>

--- a/xml/entity-decl.ent
+++ b/xml/entity-decl.ent
@@ -152,18 +152,18 @@ suggested official replacement from rsalevsky. -->
 
 <!-- +++++++++++++++++++++++ Books +++++++++++++++++++++++++++++++ -->
 
-<!ENTITY clouddeploy    "<citetitle xmlns='http://docbook.org/ns/docbook'>Deployment Guide</citetitle>">
+<!-- SOC -->
+
+<!ENTITY clouddeploy    "<citetitle xmlns='http://docbook.org/ns/docbook'>Deploying With &crow;</citetitle>">
 <!ENTITY cloudadmin     "<citetitle xmlns='http://docbook.org/ns/docbook'>Administrator Guide</citetitle>">
 <!ENTITY clouduser      "<citetitle xmlns='http://docbook.org/ns/docbook'>End User Guide</citetitle>">
 <!ENTITY cloudsuppl     "<citetitle xmlns='http://docbook.org/ns/docbook'>Supplement to &cloudadmin; and &clouduser;</citetitle>">
 <!ENTITY socmover       "<citetitle xmlns='http://docbook.org/ns/docbook'>Overview</citetitle>">
 <!ENTITY socmmsop       "<citetitle xmlns='http://docbook.org/ns/docbook'>Monitoring Service Operator's Guide</citetitle>">
 <!ENTITY socmosop       "<citetitle xmlns='http://docbook.org/ns/docbook'>&ostack; Operator's Guide</citetitle>">
+<!ENTITY soclcminstall  "<citetitle xmlns='http://docbook.org/ns/docbook'>Installing with &lcm;</citetitle>">
+<!ENTITY soclcmplan     "<citetitle xmlns='http://docbook.org/ns/docbook'>Planning an Installation with &lcm;</citetitle>">
 
-
-<!-- ============================================================= -->
-<!--                   SUSE Books                                  -->
-<!-- ============================================================= -->
 
 <!-- SLES -->
 <!ENTITY instquick      "<citetitle xmlns='http://docbook.org/ns/docbook'>Installation Quick Start</citetitle>">


### PR DESCRIPTION
Do this? Leaving book names as is might be confusing to customers.

I think on one of the last calls, Sheilagh basically agreed.

Unfortunately, this is now inconsistent to the other guides that all end on "... Guide", but I didn't see a good way to avoid that.