### PR TITLE
fix broken link reference

### DIFF
--- a/xml/installation-installation-config_availability_zones.xml
+++ b/xml/installation-installation-config_availability_zones.xml
@@ -25,7 +25,8 @@
   configuration.
  </para>
  <para>
-  For more details, see
-  <!-- FIXME: <xref href="../operations/compute/creating_aggregates.xml"/> -->.
+  <!-- FIXME: HOS docs refer to <xref href="../operations/compute/creating_aggregates.xml"/>, which might be better suited when the operations guide is developed or converted. -->
+  For more details, see the OpenStack Availability Zone documentation at
+ <link xlink:href="https://docs.openstack.org/nova/pike/user/aggregates.html"/>.
  </para>
 </chapter>


### PR DESCRIPTION
one of many corrections in
bsc#1082644 which refers to
https://etherpad.nue.suse.com/p/cloud8-installation-guide-notes

