### PR TITLE
remove PB3 per Keith Berger - HPE term, partner build 3

### DIFF
--- a/xml/installation-installation-install_vcp.xml
+++ b/xml/installation-installation-install_vcp.xml
@@ -27,10 +27,7 @@
   <section xml:id="d1e55">
    <title>passthrough-network-groups</title>
    <para>
-    <!-- FIXME: The heck is PB3? a version number like "prebeta 3"? (appears
-    multiple times in this document) - sknorr, 2017-12-29 -->
-    With PB3 the specification of
-    <literal>passthrough-network-groups</literal> is now
+    The specification of <literal>passthrough-network-groups</literal> is
     supported within the Interfaces section of the input model.
    </para>
    <para>
@@ -178,10 +175,9 @@
   <section xml:id="d1e225">
    <title>ardana-hypervisor</title>
    <para>
-    With PB3 we now support the specification
-    of <literal>ardana-hypervisor</literal> Boolean within the
-    Servers section of the input model. This setting is used to identify nodes
-    that can host VMs (non-NOVA).
+    Specifying the <literal>ardana-hypervisor</literal> Boolean is supported
+    within the Servers section of the input model. This setting is used to
+    identify nodes that can host VMs (non-Nova).
    </para>
    <para>
     This is related to the specification


### PR DESCRIPTION
PB3 is no longer apropos per Keith Berger Level 3 Support