### PR TITLE
Rename HPE DC and DEF to full name (bsc#1079065)

### DIFF
--- a/.travis-check-docs
+++ b/.travis-check-docs
@@ -6,5 +6,5 @@ DC-suse-openstack-cloud-monitor-overview
 DC-suse-openstack-cloud-monitor-osoperator
 DC-suse-openstack-cloud-monitor-msoperator
 DC-suse-openstack-cloud-hos-imported
-DC-hpe-helion-installation
-DC-hpe-helion-planning
+DC-hpe-helion-openstack-cloud-installation
+DC-hpe-helion-openstack-cloud-planning

--- a/DC-hpe-helion-openstack-cloud-installation
+++ b/DC-hpe-helion-openstack-cloud-installation
@@ -1,5 +1,5 @@
 ## ----------------------------------------
-## Doc Config File for SUSE OpenStack Cloud 
+## Doc Config File for HPE Helion OpenStack Cloud
 ## Installation Guide
 ## ----------------------------------------
 

--- a/DC-hpe-helion-openstack-cloud-planning
+++ b/DC-hpe-helion-openstack-cloud-planning
@@ -1,5 +1,5 @@
 ## ----------------------------------------
-## Doc Config File for SUSE OpenStack Cloud 
+## Doc Config File for HPE Helion OpenStack Cloud
 ## Installation Guide
 ## ----------------------------------------
 

--- a/DEF-hpe-helion-installation
+++ b/DEF-hpe-helion-installation
@@ -1,2 +1,0 @@
-html       hpe-helion-installation  copyright_suse_openstack_cloud.xml   ok https://api.suse.de Devel:Cloud:8
-pdfsub     hpe-helion-installation  copyright_suse_openstack_cloud.xml   ok

--- a/DEF-hpe-helion-openstack-cloud-installation
+++ b/DEF-hpe-helion-openstack-cloud-installation
@@ -1,0 +1,2 @@
+html       hpe-helion-openstack-cloud-installation  copyright_suse_openstack_cloud.xml   ok https://api.suse.de Devel:Cloud:8
+pdfsub     hpe-helion-openstack-cloud-installation  copyright_suse_openstack_cloud.xml   ok

--- a/DEF-hpe-helion-openstack-cloud-planning
+++ b/DEF-hpe-helion-openstack-cloud-planning
@@ -1,0 +1,2 @@
+html       hpe-helion-openstack-cloud-planning  copyright_suse_openstack_cloud.xml   ok https://api.suse.de Devel:Cloud:8
+pdfsub     hpe-helion-openstack-cloud-planning  copyright_suse_openstack_cloud.xml   ok

--- a/DEF-hpe-helion-planning
+++ b/DEF-hpe-helion-planning
@@ -1,2 +1,0 @@
-html       hpe-helion-planning  copyright_suse_openstack_cloud.xml   ok https://api.suse.de Devel:Cloud:8
-pdfsub     hpe-helion-planning  copyright_suse_openstack_cloud.xml   ok


### PR DESCRIPTION
This is necessary as otherwise the files are named wrong during the
package build and a later rename is not possible.