### PR TITLE
remove references to rhel, rhla in SUSE branded version

### DIFF
--- a/xml/installation-installation-ironic-ironic_provisioning.xml
+++ b/xml/installation-installation-ironic-ironic_provisioning.xml
@@ -571,8 +571,7 @@ ssh ubuntu@192.3.15.14 -i ironic_kp.pem
    <link xlink:href="http://docs.openstack.org/developer/diskimage-builder/user_guide/installation.html"/>.
   </para>
  </section>
- <!-- FIXME: no SUSE instructions here - sknorr, 2018-01-03 -->
- <section>
+ <section vendor="hpe"> 
   <title>Creating BIOS images for &rhla;</title>
   <procedure>
    <step>

--- a/xml/installation-installation-multipath_boot_from_san.xml
+++ b/xml/installation-installation-multipath_boot_from_san.xml
@@ -294,7 +294,7 @@ cd ~/helion/hos/ansible
 ansible-playbook -i hosts/verb_hosts fcoe-enable.yml
 </screen>
  </section>
- <section>
+ <section vendor="hpe">
   <title>&rh; Compute Host for FCoE</title>
   <para>
    When installing a &rh; compute host, the names of the network interfaces
@@ -397,6 +397,7 @@ ansible-playbook -i hosts/verb_hosts fcoe-enable.yml
     playbook.</emphasis>
    </para>
   </note>
+</section>
   <section xml:id="install_boot_from_san">
    <title>Installing the &kw-hos-phrase; iso for nodes that support Boot from SAN</title>
    <para>

--- a/xml/installation-installation-rhel-install_rhel.xml
+++ b/xml/installation-installation-rhel-install_rhel.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE section [
  <!ENTITY % entities SYSTEM "entities.ent"> %entities;
 ]>
-<section xml:id="install_rhel"
+<section vendor="hpe" xml:id="install_rhel"
  xmlns="http://docbook.org/ns/docbook" version="5.1"
  xmlns:xi="http://www.w3.org/2001/XInclude"
  xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/xml/installation-installation-rhel-install_rhel_ceph.xml
+++ b/xml/installation-installation-rhel-install_rhel_ceph.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE section [
  <!ENTITY % entities SYSTEM "entities.ent"> %entities;
 ]>
-<section xml:id="install_rhel_ceph"
+<section vendor="hpe" xml:id="install_rhel_ceph"
  xmlns="http://docbook.org/ns/docbook" version="5.1"
  xmlns:xi="http://www.w3.org/2001/XInclude"
  xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -50,7 +50,7 @@ ansible-playbook -i hosts/verb_hosts ceph-client-prepare.yml
    </listitem>
   </itemizedlist>
  </note>
- <section xml:id="yum_repo_steps">
+ <section vendor="hpe" xml:id="yum_repo_steps">
   <title>Setting up a yum repo on &lcm; Node for Hosting the Ceph Client Packages for &rhla; 7.2</title>
   <para>
    On the &lcm;, execute the following steps:

--- a/xml/installation-installation-rhel-install_rhel_compute.xml
+++ b/xml/installation-installation-rhel-install_rhel_compute.xml
@@ -2,15 +2,15 @@
 <!DOCTYPE chapter [
  <!ENTITY % entities SYSTEM "entities.ent"> %entities;
 ]>
-<chapter xml:id="install_rhel_compute"
+<chapter vendor="hpe" xml:id="install_rhel_compute"
  xmlns="http://docbook.org/ns/docbook" version="5.1"
  xmlns:xi="http://www.w3.org/2001/XInclude"
  xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>Installing &rhla; Compute</title>
 
- <xi:include href="installation-installation-rhel-rhel_overview.xml"/>
- <xi:include href="installation-installation-rhel-rhel_support.xml"/>
- <xi:include href="installation-installation-rhel-install_rhel.xml"/>
- <xi:include href="installation-installation-rhel-provisioning_rhel.xml"/>
- <xi:include href="installation-installation-rhel-install_rhel_ceph.xml"/>
+ <xi:include vendor="hpe" href="installation-installation-rhel-rhel_overview.xml"/>
+ <xi:include vendor="hpe" href="installation-installation-rhel-rhel_support.xml"/>
+ <xi:include vendor="hpe" href="installation-installation-rhel-install_rhel.xml"/>
+ <xi:include vendor="hpe" href="installation-installation-rhel-provisioning_rhel.xml"/>
+ <xi:include vendor="hpe" href="installation-installation-rhel-install_rhel_ceph.xml"/>
 </chapter>

--- a/xml/installation-installation-rhel-provisioning_rhel.xml
+++ b/xml/installation-installation-rhel-provisioning_rhel.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE section [
  <!ENTITY % entities SYSTEM "entities.ent"> %entities;
 ]>
-<section xml:id="provisioning_rhel"
+<section vendor="hpe" xml:id="provisioning_rhel"
  xmlns="http://docbook.org/ns/docbook" version="5.1"
  xmlns:xi="http://www.w3.org/2001/XInclude"
  xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/xml/installation-installation-rhel-rhel_overview.xml
+++ b/xml/installation-installation-rhel-rhel_overview.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE section [
  <!ENTITY % entities SYSTEM "entities.ent"> %entities;
 ]>
-<section xml:id="rhel_overview"
+<section vendor="hpe" xml:id="rhel_overview"
  xmlns="http://docbook.org/ns/docbook" version="5.1"
  xmlns:xi="http://www.w3.org/2001/XInclude"
  xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/xml/installation-installation-rhel-rhel_preinstall.xml
+++ b/xml/installation-installation-rhel-rhel_preinstall.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE section [
  <!ENTITY % entities SYSTEM "entities.ent"> %entities;
 ]>
-<section xml:id="rhel_preinstall"
+<section vendor="hpe" xml:id="rhel_preinstall"
  xmlns="http://docbook.org/ns/docbook" version="5.1"
  xmlns:xi="http://www.w3.org/2001/XInclude"
  xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/xml/installation-installation-rhel-rhel_support.xml
+++ b/xml/installation-installation-rhel-rhel_support.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE section [
  <!ENTITY % entities SYSTEM "entities.ent"> %entities;
 ]>
-<section xml:id="rhel_support"
+<section vendor="hpe" xml:id="rhel_support"
  xmlns="http://docbook.org/ns/docbook" version="5.1"
  xmlns:xi="http://www.w3.org/2001/XInclude"
  xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/xml/installation-installation-sles-sles_preinstall.xml
+++ b/xml/installation-installation-sles-sles_preinstall.xml
@@ -17,14 +17,8 @@
  <section>
   <title>Sample iptables rules must be removed on &slsa;</title>
   <para>
-   <!-- FIXME: Red Hat content in SLES section. iptables-services package
-   does not seem to exist (at least on openSUSE). - sknorr, 2018-01-29 -->
    &kw-hos-phrase; uses iptables to secure access to &lcm; network
-   interfaces and on &rh; this requires the package
-   <literal>iptables-services</literal> to be installed. The package will
-   provide sample iptables configurations for IPv4 and IPv6 if none existed
-   before. This sample configuration is inappropriate for &kw-hos; operation and
-   the node will not be able to run &productname; with these rules installed.
+   interfaces. Any iptable configuration packages previously installed must be removed. Some sample configurations are inappropriate for &kw-hos; operation. The node will not be able to run &productname; with these rules installed.
   </para>
   <para>
    The files installed are:

--- a/xml/installation-operations-configuring_tls.xml
+++ b/xml/installation-operations-configuring_tls.xml
@@ -596,10 +596,10 @@ certopt = default_ca
 policy = policy_match
 copy_extensions = copy
 
-# NOTE(dprince): stateOrProvinceName must be 'supplied' or 'optional' to
+<!-- # NOTE(dprince): stateOrProvinceName must be 'supplied' or 'optional' to
 # work around a stateOrProvince printable string UTF8 mismatch on
 # RHEL 6 and Fedora 14 (using openssl-1.0.0-4.el6.x86_64 or
-# openssl-1.0.0d-1.fc14.x86_64)
+# openssl-1.0.0d-1.fc14.x86_64) -->
 [ policy_match ]
 countryName = optional
 stateOrProvinceName = optional

--- a/xml/planning-architecture-alternative-rhel_compute_model.xml
+++ b/xml/planning-architecture-alternative-rhel_compute_model.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE section [
  <!ENTITY % entities SYSTEM "entities.ent"> %entities;
 ]>
-<section xml:id="rhel_compute_model" version="5.1" xmlns="http://docbook.org/ns/docbook"
+<section vendor="hpe" xml:id="rhel_compute_model" version="5.1" xmlns="http://docbook.org/ns/docbook"
   xmlns:xi="http://www.w3.org/2001/XInclude"
   xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>&rhla; Compute Nodes</title>


### PR DESCRIPTION
ref: bsc#1076356
includes possibly redundant vendor="hpe" in
installation-installation-rhel-install_rhel_compute.xml