### PR TITLE
migration: Add important note to use latest doc (bsc#1090232)

### DIFF
--- a/xml/art_migration.xml
+++ b/xml/art_migration.xml
@@ -17,6 +17,13 @@
 <!-- <xi:include href="common_copyright_gfdl.xml"/> -->
 <!--<xi:include href="authors.xml"/>-->
  </info>
+ <important>
+   <title>Use latest documentation version</title>
+   <para>
+     Please follow the latest online version of the documentation when starting the
+     migration process.
+   </para>
+ </important>
  <para>
   <remark role="clarity">taroth 2018-02-27: who is the target audience for this document?
   cloud operators? cloud administrators?</remark>


### PR DESCRIPTION
Given that the migration might be only supported to a GM (without
updates installed), mention that the documentation should not be taken
from GM (but the online version which is GM+Updates).