### PR TITLE
change 2.3 Cloud Lifecycle Manager checklist entry

### DIFF
--- a/xml/installation-installation-preinstall_checklist.xml
+++ b/xml/installation-installation-preinstall_checklist.xml
@@ -553,7 +553,8 @@
      </row>
      <row>
       <entry/>
-      <entry><xref linkend="install_kvm"/>
+      <entry>
+       <xref linkend="sec.kvm.setup_deployer"/>
       </entry>
       <entry/>
      </row>


### PR DESCRIPTION
to show proper link location. This checklist is referred to in the suggested content for 
Manual Deployment of Entry-Scale-ESX-KVM (comment 5)
bsc#1075107
https://suse-wiki.dyndns.org/display/HHE/Manual+Deployment+of+Entry-Scale-ESX-KVM-VSA+in+the+absence+of+EON