### PR TITLE
Add Report Bug links to HOS-originated books

### DIFF
--- a/xml/MAIN.hos-imported.xml
+++ b/xml/MAIN.hos-imported.xml
@@ -14,6 +14,14 @@
  <info>
   <productname>&productname;</productname>
   <productnumber>&productnumber;</productnumber>
+  <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
+   <dm:bugtracker>
+    <dm:url>https://bugzilla.suse.com/enter_bug.cgi</dm:url>
+    <dm:product>SUSE OpenStack Cloud 8</dm:product>
+    <dm:component>Documentation</dm:component>
+   </dm:bugtracker>
+   <dm:translation>no</dm:translation>
+  </dm:docmanager>
  </info>
 
  <xi:include href="MAIN.planning.xml"/>


### PR DESCRIPTION
Currently not profiled for SUSE/HPE. Does it make sense to send people
to SUSE Bugzilla from an HPE-branded document..?