### PR TITLE
Remove duplicate section in Installation Guide

### DIFF
--- a/xml/installation-installation-esx-procedure_to_deploy_esx_cloud.xml
+++ b/xml/installation-installation-esx-procedure_to_deploy_esx_cloud.xml
@@ -8,11 +8,13 @@
  xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>Procedure to Deploy ESX Cloud with OVSvApp</title>
 
- <!-- Setting Up the &lcm; -->
+ <!-- Setting Up the &lcm;
+      FIXME: This section may still be needed when EON
+      situation is resolved. csymons 2018-05-18
  <section xml:id="sec.esx.setup_deployer">
   <xi:include xpointer="element(/1/4/1)" href="installation-kvm_xpointer.xml"/>
   <xi:include xpointer="element(/1/4/2)" href="installation-kvm_xpointer.xml"/>
- </section>
+ </section> -->
 
  <section>
   <title>Prepare and Deploy Cloud Controllers</title>
@@ -22,7 +24,7 @@
      Setup your configuration files, as follows:
     </para>
     <substeps>
-	<step>
+      <step>
       <para>
        Copy the example configuration files into the required setup directory
        and edit them as required:
@@ -31,8 +33,8 @@
   ~/openstack/my_cloud/definition/</screen>
       <para>
        See a sample set of configuration files in the directory
-       <literal>~/openstack/examples/entry-scale-kvm</literal>.
-       The accompanying README.md file explains the contents of each of the
+       <filename>~/openstack/examples/entry-scale-kvm</filename>.
+       The accompanying <filename>README.md</filename> file explains the contents of each of the
        configuration files.
       </para>
      </step>
@@ -40,14 +42,14 @@
       <para>
        Begin inputting your environment information into the configuration
        files in the directory
-       <literal>~/openstack/my_cloud/definition</literal>.
+       <filename>~/openstack/my_cloud/definition</filename>.
       </para>
       <note>
        <para>
         If you want to use a dedicated deployer node in your ESX deployment,
-        add <emphasis role="bold">eon-client</emphasis> service-component, to
+        add <literal>eon-client</literal> service-component, to
         manage vCenter via EON operation from the deployer node, in the
-        <literal>control_plane.yml</literal> file as shown in the following
+        <filename>control_plane.yml</filename> file as shown in the following
         example.
        </para>
       </note>
@@ -60,7 +62,7 @@
             - <emphasis role="bold">eon-client</emphasis>
             ...</screen>
      </step>
-	</substeps>
+       </substeps>
     </step>
    <step>
     <para>

--- a/xml/installation-installation-gui_installer.xml
+++ b/xml/installation-installation-gui_installer.xml
@@ -405,7 +405,7 @@ ssh -N -L 8080:localhost:3000 ardana@<replaceable>MANAGEMENT IP address of &lcm;
 </screen>
     <para>
      The user name and password should be what was set in
-     <xref linkend="sec.kvm.setup_deployer"/>. There will be no prompt after
+     <xref linkend="sec.depl.adm_inst.add_on"/>. There will be no prompt after
      you have logged in.
     </para>
    </step>

--- a/xml/installation-installation-installing_kvm.xml
+++ b/xml/installation-installation-installing_kvm.xml
@@ -10,11 +10,6 @@
  <itemizedlist>
   <listitem>
    <para>
-    <xref linkend="sec.kvm.setup_deployer"/>
-   </para>
-  </listitem>
-  <listitem>
-   <para>
     <xref linkend="sec.kvm.configuration"/>
    </para>
   </listitem>
@@ -62,11 +57,11 @@
   <xi:include xpointer="element(/1/3/2)" href="installation-kvm_xpointer.xml"/>
  </section>
 
- <!-- Setting Up the &lcm; -->
+ <!-- Setting Up the &lcm;
  <section xml:id="sec.kvm.setup_deployer">
   <xi:include xpointer="element(/1/4/1)" href="installation-kvm_xpointer.xml"/>
   <xi:include xpointer="element(/1/4/2)" href="installation-kvm_xpointer.xml"/>
- </section>
+ </section> -->
 
  <!-- Configuring Your Environment -->
  <section xml:id="sec.kvm.configuration">

--- a/xml/installation-installation-preinstall_checklist.xml
+++ b/xml/installation-installation-preinstall_checklist.xml
@@ -554,7 +554,7 @@
      <row>
       <entry/>
       <entry>
-       <xref linkend="sec.kvm.setup_deployer"/>
+       <xref linkend="sec.depl.adm_inst.add_on"/>
       </entry>
       <entry/>
      </row>

--- a/xml/operations-maintenance-controller-lifecyclemanager_recovery.xml
+++ b/xml/operations-maintenance-controller-lifecyclemanager_recovery.xml
@@ -21,7 +21,7 @@
   Ensuring that you use the same version of &kw-hos; that you previously had
   loaded on your &lcm;, you will need to download and install the
   lifecycle management software using the instructions from the
-  <xref linkend="sec.kvm.setup_deployer"/> before proceeding further.
+  <xref linkend="sec.depl.adm_inst.add_on"/> before proceeding further.
  </para>
  <section>
   <title>Restore from a Swift backup</title>

--- a/xml/operations-maintenance-controller-replace_shared_lm.xml
+++ b/xml/operations-maintenance-controller-replace_shared_lm.xml
@@ -28,7 +28,7 @@
    <orderedlist>
     <listitem>
      <para>
-      <xref linkend="sec.kvm.setup_deployer"/>
+      <xref linkend="sec.depl.adm_inst.add_on"/>
      </para>
     </listitem>
     <listitem>


### PR DESCRIPTION
bsc#1093835; section "Installing Cloud Lifecycle Manager" in
Section 12 Installing Mid-scale and Entry-scale KVM
is duplicate of information in
Section 3-Installing the Cloud Lifecycle Manager server