### PR TITLE
Fix typo in SOC8 repo name (bsc#1089770)

### DIFF
--- a/xml/entity-decl.ent
+++ b/xml/entity-decl.ent
@@ -245,7 +245,7 @@ suggested official replacement from rsalevsky. -->
 <!ENTITY sle_repo     "SLES12-SP3">
 <!ENTITY sleha_repo   "SLE-HA12-SP3">
 <!ENTITY ses_repo     "SUSE-Enterprise-Storage-4">
-<!ENTITY cloud_repo  "<phrase xmlns='http://docbook.org/ns/docbook'><phrase vendor='suse'>SUSE-OpenStack-Cloud-8></phrase><phrase vendor='hpe'>HPE-Helion-OpenStack-8</phrase></phrase>">
+<!ENTITY cloud_repo  "<phrase xmlns='http://docbook.org/ns/docbook'><phrase vendor='suse'>SUSE-OpenStack-Cloud-8</phrase><phrase vendor='hpe'>HPE-Helion-OpenStack-8</phrase></phrase>">
 <!ENTITY smt_os       "sle-12-x86_64">
 <!ENTITY smt_dir      "/srv/www/htdocs/repo/SUSE">
 <!ENTITY tftp_dir     "/srv/tftpboot/suse-12.2/x86_64">


### PR DESCRIPTION
The &cloud_repo entity had an extra '>' in it, which when rendered in a
shell example caused the example to be incorrect.