### PR TITLE
Document backup restore command

### DIFF
--- a/xml/depl_maintenance.xml
+++ b/xml/depl_maintenance.xml
@@ -2078,6 +2078,18 @@ done</screen>
       </para>
      </listitem>
     </varlistentry>
+    <varlistentry>
+     <term>
+      <command>crowbarctl backup restore
+      <replaceable>NAME</replaceable></command>
+     </term>
+     <listitem>
+      <para>
+       Restore crowbar data from a backup named <replaceable>NAME</replaceable>.
+       The backup needs to be uploaded before. <replaceable>NAME</replaceable> will be the name of the uploaded file without the <filename>.tar.gz</filename> ending.
+      </para>
+     </listitem>
+    </varlistentry>
    </variablelist>
   </sect2>
  </sect1>


### PR DESCRIPTION
there is more waiting to be documented - e.g. on the required (rather fresh) state of the crowbar node during restore
https://bugzilla.suse.com/show_bug.cgi?id=1093004#c57