### PR TITLE
SCRD-2781 Document installation and repo prep

### DIFF
--- a/xml/entity-decl.ent
+++ b/xml/entity-decl.ent
@@ -241,13 +241,14 @@ suggested official replacement from rsalevsky. -->
 
 <!-- ++++++++++++++++++ Repository Names +++++++++++++++++++++++++ -->
 
-<!ENTITY sle_repo     "SLES12-SP2">
+<!ENTITY sle_repo     "SLES12-SP3">
 <!ENTITY sleha_repo   "SLE-HA12-SP2">
 <!ENTITY ses_repo     "SUSE-Enterprise-Storage-4">
-<!ENTITY cloud_repo   "SUSE-OpenStack-Cloud-7">
+<!ENTITY cloud_repo  "<phrase xmlns='http://docbook.org/ns/docbook'><phrase vendor='suse'>SUSE-OpenStack-Cloud-8></phrase><phrase vendor='hpe'>HPE-Helion-OpenStack-Cloud-8</phrase></phrase>">
 <!ENTITY smt_os       "sle-12-x86_64">
 <!ENTITY smt_dir      "/srv/www/htdocs/repo/SUSE">
 <!ENTITY tftp_dir     "/srv/tftpboot/suse-12.2/x86_64">
+<!ENTITY www_dir      "/srv/www/suse-12.3/x86_64">
 <!ENTITY ztftp_dir     "/srv/tftpboot/suse-12.2/s390x">
 
 <!ENTITY repospace    "30 GB">

--- a/xml/installation-installation-preinstall_overview.xml
+++ b/xml/installation-installation-preinstall_overview.xml
@@ -66,6 +66,9 @@
   </para>
  </chapter>
  <xi:include href="installation-installation-preinstall_checklist.xml"/>
+ <xi:include href="preinstall-prepare-deployer.xml" />
+ <xi:include href="preinstall-smt-setup.xml" />
+ <xi:include href="preinstall-configure-deployer-repos.xml" />
  <xi:include href="installation-installation-using_git.xml"/>
  <xi:include href="installation-installation-multipath_boot_from_san.xml"/>
  <xi:include href="installation-networking-l2gw5930.xml"/>

--- a/xml/installation-kvm_xpointer.xml
+++ b/xml/installation-kvm_xpointer.xml
@@ -109,14 +109,16 @@
    </step>
    <step>
     <para>
-     Prepare your servers. The &lcm; must be accessible either directly or via
+     Prepare the &lcm; node. The &lcm; must be accessible either directly or via
      <literal>ssh</literal>, and have &sles; 12 SP3 installed. All nodes must
-     be accessible to the &lcm;.
+     be accessible to the &lcm;. If the nodes do not have direct access to
+     online Cloud subscription channels, the &lcm; node will need to host the
+     Cloud repositories.
     </para>
     <substeps>
      <step>
       <para>
-       Add the repository as <literal>cloud-install-repo</literal>:
+       Add the repository as <literal>cloud-install-repo</literal> and refresh your repositories:
       </para>
 <screen vendor="suse">
 sudo zypper ar -G "iso:/?iso=SUSE-OPENSTACK-CLOUD-8-x86_64-GM-DVD1.iso" \
@@ -124,12 +126,23 @@ sudo zypper ar -G "iso:/?iso=SUSE-OPENSTACK-CLOUD-8-x86_64-GM-DVD1.iso" \
 <screen vendor="hpe">
 sudo zypper ar -G "iso:/?iso=HPE-HELION-OPENSTACK-CLOUD-8-x86_64-GM-DVD1.iso" \
   cloud-install-repo</screen>
+<screen>sudo zypper ref</screen>
      </step>
      <step>
       <para>
-       Refresh your repositories:
+       Prepare the &lcm; server for serving the Cloud media and updates
+       repositories as described in <xref linkend="cha.depl.dep_inst" />.
       </para>
-<screen>sudo zypper ref</screen>
+     </step>
+     <step>
+      <para>
+       Ensure the &productname; media repositories and updates repositories are made
+       available to all nodes in your deployment. This can be accomplished
+       either by configuring the &lcm; server as an SMT mirror as described in
+       <xref linkend="app.deploy.smt_lcm" /> or by syncing or mounting the Cloud
+       and updates repositories to the &lcm; server as described in
+       <xref linkend="cha.depl.repo_conf_lcm"/>.
+      </para>
      </step>
      <step>
       <para>

--- a/xml/preinstall-configure-deployer-repos.xml
+++ b/xml/preinstall-configure-deployer-repos.xml
@@ -1,0 +1,465 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE chapter
+[
+ <!ENTITY % entities SYSTEM "entity-decl.ent">
+  %entities;
+]>
+<chapter xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.0" xml:id="cha.depl.repo_conf_lcm">
+ <info>
+  <title>Software Repository Setup</title>
+ </info>
+ <para>
+  Software repositories containing products, extensions, and the respective
+  updates for all software need to be available to all nodes in &productname;
+  in order to complete the deployment. These can be managed manually, or they
+  can be hosted on the &lcm; server. In this configuration step, these
+  repositories are made available on the &lcm; server. There are two types of
+  repositories:
+ </para>
+ <para>
+  <emphasis role="bold">Product Media Repositories</emphasis>: Product media
+  repositories are copies of the installation media. They need to be
+  directly copied to the &lcm; server, <quote>loop-mounted</quote> from an iso
+  image, or mounted from a remote server via NFS. Affected are &cloudos; and
+  &productname; &productnumber;. These are static repositories; they do not
+  change or receive updates. See <xref
+  linkend="sec.depl.adm_conf.repos.product"/> for setup instructions.
+ </para>
+ <para>
+  <emphasis role="bold">Update and Pool Repositories</emphasis>: Update and
+  Pool repositories are provided by the &scc;. They contain all updates and
+  patches for the products and extensions. To make them available for
+  &productname; they need to be mirrored from the &scc;. Since their content is
+  regularly updated, they must be kept in synchronization with &scc;. For
+  these purposes, &suse; provides either the &smtool; (&smt;) or the
+  &susemgr;. See <xref linkend="sec.depl.adm_conf.repos.scc" /> for setup instructions.
+ </para>
+ <sect1 xml:id="sec.depl.adm_conf.repos.product">
+  <title>Copying the Product Media Repositories</title>
+  <para>
+   The files in the product repositories for &productname; do not
+   change, therefore they do not need to be synchronized with a remote
+   source. If you have installed the product media from a downloaded ISO image,
+   the product repositories will automatically be made available to the client
+   nodes and these steps can be skipped. These steps can also be skipped if you
+   prefer to install from the Pool repositories provided by &scc;. Otherwise,
+   it is sufficient to either copy the data (from a remote host or the
+   installation media), to mount the product repository from a remote server
+   via <literal>NFS</literal>, or to loop mount a copy of the installation
+   images.
+   </para>
+   <para>
+    If you choose to install from the product media rather than from the &scc;
+    repositories, the following product media needs to reside in the specified
+    directories:
+   </para>
+   <table>
+    <title>Local Product Repositories for &productname;</title>
+    <tgroup cols="2">
+     <colspec colnum="1" colname="1" colwidth="40*"/>
+     <colspec colnum="2" colname="2" colwidth="60*"/>
+     <thead>
+      <row>
+       <entry>
+        <para>
+         Repository
+        </para>
+       </entry>
+       <entry>
+        <para>
+         Directory
+        </para>
+       </entry>
+      </row>
+     </thead>
+     <tbody>
+      <row>
+       <entry>
+        <para>
+         &productname; &productnumber; DVD #1
+        </para>
+       </entry>
+       <entry>
+        <para>
+         <filename>&www_dir;/repos/Cloud</filename>
+        </para>
+       </entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </table>
+   <para>
+    The data can be copied by a variety of methods:
+   </para>
+   <variablelist>
+    <!-- sec.depl.adm_conf.repos.product.media -->
+    <varlistentry>
+     <term>Copying from the Installation Media</term>
+     <listitem>
+     <para>
+      We recommend using <command>rsync</command> for copying. If the
+      installation data is located on a removable device, make sure to mount
+      it first (for example, after inserting the DVD1 in the &admserv; and
+      waiting for the device to become ready):
+     </para>
+     <bridgehead renderas="sect4">
+      &productname; &productnumber; DVD#1
+     </bridgehead>
+     <screen>mkdir -p &www_dir;/repos/Cloud
+mount /dev/dvd /mnt
+rsync -avP /mnt/ &www_dir;/repos/Cloud/
+umount /mnt</screen>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <!-- sec.depl.adm_conf.repos.product.remote -->
+     <term>Copying from a Remote Host</term>
+     <listitem>
+      <para>
+       If the data is provided by a remote machine, log in to that machine and
+       push the data to the &admserv; (which has the IP address <systemitem
+       class="etheraddress">192.168.245.10</systemitem> in the following
+       example):
+      </para>
+      <bridgehead renderas="sect4">
+       &productname; &productnumber; DVD#1
+      </bridgehead>
+      <screen>mkdir -p &www_dir;/repos/Cloud
+rsync -avPz <replaceable>/data/SUSE-OPENSTACK-CLOUD//DVD1/</replaceable> <replaceable>192.168.245.10</replaceable>:&www_dir;/repos/Cloud/</screen>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <!-- sec.depl.adm_conf.repos.product.nfs -->
+     <term>Mounting from an NFS Server</term>
+     <listitem>
+      <para>
+       If the installation data is provided via NFS by a remote machine, mount
+       the respective shares as follows. To automatically mount these
+       directories either create entries in <filename>/etc/fstab</filename> or
+       set up the automounter.
+      </para>
+      <bridgehead renderas="sect4">
+       &productname; &productnumber; DVD#1
+      </bridgehead>
+      <screen>mkdir -p &www_dir;/repos/Cloud/
+mount -t nfs <replaceable>nfs.&exampledomain;:/exports/SUSE-OPENSTACK-CLOUD/DVD1/</replaceable> &www_dir;/repos/Cloud</screen>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </sect1>
+
+  <sect1 xml:id="sec.depl.adm_conf.repos.scc">
+   <title>Update and Pool Repositories</title>
+   <para>
+    Update and Pool Repositories are required on the &lcm; server to set up and
+    maintain the &productname; nodes. They are provided by &scc; and contain all
+    software packages needed to install &cloudos; and the extensions (pool
+    repositories). In addition, they contain all updates and patches (update
+    repositories).
+   </para>
+   <para>
+    The repositories can be made available on the &lcm; server using one or more of the
+    following methods:
+   </para>
+   <itemizedlist mark="bullet" spacing="normal">
+    <listitem>
+     <para>
+      <xref linkend="sec.depl.adm_conf.repos.scc.local_smt"/>
+     </para>
+    </listitem>
+    <listitem>
+     <para>
+      <xref linkend="sec.depl.adm_conf.repos.scc.alternatives"/>
+     </para>
+    </listitem>
+   </itemizedlist>
+   <sect2 xml:id="sec.depl.adm_conf.repos.scc.local_smt">
+    <title>
+     Repositories Hosted on an &smt; Server Installed on the &admserv;
+    </title>
+    <para>
+     When all update and pool repositories are managed by an &smt; server
+     installed on the &lcm; server (see <xref linkend="app.deploy.smt_lcm"/>),
+     the &lcm; automatically detects all available repositories. No further
+     action is required.
+    </para>
+   </sect2>
+
+   <sect2 xml:id="sec.depl.adm_conf.repos.scc.alternatives">
+    <title>Alternative Ways to Make the Repositories Available</title>
+    <para>
+     If you want to keep your &productname; network as isolated from the company
+     network as possible, or your infrastructure does not allow accessing a
+     &susemgr; or an &smt; server, you can alternatively provide access to the
+     required repositories by one of the following methods:
+    </para>
+    <itemizedlist>
+     <listitem>
+      <para>
+       Mount the repositories from a remote server.
+      </para>
+     </listitem>
+     <listitem>
+      <para>
+       Synchronize the repositories from a remote server (for example via
+       <command>rsync</command> and cron).
+      </para>
+     </listitem>
+     <listitem>
+      <para>
+        Manually synchronize the update repositories from removable media.
+      </para>
+     </listitem>
+    </itemizedlist>
+    <para>
+     The repositories must be made available at the
+     default locations on the &lcm; server as listed in <xref
+     linkend="tab.depl.adm_conf.local-repos"/>.
+    </para>
+   </sect2>
+  </sect1>
+
+ <sect1 xml:id="sec.deploy.repo_locations">
+ <title>Repository Locations</title>
+<para>
+The following tables show the locations of all repositories that can be used for &productname;.
+ </para>
+
+<table xml:id="tab.smt.repos_local">
+  <title>&smt; Repositories Hosted on the &admserv;</title>
+  <tgroup cols="2">
+   <colspec colnum="1" colname="1" colwidth="25*"/>
+   <colspec colnum="2" colname="2" colwidth="75*"/>
+   <thead>
+    <row>
+     <entry>
+      <para>
+       Repository
+      </para>
+     </entry>
+     <entry>
+      <para>
+       Directory
+      </para>
+     </entry>
+    </row>
+   </thead>
+   <tbody>
+    <row>
+     <entry namest="1" nameend="2">
+      <para>
+       Mandatory Repositories
+      </para>
+     </entry>
+    </row>
+    <row>
+     <entry>
+      <para>
+       &sle_repo;-Pool
+      </para>
+     </entry>
+     <entry>
+      <para>
+       <filename>&smt_dir;/Products/SLE-SERVER/12-SP3/x86_64/product/</filename>
+      </para>
+     </entry>
+    </row>
+    <row>
+     <entry>
+      <para>
+       &sle_repo;-Updates
+      </para>
+     </entry>
+     <entry>
+      <para>
+       <filename>&smt_dir;/Updates/SLE-SERVER/12-SP3/x86_64/update/</filename>
+      </para>
+     </entry>
+    </row>
+    <row>
+     <entry>
+      <para>
+       &cloud_repo;-Pool
+      </para>
+     </entry>
+     <entry>
+      <para>
+       <filename>&smt_dir;/Products/OpenStack-Cloud/8/x86_64/product/</filename>
+      </para>
+     </entry>
+    </row>
+    <row>
+     <entry>
+      <para>
+       &cloud_repo;-Updates
+      </para>
+     </entry>
+     <entry>
+      <para>
+       <filename>&smt_dir;/Updates/OpenStack-Cloud/8/x86_64/update/</filename>
+      </para>
+     </entry>
+    </row>
+   </tbody>
+  </tgroup>
+ </table>
+
+
+ <table xml:id="tab.depl.adm_conf.susemgr-repos">
+  <title>&susemgr; Repositories (Channels)</title>
+  <tgroup cols="2">
+   <colspec colnum="1" colname="1" colwidth="25*"/>
+   <colspec colnum="2" colname="2" colwidth="75*"/>
+   <thead>
+    <row>
+     <entry>
+      <para>
+       Repository
+      </para>
+     </entry>
+     <entry>
+      <para>
+       URL
+      </para>
+     </entry>
+    </row>
+   </thead>
+   <tbody>
+    <row>
+     <entry namest="1" nameend="2">
+      <para>
+       Mandatory Repositories
+      </para>
+     </entry>
+    </row>
+    <row>
+     <entry>
+      <para>
+       &sle_repo;-Updates
+      </para>
+     </entry>
+     <entry>
+      <para>
+       <uri>http://manager.&exampledomain;/ks/dist/child/sles12-sp3-updates-x86_64/sles12-sp3-x86_64/</uri>
+      </para>
+     </entry>
+    </row>
+    <row>
+     <entry>
+      <para>
+       &cloud_repo;-Pool
+      </para>
+     </entry>
+     <entry>
+      <para>
+       <remark condition="clarity">
+        2016-12-21 - fs: Check if true
+       </remark>
+       <uri>http://manager.&exampledomain;/ks/dist/child/suse-openstack-cloud-8-pool-x86_64/sles12-sp3-x86_64/</uri>
+      </para>
+     </entry>
+    </row>
+    <row>
+     <entry>
+      <para>
+       &cloud_repo;-Updates
+      </para>
+     </entry>
+     <entry>
+      <para>
+       <remark condition="clarity">
+        2016-01-13 - fs: Check if true
+       </remark>
+       <uri>http://manager.&exampledomain;/ks/dist/child/suse-openstack-cloud-8-updates-x86_64/sles12-sp3-x86_64/</uri>
+      </para>
+     </entry>
+    </row>
+   </tbody>
+  </tgroup>
+ </table>
+
+ <para>
+  The following table shows the required repository locations  to use when manually copying, synchronizing, or mounting the
+  repositories.
+ </para>
+
+ <table xml:id="tab.depl.adm_conf.local-repos">
+  <title>Repository Locations on the &lcm; server</title>
+  <tgroup cols="2">
+   <colspec colnum="1" colname="1" colwidth="25*"/>
+   <colspec colnum="2" colname="2" colwidth="75*"/>
+   <thead>
+    <row>
+     <entry>
+      <para>
+       Channel
+      </para>
+     </entry>
+     <entry>
+      <para>
+       Directory on the &admserv;
+      </para>
+     </entry>
+    </row>
+   </thead>
+   <tbody>
+    <row>
+     <entry namest="1" nameend="2">
+      <para>
+       Mandatory Repositories
+      </para>
+     </entry>
+    </row>
+    <row>
+     <entry>
+      <para>
+       &sle_repo;-Pool
+      </para>
+     </entry>
+     <entry>
+      <para>
+       <filename>&www_dir;/repos/&sle_repo;-Pool/</filename>
+      </para>
+     </entry>
+    </row>
+    <row>
+     <entry>
+      <para>
+       &sle_repo;-Updates
+      </para>
+     </entry>
+     <entry>
+      <para>
+       <filename>&www_dir;/repos/&sle_repo;-Updates/</filename>
+      </para>
+     </entry>
+    </row>
+    <row>
+     <entry>
+      <para>
+       &cloud_repo;-Pool
+      </para>
+     </entry>
+     <entry>
+      <para>
+       <filename>&www_dir;/repos/&cloud_repo;-Pool/</filename>
+      </para>
+     </entry>
+    </row>
+    <row>
+     <entry>
+      <para>
+       &cloud_repo;-Updates
+      </para>
+     </entry>
+     <entry>
+      <para>
+       <filename>&www_dir;/repos/&cloud_repo;-Updates</filename>
+      </para>
+     </entry>
+    </row>
+   </tbody>
+  </tgroup>
+ </table>
+ </sect1>
+ </chapter>

--- a/xml/preinstall-prepare-deployer.xml
+++ b/xml/preinstall-prepare-deployer.xml
@@ -1,0 +1,149 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE chapter
+[
+  <!ENTITY % entities SYSTEM "entity-decl.ent">
+  %entities;
+]>
+<chapter xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.0" xml:id="cha.depl.dep_inst">
+ <info>
+  <title>Installing the &lcm; server</title>
+  <abstract>
+   <para>
+    In this chapter you will learn how to install the &lcm; from
+    scratch. It will run on &cloudos; and include the &productname;
+    extension and, optionally, the &smtool; (&smt;) server.
+   </para>
+  </abstract>
+ </info>
+ <sect1 xml:id="sec.depl.adm_inst.os">
+  <title>Starting the Operating System Installation</title>
+  <para>
+   Start the installation by booting into the &cloudos; installation system.
+   For an overview of a default &sls; installation, refer to the <link
+   xlink:href="&suse-onlinedoc;/sles-12/book_quickstarts/data/art_sle_installquick.html">&sls;
+   &instquick;</link>. <link
+   xlink:href="&suse-onlinedoc;/sles-12/book_sle_deployment/data/cha_inst.html">Detailed
+   installation instructions</link> are available in the &sls;
+   <citetitle>Deployment Guide</citetitle>. Both documents are available at
+   <link xlink:href="&suse-onlinedoc;/sles-12/"/>.
+  </para>
+
+  <para>
+   The following sections will only cover the differences from the default
+   installation process.
+  </para>
+ </sect1>
+
+ <sect1 xml:id="sec.depl.adm_inst.online_update">
+  <title>Registration and Online Updates</title>
+  <para>
+   Registering &cloudos; during the installation process is required for
+   getting product updates and for installing the &productname;
+   extension. Refer to the <link
+   xlink:href="&suse-onlinedoc;/sles-12/book_sle_deployment/data/sec_i_yast2_conf_manual_cc.html">SUSE
+   Customer Center Registration</link> section of the &cloudos; <citetitle>Deployment
+   Guide</citetitle> for further instructions.
+  </para>
+  <para>
+   After a successful registration you will be asked whether
+   to add the update repositories. If you agree, the latest updates will
+   automatically be installed, ensuring that your system is on the latest
+   patch level after the initial installation. We strongly recommend adding the
+   update repositories immediately. If you choose to skip this step you need to
+   perform an online update later, before starting the installation.
+  </para>
+
+  <note>
+   <title>&suse; Login Required</title>
+   <para>
+    To register a product, you need to have a &suse; login.
+    If you do not have such a login, create it at
+    <link xlink:href="http://www.suse.com/login"/>.
+   </para>
+  </note>
+ </sect1>
+
+ <sect1 xml:id="sec.depl.adm_inst.add_on">
+  <title>Installing the &productname; Extension</title>
+
+  <para>
+   &cloud; is an extension to &sls;. Installing it during the &sls;
+   installation is the easiest and recommended way to set up the &lcm;. To get
+   access to the extension selection dialog, you need to register &cloudos;
+   during the installation. After a successful registration, the
+   &cloudos; installation continues with the <guimenu>Extension &amp; Module
+   Selection</guimenu>. Choose <guimenu>&productname; &productnumber;</guimenu>
+   and provide the registration key you obtained by purchasing
+   &productname;. The registration and the extension installation require an
+   Internet connection.
+  </para>
+  <para>
+   Alternatively, install the &productname; after the
+   &cloudos; installation via <menuchoice><guimenu>&yast;</guimenu>
+   <guimenu>Software</guimenu> <guimenu>Add-On Products</guimenu></menuchoice>.
+   For details, refer to the section <link
+   xlink:href="https://www.suse.com/documentation/sles-12/book_sle_deployment/data/sec_add-ons_extensions.html">Installing
+   Modules and Extensions from Online Channels</link> of the &cloudos;
+   <citetitle>Deployment Guide</citetitle>.
+  </para>
+
+ </sect1>
+
+ <sect1 xml:id="sec.depl.adm_inst.settings">
+  <title>Installation Settings</title>
+  <para>
+   In the final installation step, <guimenu>Installation Settings</guimenu>, you need to adjust
+   the software selection for your &lcm; setup. For more information
+   refer to the <link
+   xlink:href="&suse-onlinedoc;/sles-12/book_sle_deployment/data/sec_i_yast2_proposal.html">Installation
+   Settings</link> section of the &cloudos; <citetitle>Deployment
+   Guide</citetitle>.
+  </para>
+
+  <sect2 xml:id="sec.depl.adm_inst.settings.software">
+   <title>Software Selection</title>
+   <para>
+    Installing a minimal base system is sufficient to set up the
+    &admserv;. The following patterns are the minimum required:
+   </para>
+   <itemizedlist mark="bullet" spacing="normal">
+    <listitem>
+     <para>
+      <guimenu>Base System</guimenu>
+     </para>
+    </listitem>
+    <listitem>
+     <para>
+      <guimenu>Minimal System (Appliances)</guimenu>
+     </para>
+    </listitem>
+    <listitem>
+     <para>
+      <guimenu>Meta Package for Pattern cloud-ardana</guimenu> (in case you have
+      chosen to install the &productname; Extension)
+     </para>
+    </listitem>
+    <listitem>
+     <para>
+      <guimenu>Subscription Management Tool</guimenu> (optional, also see <xref
+      linkend="tip.depl.adm_inst.settings.smt"/>)
+     </para>
+    </listitem>
+   </itemizedlist>
+
+   <tip xml:id="tip.depl.adm_inst.settings.smt">
+    <title>Installing a Local &smt; Server (Optional)</title>
+    <para>
+     If you do not have a &susemgr; or &smt; server in your
+     organization, or are planning to manually update the repositories required for deployment of the &cloud; nodes, you need to set up an &smt; server on
+     the &admserv;. Choose the pattern <guimenu>Subscription Management
+     Tool</guimenu> in addition to the patterns listed above to install the
+     &smt; server software.
+    </para>
+   </tip>
+  </sect2>
+
+ </sect1>
+
+
+</chapter>

--- a/xml/preinstall-smt-setup.xml
+++ b/xml/preinstall-smt-setup.xml
@@ -1,0 +1,229 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE chapter
+[
+  <!ENTITY % entities SYSTEM "entity-decl.ent">
+  %entities;
+]>
+<chapter xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.0" xml:id="app.deploy.smt_lcm">
+ <title>Installing and Setting Up an &smt; Server on the &lcm; server (Optional)</title>
+ <info>
+  <abstract>
+   <para>
+    One way to provide the repositories needed to set up the nodes in
+    &cloud; is to install a &smtool; (&smt;) server on the &lcm; server, and then mirror all
+    repositories from &scc; via this server. Installing an &smt; server
+    on the &lcm; server is optional. If your organization already provides an
+    &smt; server or a &susemgr; server that can be accessed from the
+    &lcm; server, skip this step.
+   </para>
+  </abstract>
+ </info>
+ <important>
+  <title>Use of &smt; Server and Ports</title>
+  <para>
+   When installing an &smt; server on the &lcm; server, use it exclusively
+   for &productname;. To use the &smt; server for other
+   products, run it outside of &productname;. Make sure it can be accessed
+   from the &lcm; for mirroring the repositories needed for &productname;.
+  </para>
+  <para>
+   When the &smt; server is installed on the &lcm; server, &lcm;
+   provides the mirrored repositories on port <literal>79</literal>.
+  </para>
+ </important>
+ <sect1 xml:id="app.deploy.smt.install">
+  <title>&smt; Installation</title>
+
+  <para>
+   If you have not installed the &smt; server during the initial &lcm; server
+   installation as suggested in <xref
+   linkend="sec.depl.adm_inst.settings.software"/>, run the following command
+   to install it:
+  </para>
+  <screen>sudo zypper in -t pattern smt</screen>
+ </sect1>
+
+ <sect1 xml:id="app.deploy.smt.config">
+  <title>&smt; Configuration</title>
+
+  <para>
+   No matter whether the &smt; server was installed during the initial
+   installation or in the running system, it needs to be configured with the
+   following steps.
+  </para>
+
+  <note>
+   <title>Prerequisites</title>
+   <para>
+    To configure the &smt; server, a SUSE account is required. If you do not
+    have such an account, register at <link
+    xlink:href="http://www.suse.com/login"/>. All products and
+    extensions for which you want to mirror updates with the &smt;
+    server should be registered at the &scc; (<link
+    xlink:href="http://scc.suse.com/"/>).
+   </para>
+  </note>
+
+  <procedure>
+   <step>
+    <para>
+     Configuring the &smt; server requires you to have your mirroring
+     credentials (user name and password) and your registration e-mail
+     address at hand. To access them, proceed as follows:
+    </para>
+    <substeps performance="required">
+     <step>
+      <para>
+       Open a Web browser and log in to the &scc; at
+       <link xlink:href="http://scc.suse.com/"/>.
+      </para>
+     </step>
+     <step>
+      <para>
+       Click your name to see the e-mail address which you have registered.
+      </para>
+     </step>
+     <step>
+      <para>
+       Click <menuchoice> <guimenu>Organization</guimenu>
+       <guimenu>Organization Credentials</guimenu> </menuchoice> to obtain
+       your mirroring credentials (user name and password).
+      </para>
+     </step>
+    </substeps>
+   </step>
+   <step>
+    <para>
+     Start <menuchoice> <guimenu>&yast;</guimenu> <guimenu>Network
+     Services</guimenu> <guimenu>SMT Configuration
+     Wizard</guimenu></menuchoice>.
+    </para>
+   </step>
+   <step>
+    <para>
+     Activate <guimenu>Enable Subscription Management Tool Service
+     (SMT)</guimenu>.
+    </para>
+   </step>
+   <step>
+    <para>
+     Enter the <guimenu>Customer Center Configuration</guimenu> data as
+     follows:
+    </para>
+    <simplelist>
+     <member><guimenu>Use Custom Server</guimenu>:
+     Do <emphasis>not</emphasis> activate this option</member>
+     <member><guimenu>User</guimenu>: The user name you retrieved from the
+     &scc;</member>
+     <member><guimenu>Password</guimenu>: The password you retrieved from the
+     &scc;</member>
+    </simplelist>
+    <para>
+     Check your input with <guimenu>Test</guimenu>. If the test does not
+     return <literal>success</literal>, check the credentials you entered.
+    </para>
+   </step>
+   <step>
+    <para>
+     Enter the e-mail address you retrieved from the &scc; at
+     <guimenu>SCC E-Mail Used for Registration</guimenu>.
+    </para>
+   </step>
+   <step>
+    <para>
+     <guimenu>Your SMT Server URL</guimenu> shows the HTTP address of your
+     server. Usually it should not be necessary to change it.
+    </para>
+   </step>
+   <step>
+    <para>
+     Select <guimenu>Next</guimenu> to proceed to step two of the <guimenu>SMT Configuration Wizard</guimenu>.
+    </para>
+   </step>
+   <step>
+    <para>
+     Enter a <guimenu>Database Password for SMT User</guimenu> and confirm
+     it by entering it once again.
+    </para>
+   </step>
+   <step>
+    <para>
+     Enter one or more e-mail addresses to which &smt; status reports are
+     sent by selecting <guimenu>Add</guimenu>.
+    </para>
+   </step>
+   <step>
+    <para>
+     Select <guimenu>Next</guimenu> to save your &smt; configuration. When
+     setting up the database you will be prompted for the MariaDB root
+     password. If you have not already created one then create it in this step. Note that this is
+     the global MariaDB root password, not the database password for the SMT
+     user you specified before.
+    </para>
+    <para>
+     The &smt; server requires a server certificate at
+     <filename>/etc/pki/trust/anchors/YaST-CA.pem</filename>. Choose
+     <guimenu>Run CA Management</guimenu>, provide a password and choose
+     <guimenu>Next</guimenu> to create such a certificate. If your
+     organization already provides a CA certificate, <guimenu>Skip</guimenu>
+     this step and import the certificate via <menuchoice>
+     <guimenu>YaST</guimenu> <guimenu>Security and Users</guimenu>
+     <guimenu>CA Management</guimenu> </menuchoice> after the &smt;
+     configuration is done. See
+   <link xlink:href="&suse-onlinedoc;/sles-12/book_security/data/cha_security_yast_ca.html"/>
+   for more information.
+    </para>
+    <para>
+     After you complete your configuration a synchronization check with the &scc; will run, which may take several minutes.
+    </para>
+   </step>
+  </procedure>
+ </sect1>
+
+ <sect1 xml:id="app.deploy.smt.repos">
+  <title>Setting up Repository Mirroring on the &smt; Server</title>
+
+  <para>
+   The final step in setting up the &smt; server is configuring it to
+   mirror the repositories needed for &cloud;. The &smt; server
+   mirrors the repositories from the &scc;. Make
+   sure to have the appropriate subscriptions registered in &scc; with the
+   same e-mail address you specified when configuring &smt;.
+  </para>
+
+  <sect2 xml:id="app.deploy.smt.repos.mandatory">
+   <title>Adding Mandatory Repositories</title>
+   <para>
+    Mirroring the &cloudos; and &productname; &productnumber;
+    repositories is mandatory. Run the following commands as user
+    &rootuser; to add them to the list of mirrored repositories:
+   </para>
+<screen><?dbsuse-fo font-size="0.63em"?>for REPO in &sle_repo;-{Pool,Updates} &cloud_repo;-{Pool,Updates}; do
+  smt-repos $REPO &smt_os; -e
+done</screen>
+  </sect2>
+
+  <sect2 xml:id="app.deploy.smt.repos.mirror">
+   <title>Updating the Repositories</title>
+   <para>
+    New repositories added to &smt; must be updated immediately by running the following command as user &rootuser;:
+   </para>
+<screen>smt-mirror -L /var/log/smt/smt-mirror.log</screen>
+   <para>
+    This command will download several GB of patches. This process may last
+    up to several hours. A log file is written to
+    <filename>/var/log/smt/smt-mirror.log</filename>. After this first manual update the repositories are updated automatically via cron
+    job. A list of all
+    repositories and their location in the file system on the &lcm; server can be
+    found at <xref linkend="tab.smt.repos_local"/>.
+   </para>
+  </sect2>
+ </sect1>
+ <sect1 xml:id="app.deploy.smt.info">
+  <title>For More Information</title>
+
+  <para>
+   For detailed information about &smt; refer to the &smtool; manual at <link xlink:href="&suse-onlinedoc;/sles-12/book_smt/data/book_smt.html"/>.
+  </para>
+ </sect1>
+</chapter>


### PR DESCRIPTION
In order to make the Cloud installer and updates media available to the
all nodes in the deployment beyond just the deployer node, certain
manual steps must be taken. This patch updates the GUI installer guide
to instruct users to take these extra preparation steps. These steps are
very similar to steps 3, 4, and 5 of setting up the administration
server for Cloud 7[1].

[1] http://docserv.nue.suse.com/documents/Cloud7/suse-openstack-cloud-deployment/html/part.depl.admserv.html