### PR TITLE
fixes bcs#1073516: monasca typos

### DIFF
--- a/xml/msoperator-cmmoperator-install-c-cmmoprepansiblemaster.xml
+++ b/xml/msoperator-cmmoperator-install-c-cmmoprepansiblemaster.xml
@@ -44,8 +44,8 @@ ssh_args = -o ControlMaster=auto -o BatchMode=yes -o ForwardAgent=yes</screen>
 <screen>sudo vim /etc/ansible/hosts</screen>
    <para>
     For detailed information on the configuration of the Control Machine, refer
-    to the <ulink url="http://docs.ansible.com/intro_inventory.html"> Ansible
-    Inventory documentation </ulink>.
+    to the <ulink url="http://docs.ansible.com/intro_inventory.html">Ansible
+    Inventory documentation</ulink>.
    </para>
   </listitem>
   <listitem>

--- a/xml/msoperator-cmmoperator-intro-c-cmmoarchitecture.xml
+++ b/xml/msoperator-cmmoperator-intro-c-cmmoarchitecture.xml
@@ -219,8 +219,8 @@
   OpenStack with a view for monitoring. This enables <phrase>SUSE OpenStack
   Cloud Monitoring</phrase> users to access the monitoring functions from a
   central Web-based graphical user interface. For details, refer to the
-  <ulink url="http://docs.openstack.org/developer/horizon/"> OpenStack Horizon
-  documentation </ulink>.
+  <ulink url="http://docs.openstack.org/developer/horizon/">OpenStack Horizon
+  documentation</ulink>.
  </para>
  <para>
   Based on OpenStack Horizon, the monitoring data is visualized on a
@@ -261,7 +261,7 @@
  <para>
   The agent functionality is fully integrated into the source code base of the
   Monasca project. For details, refer to the
-  <ulink url="https://wiki.openstack.org/wiki/Monasca"> Monasca Wiki </ulink>.
+  <ulink url="https://wiki.openstack.org/wiki/Monasca">Monasca Wiki</ulink>.
  </para>
  <bridgehead renderas="sect4">Log Agent</bridgehead>
  <para>
@@ -273,7 +273,7 @@
  <para>
   The agent functionality is fully integrated into the source code base of the
   Monasca project. For details, refer to the
-  <ulink url="https://wiki.openstack.org/wiki/Monasca"> Monasca Wiki </ulink>.
+  <ulink url="https://wiki.openstack.org/wiki/Monasca">Monasca Wiki</ulink>.
  </para>
   <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="msoperator-cmmoperator-operate-c-cmmostartstopcmm.xml"/>
 </section>

--- a/xml/msoperator-cmmoperator-operate-c-backupdashboards.xml
+++ b/xml/msoperator-cmmoperator-operate-c-backupdashboards.xml
@@ -7,15 +7,14 @@
   Kibana can persist customized log dashboard designs to the Elasticsearch
   database, and allows you to recall them. For details on saving, loading, and
   sharing log management dashboards, refer to the
-  <ulink url="https://www.elastic.co/guide/en/kibana/4.5/dashboard.html#saving-dashboards">
-  Kibana documentation </ulink>.
+  <ulink url="https://www.elastic.co/guide/en/kibana/4.5/dashboard.html#saving-dashboards">Kibana documentation</ulink>.
  </para>
  <para>
   Grafana allows you to export a monitoring dashboard to a JSON file, and to
   re-import it when necessary. For backing up and restoring the exported
   dashboards, use the standard mechanisms of your file system. For details on
   exporting monitoring dashboards, refer to the
-  <ulink url="http://docs.grafana.org/v1.9/guides/gettingstarted/"> Getting
-  Started </ulink> tutorial of Grafana.
+  <ulink url="http://docs.grafana.org/v1.9/guides/gettingstarted/">Getting
+  Started</ulink> tutorial of Grafana.
  </para>
 </section>

--- a/xml/msoperator-cmmoperator-operate-c-backupdb.xml
+++ b/xml/msoperator-cmmoperator-operate-c-backupdb.xml
@@ -169,8 +169,7 @@ To restart the Monitoring API and the Log API, use the following command:
  <para>
   For additional information on backing up and restoring an Elasticsearch
   database, refer to the
-  <ulink url="https://www.elastic.co/guide/en/elasticsearch/reference/2.3/modules-snapshots.html">
-  Elasticsearch documentation </ulink>.
+  <ulink url="https://www.elastic.co/guide/en/elasticsearch/reference/2.3/modules-snapshots.html">Elasticsearch documentation</ulink>.
  </para>
  <bridgehead renderas="sect4">InfluxDB Database</bridgehead>
  <para>
@@ -273,8 +272,7 @@ systemctl stop influxdb
  <para>
   For additional information on backing up and restoring an InfluxDB database,
   refer to the
-  <ulink url="https://docs.influxdata.com/influxdb/v1.1/administration/backup_and_restore/">
-  InfluxDB documentation </ulink>.
+  <ulink url="https://docs.influxdata.com/influxdb/v1.1/administration/backup_and_restore/">InfluxDB documentation</ulink>.
  </para>
  
  <bridgehead renderas="sect4">MariaDB Database</bridgehead>
@@ -341,7 +339,7 @@ Exit mariadb:
  <para>
   For additional information on backing up and restoring a MariaDB database
   with <literal>mysqldump</literal>, refer to the
-  <ulink url="https://mariadb.com/kb/en/mariadb/mysqldump/"> MariaDB
-  documentation </ulink>.
+  <ulink url="https://mariadb.com/kb/en/mariadb/mysqldump/">MariaDB
+  documentation</ulink>.
  </para>
 </section>

--- a/xml/msoperator-cmmoperator-operate-c-dataretention-es.xml
+++ b/xml/msoperator-cmmoperator-operate-c-dataretention-es.xml
@@ -128,10 +128,8 @@ crontab -e</screen>
  </para>
  <para>
   For details on Elasticsearch Curator, refer to the
-  <ulink url="https://www.elastic.co/guide/en/elasticsearch/client/curator/4.0/index.html">
-  Elasticsearch Curator documentation </ulink>. Find details on configuring the
+  <ulink url="https://www.elastic.co/guide/en/elasticsearch/client/curator/4.0/index.html">Elasticsearch Curator documentation</ulink>. Find details on configuring the
   Cron daemon, for example, in the
-  <ulink url="https://help.ubuntu.com/community/CronHowto"> Ubuntu Wiki
-  </ulink>.
+  <ulink url="https://help.ubuntu.com/community/CronHowto">Ubuntu Wiki</ulink>.
  </para>
 </section>

--- a/xml/msoperator-cmmoperator-operate-c-dataretention-inf.xml
+++ b/xml/msoperator-cmmoperator-operate-c-dataretention-inf.xml
@@ -175,9 +175,8 @@ Using database mon</screen>
  </orderedlist>
  <para>
   For an introduction to the InfluxDB command line interface, refer to the
-  <ulink url="https://docs.influxdata.com/influxdb/v1.1/tools/shell/"> InfluxDB
-  CLI/Shell documentation </ulink>. For details on data retention, refer to
-  <ulink url="https://docs.influxdata.com/influxdb/v1.1/query_language/database_management/#retention-policy-management">
-  Retention Policy Management </ulink>.
+  <ulink url="https://docs.influxdata.com/influxdb/v1.1/tools/shell/">InfluxDB
+  CLI/Shell documentation</ulink>. For details on data retention, refer to
+  <ulink url="https://docs.influxdata.com/influxdb/v1.1/query_language/database_management/#retention-policy-management">Retention Policy Management</ulink>.
  </para>
 </section>

--- a/xml/msoperator-shared-gettingstarted-c-webreferences.xml
+++ b/xml/msoperator-shared-gettingstarted-c-webreferences.xml
@@ -10,20 +10,19 @@
  <itemizedlist>
   <listitem>
    <para>
-    <ulink url="http://docs.openstack.org/newton/"> OpenStack </ulink>:
+    <ulink url="http://docs.openstack.org/newton/">OpenStack</ulink>:
     Documentation on OpenStack, the underlying platform technology.
    </para>
   </listitem>
   <listitem>
    <para>
-    <ulink url="http://docs.openstack.org/developer/horizon/"> OpenStack
-    Horizon </ulink>: Documentation on the OpenStack Horizon dashboard.
+    <ulink url="http://docs.openstack.org/developer/horizon/">OpenStack
+    Horizon</ulink>: Documentation on the OpenStack Horizon dashboard.
    </para>
   </listitem>
   <listitem>
    <para>
-    <ulink url="https://wiki.openstack.org/wiki/Monasca"> Monasca Wiki
-    </ulink>: Information on Monasca, the core of <phrase>SUSE OpenStack Cloud
+    <ulink url="https://wiki.openstack.org/wiki/Monasca">Monasca Wiki</ulink>: Information on Monasca, the core of <phrase>SUSE OpenStack Cloud
     Monitoring</phrase>.
    </para>
   </listitem>

--- a/xml/msoperator-shared-install-c-cmmoprepare-cm.xml
+++ b/xml/msoperator-shared-install-c-cmmoprepare-cm.xml
@@ -50,8 +50,7 @@
  <para>
   For details on the operating system required for the Control Machine, refer
   to the
-  <ulink url="http://docs.ansible.com/ansible/intro_installation.html#control-machine-requirements">
-  Ansible documentation </ulink>.
+  <ulink url="http://docs.ansible.com/ansible/intro_installation.html#control-machine-requirements">Ansible documentation</ulink>.
  </para>
  <para>
   To install and prepare Ansible on the Control Machine, proceed as follows:

--- a/xml/msoperator-shared-install-c-configurelogagent.xml
+++ b/xml/msoperator-shared-install-c-configurelogagent.xml
@@ -32,16 +32,14 @@
     The Log Agent is based on the so-called ELK stack, a solution for searching
     and analyzing log data that combines the open source projects
     Elasticsearch, Logstash, and Kibana. For details on the ELK stack, refer to
-    the documentation on <ulink url="https://www.elastic.co/guide/index.html">
-    Elasticsearch, Logstash, and Kibana </ulink>.
+    the documentation on <ulink url="https://www.elastic.co/guide/index.html">Elasticsearch, Logstash, and Kibana</ulink>.
    </para>
    <para>
     <phrase>SUSE OpenStack Cloud Monitoring</phrase> supports the file plugin
     of Logstash as input mechanism. The file plugin enables Logstash to read
     log data from any log file on your file system. Logstash supports
     additional plugins. For details, refer to
-    <ulink url="https://www.elastic.co/guide/en/logstash/2.3/input-plugins.html">
-    Logstash Input Plugins </ulink>. Contact your <phrase>SUSE OpenStack Cloud
+    <ulink url="https://www.elastic.co/guide/en/logstash/2.3/input-plugins.html">Logstash Input Plugins</ulink>. Contact your <phrase>SUSE OpenStack Cloud
     Monitoring</phrase> support if you want to integrate a different plugin.
    </para>
   </listitem>

--- a/xml/msoperator-shared-logging-c-osolog-kibana.xml
+++ b/xml/msoperator-shared-logging-c-osolog-kibana.xml
@@ -56,8 +56,8 @@
  <para>
   The following sections provide an introduction to queries, visualizations,
   and dashboards. For additional details, refer to the
-  <ulink url="https://www.elastic.co/guide/en/kibana/4.5/index.html"> Kibana
-  documentation </ulink>.
+  <ulink url="https://www.elastic.co/guide/en/kibana/4.5/index.html">Kibana
+  documentation</ulink>.
  </para>
  <bridgehead renderas="sect4">Querying Log Data</bridgehead>
  <para>
@@ -100,8 +100,7 @@
    <para>
     For entering strings in the search box, use the Lucene query syntax. Kibana
     also supports the Elasticsearch Query DSL. For details, refer to the
-    <ulink url="https://www.elastic.co/guide/en/elasticsearch/reference/2.3/query-dsl.html">
-    Elasticsearch Reference documentation </ulink>.
+    <ulink url="https://www.elastic.co/guide/en/elasticsearch/reference/2.3/query-dsl.html">Elasticsearch Reference documentation</ulink>.
    </para>
   </listitem>
   <listitem>

--- a/xml/msoperator-shared-monitor-c-monitor-alarm.xml
+++ b/xml/msoperator-shared-monitor-c-monitor-alarm.xml
@@ -100,8 +100,7 @@ max(disk.space_used_perc{service=monitoring}) &gt; 90</screen>
  <para>
   The expression defines how to evaluate a metrics. The expression syntax is
   based on a simple expressive grammar. For details, refer to the
-  <ulink url="https://github.com/openstack/monasca-api/blob/stable/ocata/docs/monasca-api-spec.md">
-  Monasca API documentation </ulink>.
+  <ulink url="https://github.com/openstack/monasca-api/blob/stable/ocata/docs/monasca-api-spec.md">Monasca API documentation</ulink>.
  </para>
  <informalfigure>
   <mediaobject>
@@ -262,8 +261,7 @@ max(disk.space_used_perc{service=monitoring}) &gt; 90</screen>
    By default, an alarm definition is evaluated every minute. When updating the
    alarm definition, you can change this interval. For syntax details, refer to
    the Monasca API documentation on
-   <ulink url="https://github.com/openstack/monasca-api/blob/stable/ocata/docs/monasca-api-spec.md#alarm-definition-expressions">
-   Alarm Definition Expressions </ulink>.
+   <ulink url="https://github.com/openstack/monasca-api/blob/stable/ocata/docs/monasca-api-spec.md#alarm-definition-expressions">Alarm Definition Expressions</ulink>.
   </para>
  </note>
  <bridgehead renderas="sect4">Notifications</bridgehead>

--- a/xml/msoperator-shared-operationmaintenance-c-logfilelocation.xml
+++ b/xml/msoperator-shared-operationmaintenance-c-logfilelocation.xml
@@ -26,7 +26,6 @@
  <para>
   For details on the <literal>systemd</literal> and <literal>journald</literal>
   utilities, refer to the
-  <ulink url="https://www.suse.com/documentation/sles-12/singlehtml/book_sle_admin/book_sle_admin.html#part.system">
-  SUSE Linux Enterprise Server documentation </ulink>.
+  <ulink url="https://www.suse.com/documentation/sles-12/singlehtml/book_sle_admin/book_sle_admin.html#part.system">SUSE Linux Enterprise Server documentation</ulink>.
  </para>
 </section>

--- a/xml/osoperator-install-c-osoprepansiblemaster.xml
+++ b/xml/osoperator-install-c-osoprepansiblemaster.xml
@@ -44,8 +44,8 @@ ssh_args = -o ControlMaster=auto -o BatchMode=yes -o ForwardAgent=yes</screen>
 <screen>sudo vim /etc/ansible/hosts</screen>
    <para>
     For detailed information on the configuration of the Control Machine, refer
-    to the <ulink url="http://docs.ansible.com/intro_inventory.html"> Ansible
-    Inventory documentation </ulink>.
+    to the <ulink url="http://docs.ansible.com/intro_inventory.html">Ansible
+    Inventory documentation</ulink>.
    </para>
   </listitem>
   <listitem>

--- a/xml/osoperator-intro-c-osocomponents.xml
+++ b/xml/osoperator-intro-c-osocomponents.xml
@@ -34,7 +34,7 @@
   The Monitoring Service relies on Monasca. It uses Monasca for high-speed
   metrics querying and integrates the streaming alarm engine and the
   notification engine of Monasca. For details, refer to the
-  <ulink url="https://wiki.openstack.org/wiki/Monasca"> Monasca Wiki </ulink>.
+  <ulink url="https://wiki.openstack.org/wiki/Monasca">Monasca Wiki</ulink>.
  </para>
  <bridgehead renderas="sect4">Horizon Plugin</bridgehead>
  <para>
@@ -42,8 +42,7 @@
   The plugin extends the main dashboard in OpenStack with a view for
   monitoring. This enables <phrase>CMM</phrase> users to access the monitoring
   functions from a central Web-based graphical user interface. For details,
-  refer to the <ulink url="http://docs.openstack.org/developer/horizon/">
-  OpenStack Horizon documentation </ulink>.
+  refer to the <ulink url="http://docs.openstack.org/developer/horizon/">OpenStack Horizon documentation</ulink>.
  </para>
  <para>
   Based on OpenStack Horizon, the monitoring data is visualized on a
@@ -78,7 +77,7 @@
  <para id="The_agent_functionality_is_fu_concept_conbody_section_5_p">
   The agent functionality is fully integrated into the source code base of the
   Monasca project. For details, refer to the
-  <ulink url="https://wiki.openstack.org/wiki/Monasca"> Monasca Wiki </ulink>.
+  <ulink url="https://wiki.openstack.org/wiki/Monasca">Monasca Wiki</ulink>.
  </para>
  <bridgehead renderas="sect4">Log Agent</bridgehead>
  <para>
@@ -90,6 +89,6 @@
  <para>
   The agent functionality is fully integrated into the source code base of the
   Monasca project. For details, refer to the
-  <ulink url="https://wiki.openstack.org/wiki/Monasca"> Monasca Wiki </ulink>.
+  <ulink url="https://wiki.openstack.org/wiki/Monasca">Monasca Wiki</ulink>.
  </para>
 </section>

--- a/xml/osoperator-intro-c-osousers.xml
+++ b/xml/osoperator-intro-c-osousers.xml
@@ -40,7 +40,6 @@
  </itemizedlist>
  <para>
   For details on user management, refer to the
-  <ulink url="http://docs.openstack.org/liberty/"> OpenStack documentation
-  </ulink>.
+  <ulink url="http://docs.openstack.org/liberty/">OpenStack documentation</ulink>.
  </para>
 </section>

--- a/xml/osoperator-monitor-c-monitor-graf-oso.xml
+++ b/xml/osoperator-monitor-c-monitor-graf-oso.xml
@@ -110,7 +110,7 @@
   The following sections provide introductory information on dashboards, rows,
   and panels, and make you familiar with the first steps involved in building a
   dashboard. For additional information, you can also refer to the
-  <ulink url="http://docs.grafana.org/v1.9/"> Grafana documentation </ulink>.
+  <ulink url="http://docs.grafana.org/v1.9/">Grafana documentation</ulink>.
  </para>
  <bridgehead renderas="sect4">Creating a Dashboard</bridgehead>
  <para>

--- a/xml/osoperator-osoperator-install-c-osoprepansiblemaster.xml
+++ b/xml/osoperator-osoperator-install-c-osoprepansiblemaster.xml
@@ -44,8 +44,8 @@ ssh_args = -o ControlMaster=auto -o BatchMode=yes -o ForwardAgent=yes</screen>
 <screen>sudo vim /etc/ansible/hosts</screen>
    <para>
     For detailed information on the configuration of the Control Machine, refer
-    to the <ulink url="http://docs.ansible.com/intro_inventory.html"> Ansible
-    Inventory documentation </ulink>.
+    to the <ulink url="http://docs.ansible.com/intro_inventory.html">Ansible
+    Inventory documentation</ulink>.
    </para>
   </listitem>
   <listitem>

--- a/xml/osoperator-osoperator-intro-c-osocomponents.xml
+++ b/xml/osoperator-osoperator-intro-c-osocomponents.xml
@@ -38,7 +38,7 @@
   The Monitoring Service relies on Monasca. It uses Monasca for high-speed
   metrics querying and integrates the streaming alarm engine and the
   notification engine of Monasca. For details, refer to the
-  <ulink url="https://wiki.openstack.org/wiki/Monasca"> Monasca Wiki </ulink>.
+  <ulink url="https://wiki.openstack.org/wiki/Monasca">Monasca Wiki</ulink>.
  </para>
  <bridgehead renderas="sect4">Horizon Plugin</bridgehead>
  <para>
@@ -47,8 +47,8 @@
   OpenStack with a view for monitoring. This enables <phrase>SUSE OpenStack
   Cloud Monitoring</phrase> users to access the monitoring functions from a
   central Web-based graphical user interface. For details, refer to the
-  <ulink url="http://docs.openstack.org/developer/horizon/"> OpenStack Horizon
-  documentation </ulink>.
+  <ulink url="http://docs.openstack.org/developer/horizon/">OpenStack Horizon
+  documentation</ulink>.
  </para>
  <para>
   Based on OpenStack Horizon, the monitoring data is visualized on a
@@ -83,7 +83,7 @@
  <para>
   The agent functionality is fully integrated into the source code base of the
   Monasca project. For details, refer to the
-  <ulink url="https://wiki.openstack.org/wiki/Monasca"> Monasca Wiki </ulink>.
+  <ulink url="https://wiki.openstack.org/wiki/Monasca">Monasca Wiki</ulink>.
  </para>
  <bridgehead renderas="sect4">Log Agent</bridgehead>
  <para>
@@ -95,6 +95,6 @@
  <para>
   The agent functionality is fully integrated into the source code base of the
   Monasca project. For details, refer to the
-  <ulink url="https://wiki.openstack.org/wiki/Monasca"> Monasca Wiki </ulink>.
+  <ulink url="https://wiki.openstack.org/wiki/Monasca">Monasca Wiki</ulink>.
  </para>
 </section>

--- a/xml/osoperator-osoperator-intro-c-osousers.xml
+++ b/xml/osoperator-osoperator-intro-c-osousers.xml
@@ -43,7 +43,6 @@
  </itemizedlist>
  <para>
   For details on user management, refer to the
-  <ulink url="http://docs.openstack.org/newton/"> OpenStack documentation
-  </ulink>.
+  <ulink url="http://docs.openstack.org/newton/">OpenStack documentation</ulink>.
  </para>
 </section>

--- a/xml/osoperator-osoperator-monitor-c-monitor-graf-oso.xml
+++ b/xml/osoperator-osoperator-monitor-c-monitor-graf-oso.xml
@@ -117,7 +117,7 @@
   The following sections provide introductory information on dashboards, rows,
   and panels, and make you familiar with the first steps involved in building a
   dashboard. For additional information, you can also refer to the
-  <ulink url="http://docs.grafana.org/"> Grafana documentation </ulink>.
+  <ulink url="http://docs.grafana.org/">Grafana documentation</ulink>.
  </para>
  <bridgehead renderas="sect4">Creating a Dashboard</bridgehead>
  <para>

--- a/xml/osoperator-osoperator-prepare-c-osopreparetu.xml
+++ b/xml/osoperator-osoperator-prepare-c-osopreparetu.xml
@@ -45,8 +45,7 @@
  </orderedlist>
  <para>
   For additional information on libvirt monitoring, you can also refer to the
-  <ulink url="https://github.com/openstack/monasca-agent/blob/stable/ocata/docs/Libvirt.md">
-  Monasca documentation </ulink>.
+  <ulink url="https://github.com/openstack/monasca-agent/blob/stable/ocata/docs/Libvirt.md">Monasca documentation</ulink>.
  </para>
  <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="osoperator-osoperator-prepare-c-osoprep-turoles.xml"/>
  <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="osoperator-osoperator-prepare-c-osoprep-tuinstall.xml"/>

--- a/xml/osoperator-prepare-c-osopreparetu.xml
+++ b/xml/osoperator-prepare-c-osopreparetu.xml
@@ -45,8 +45,7 @@
  </orderedlist>
  <para>
   For additional information on libvirt monitoring, you can also refer to the
-  <ulink url="https://github.com/openstack/monasca-agent/blob/stable/newton/docs/Libvirt.md">
-  Monasca documentation </ulink>.
+  <ulink url="https://github.com/openstack/monasca-agent/blob/stable/newton/docs/Libvirt.md">Monasca documentation</ulink>.
  </para>
  <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="osoperator-prepare-c-osoprep-turoles.xml"/>
  <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="osoperator-prepare-c-osoprep-tuinstall.xml"/>

--- a/xml/osoperator-shared-gettingstarted-c-webreferences.xml
+++ b/xml/osoperator-shared-gettingstarted-c-webreferences.xml
@@ -10,20 +10,19 @@
  <itemizedlist>
   <listitem>
    <para>
-    <ulink url="http://docs.openstack.org/newton/"> OpenStack </ulink>:
+    <ulink url="http://docs.openstack.org/newton/">OpenStack</ulink>:
     Documentation on OpenStack, the underlying platform technology.
    </para>
   </listitem>
   <listitem>
    <para>
-    <ulink url="http://docs.openstack.org/developer/horizon/"> OpenStack
-    Horizon </ulink>: Documentation on the OpenStack Horizon dashboard.
+    <ulink url="http://docs.openstack.org/developer/horizon/">OpenStack
+    Horizon</ulink>: Documentation on the OpenStack Horizon dashboard.
    </para>
   </listitem>
   <listitem>
    <para>
-    <ulink url="https://wiki.openstack.org/wiki/Monasca"> Monasca Wiki
-    </ulink>: Information on Monasca, the core of <phrase>SUSE OpenStack Cloud
+    <ulink url="https://wiki.openstack.org/wiki/Monasca">Monasca Wiki</ulink>: Information on Monasca, the core of <phrase>SUSE OpenStack Cloud
     Monitoring</phrase>.
    </para>
   </listitem>

--- a/xml/osoperator-shared-install-c-cmmoprepare-cm.xml
+++ b/xml/osoperator-shared-install-c-cmmoprepare-cm.xml
@@ -45,8 +45,7 @@
  <para>
   For details on the operating system required for the Control Machine, refer
   to the
-  <ulink url="http://docs.ansible.com/ansible/intro_installation.html#control-machine-requirements">
-  Ansible documentation </ulink>.
+  <ulink url="http://docs.ansible.com/ansible/intro_installation.html#control-machine-requirements">Ansible documentation</ulink>.
  </para>
  <para>
   To install and prepare Ansible on the Control Machine, proceed as follows:

--- a/xml/osoperator-shared-install-c-configurelogagent.xml
+++ b/xml/osoperator-shared-install-c-configurelogagent.xml
@@ -32,16 +32,14 @@
     The Log Agent is based on the so-called ELK stack, a solution for searching
     and analyzing log data that combines the open source projects
     Elasticsearch, Logstash, and Kibana. For details on the ELK stack, refer to
-    the documentation on <ulink url="https://www.elastic.co/guide/index.html">
-    Elasticsearch, Logstash, and Kibana </ulink>.
+    the documentation on <ulink url="https://www.elastic.co/guide/index.html">Elasticsearch, Logstash, and Kibana</ulink>.
    </para>
    <para>
     <phrase>CMM</phrase> supports the file plugin of Logstash as input
     mechanism. The file plugin enables Logstash to read log data from any log
     file on your file system. Logstash supports additional plugins. For
     details, refer to
-    <ulink url="https://www.elastic.co/guide/en/logstash/2.3/input-plugins.html">
-    Logstash Input Plugins </ulink>. Contact your <phrase>CMM</phrase> support
+    <ulink url="https://www.elastic.co/guide/en/logstash/2.3/input-plugins.html">Logstash Input Plugins</ulink>. Contact your <phrase>CMM</phrase> support
     if you want to integrate a different plugin.
    </para>
   </listitem>

--- a/xml/osoperator-shared-logging-c-osolog-kibana.xml
+++ b/xml/osoperator-shared-logging-c-osolog-kibana.xml
@@ -56,8 +56,8 @@
  <para>
   The following sections provide an introduction to queries, visualizations,
   and dashboards. For additional details, refer to the
-  <ulink url="https://www.elastic.co/guide/en/kibana/4.5/index.html"> Kibana
-  documentation </ulink>.
+  <ulink url="https://www.elastic.co/guide/en/kibana/4.5/index.html">Kibana
+  documentation</ulink>.
  </para>
  <bridgehead renderas="sect4">Querying Log Data</bridgehead>
  <para>
@@ -100,8 +100,7 @@
    <para>
     For entering strings in the search box, use the Lucene query syntax. Kibana
     also supports the Elasticsearch Query DSL. For details, refer to the
-    <ulink url="https://www.elastic.co/guide/en/elasticsearch/reference/2.3/query-dsl.html">
-    Elasticsearch Reference documentation </ulink>.
+    <ulink url="https://www.elastic.co/guide/en/elasticsearch/reference/2.3/query-dsl.html">Elasticsearch Reference documentation</ulink>.
    </para>
   </listitem>
   <listitem>

--- a/xml/osoperator-shared-monitor-c-monitor-alarm.xml
+++ b/xml/osoperator-shared-monitor-c-monitor-alarm.xml
@@ -100,8 +100,7 @@ max(disk.space_used_perc{service=monitoring}) &gt; 90</screen>
  <para>
   The expression defines how to evaluate a metrics. The expression syntax is
   based on a simple expressive grammar. For details, refer to the
-  <ulink url="https://github.com/openstack/monasca-api/blob/stable/ocata/docs/monasca-api-spec.md">
-  Monasca API documentation </ulink>.
+  <ulink url="https://github.com/openstack/monasca-api/blob/stable/ocata/docs/monasca-api-spec.md">Monasca API documentation</ulink>.
  </para>
  <informalfigure>
   <mediaobject>
@@ -262,8 +261,7 @@ max(disk.space_used_perc{service=monitoring}) &gt; 90</screen>
    By default, an alarm definition is evaluated every minute. When updating the
    alarm definition, you can change this interval. For syntax details, refer to
    the Monasca API documentation on
-   <ulink url="https://github.com/openstack/monasca-api/blob/stable/ocata/docs/monasca-api-spec.md#alarm-definition-expressions">
-   Alarm Definition Expressions </ulink>.
+   <ulink url="https://github.com/openstack/monasca-api/blob/stable/ocata/docs/monasca-api-spec.md#alarm-definition-expressions">Alarm Definition Expressions</ulink>.
   </para>
  </note>
  <bridgehead renderas="sect4">Notifications</bridgehead>

--- a/xml/overview-overview-whatiscmm-c-components.xml
+++ b/xml/overview-overview-whatiscmm-c-components.xml
@@ -29,7 +29,7 @@
  </para>
  <para>
   For details on OpenStack, refer to the
-  <ulink url="http://docs.openstack.org/"> OpenStack documentation </ulink>.
+  <ulink url="http://docs.openstack.org/">OpenStack documentation</ulink>.
  </para>
  <bridgehead renderas="sect4">Monitoring Service</bridgehead>
  <para>
@@ -42,7 +42,7 @@
   The Monitoring Service relies on Monasca. It uses Monasca for high-speed
   metrics querying and integrates the streaming alarm engine and the
   notification engine of Monasca. For details, refer to the
-  <ulink url="https://wiki.openstack.org/wiki/Monasca"> Monasca Wiki </ulink>.
+  <ulink url="https://wiki.openstack.org/wiki/Monasca">Monasca Wiki</ulink>.
  </para>
  <bridgehead renderas="sect4">Horizon Plugin</bridgehead>
  <para>
@@ -55,8 +55,8 @@
  </para>
  <para>
   For details, refer to the
-  <ulink url="http://docs.openstack.org/developer/horizon/"> OpenStack Horizon
-  documentation </ulink>.
+  <ulink url="http://docs.openstack.org/developer/horizon/">OpenStack Horizon
+  documentation</ulink>.
  </para>
  <bridgehead renderas="sect4">Metrics Agent</bridgehead>
  <para>
@@ -72,7 +72,7 @@
  <para>
   The agent functionality is fully integrated into the source code base of the
   Monasca project. For details, refer to the
-  <ulink url="https://wiki.openstack.org/wiki/Monasca"> Monasca Wiki </ulink>.
+  <ulink url="https://wiki.openstack.org/wiki/Monasca">Monasca Wiki</ulink>.
  </para>
  <bridgehead renderas="sect4">Log Agent</bridgehead>
  <para>
@@ -84,6 +84,6 @@
  <para>
   The agent functionality is fully integrated into the source code base of the
   Monasca project. For details, refer to the
-  <ulink url="https://wiki.openstack.org/wiki/Monasca"> Monasca Wiki </ulink>.
+  <ulink url="https://wiki.openstack.org/wiki/Monasca">Monasca Wiki</ulink>.
  </para>
 </section>

--- a/xml/overview-overview-whatiscmm-c-userroles.xml
+++ b/xml/overview-overview-whatiscmm-c-userroles.xml
@@ -91,6 +91,6 @@
  </itemizedlist>
  <para>
   For details on user management, refer to the
-  <ulink url="http://docs.openstack.org/"> OpenStack documentation </ulink>.
+  <ulink url="http://docs.openstack.org/">OpenStack documentation</ulink>.
  </para>
 </section>

--- a/xml/overview-whatiscmm-c-components.xml
+++ b/xml/overview-whatiscmm-c-components.xml
@@ -26,7 +26,7 @@
  </para>
  <para id="For_details_on_OpenStack_ref_concept_conbody_section_2_p">
   For details on OpenStack, refer to the
-  <ulink url="http://docs.openstack.org/"> OpenStack documentation </ulink>.
+  <ulink url="http://docs.openstack.org/">OpenStack documentation</ulink>.
  </para>
  <bridgehead renderas="sect4">Monitoring Service</bridgehead>
  <para id="idg-overview-whatiscmm-c-components-xml-9">
@@ -38,7 +38,7 @@
   The Monitoring Service relies on Monasca. It uses Monasca for high-speed
   metrics querying and integrates the streaming alarm engine and the
   notification engine of Monasca. For details, refer to the
-  <ulink url="https://wiki.openstack.org/wiki/Monasca"> Monasca Wiki </ulink>.
+  <ulink url="https://wiki.openstack.org/wiki/Monasca">Monasca Wiki</ulink>.
  </para>
  <bridgehead renderas="sect4">Horizon Plugin</bridgehead>
  <para>
@@ -51,8 +51,8 @@
  </para>
  <para>
   For details, refer to the
-  <ulink url="http://docs.openstack.org/developer/horizon/"> OpenStack Horizon
-  documentation </ulink>.
+  <ulink url="http://docs.openstack.org/developer/horizon/">OpenStack Horizon
+  documentation</ulink>.
  </para>
  <bridgehead renderas="sect4">Metrics Agent</bridgehead>
  <para id="idg-overview-whatiscmm-c-components-xml-14">
@@ -68,7 +68,7 @@
  <para id="The_agent_functionality_is_fu_concept_conbody_section_5_p">
   The agent functionality is fully integrated into the source code base of the
   Monasca project. For details, refer to the
-  <ulink url="https://wiki.openstack.org/wiki/Monasca"> Monasca Wiki </ulink>.
+  <ulink url="https://wiki.openstack.org/wiki/Monasca">Monasca Wiki</ulink>.
  </para>
  <bridgehead renderas="sect4">Log Agent</bridgehead>
  <para>
@@ -80,6 +80,6 @@
  <para>
   The agent functionality is fully integrated into the source code base of the
   Monasca project. For details, refer to the
-  <ulink url="https://wiki.openstack.org/wiki/Monasca"> Monasca Wiki </ulink>.
+  <ulink url="https://wiki.openstack.org/wiki/Monasca">Monasca Wiki</ulink>.
  </para>
 </section>

--- a/xml/overview-whatiscmm-c-userroles.xml
+++ b/xml/overview-whatiscmm-c-userroles.xml
@@ -85,6 +85,6 @@
  </itemizedlist>
  <para>
   For details on user management, refer to the
-  <ulink url="http://docs.openstack.org/"> OpenStack documentation </ulink>.
+  <ulink url="http://docs.openstack.org/">OpenStack documentation</ulink>.
  </para>
 </section>


### PR DESCRIPTION
- remove superfluous blanks within <ulink/>
  (due to an issue with the dietrich conversion script, I guess)

(cherry picked from commit 6959dea5e232996b122d3573e24bb81a2946006f)