### PR TITLE
Remove CPU models

### DIFF
--- a/xml/operations-compute-using_flavor_metadata.xml
+++ b/xml/operations-compute-using_flavor_metadata.xml
@@ -8,154 +8,45 @@
 <section xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="topic_vhs_12v_vw">
  <title>Using Flavor Metadata to Specify CPU Model</title>
  <para>
-  In &kw-hos; Nova, the <literal>ComputeCapabilitiesFilter</literal>
-  scheduling filter matches the exact CPU model of the compute host and the
-  requested compute instance model. It doesn't entertain the libvirt's
-  capability of emulating the hosts CPU model to its guests if the guest's CPU
-  model is older or equal to that of the hosts.
+  <literal>Libvirt</literal> is a collection of software used in &ostack; to
+  manage virtualization. It has the ability to emulate a host CPU model in a
+  guest VM. In &kw-hos; &o_comp;, the ComputeCapabilitiesFilter limits this
+  ability by checking the exact CPU model of the compute host against the
+  requested compute instance model. It will only pick compute hosts that have
+  the <literal>cpu_model</literal> requested by the instance model, and if the
+  selected compute host does not have that <literal>cpu_model</literal>, the
+  ComputeCapabilitiesFilter moves on to find another compute host that matches,
+  if possible. Selecting an unavailable vCPU model may cause &o_comp; to fail
+  with <literal>no valid host found</literal>.
  </para>
  <para>
-  To assist, we have introduced a new Nova scheduler filter which captures the
-  cpu_models as a subset of a particular CPU family. The filter determines if
-  the host CPU model is capable of emulating the guest CPU model by
-  maintaining the mapping of the vCPU models per vendor (currently Intel and
-  AMD) and compares it against the 'model' of the host.
+  To assist, there is a &o_comp; scheduler filter that captures
+  <literal>cpu_models</literal> as a subset of a particular CPU family. The
+  filter determines if the host CPU model is capable of emulating the guest
+  CPU model by maintaining the mapping of the vCPU models and comparing it with
+  the host CPU model.
  </para>
  <para>
-  There is a current limitation which is when a particular cpu_model is
-  requested through <literal>hw:cpu_model</literal> via a compute flavor, the
-  cpu_mode will be set to "custom". This mode makes it so that a persistent
-  guest virtual machine will see the same hardware no matter what host
-  physical machine the guest virtual machine is booted on. This allows easier
-  live migration of virtual machines. Because of this limitation, only some of
-  the features of a CPU are exposed to the guest. Requesting a particular CPU
-  feature is not currently supported.
+  There is a limitation when a particular <literal>cpu_model</literal> is
+  specified with <literal>hw:cpu_model</literal> via a compute flavor: the
+  <literal>cpu_mode</literal> will be set to <literal>custom</literal>. This
+  mode ensures that a persistent guest virtual machine will see the same
+  hardware no matter what host physical machine the guest virtual machine is
+  booted on. This allows easier live migration of virtual machines. Because of
+  this limitation, only some of the features of a CPU are exposed to the guest.
+  Requesting particular CPU features is not supported.
  </para>
- <section xml:id="models">
-  <title>Available CPU models</title>
-  <para>
-   Available CPU model choices are:
-  </para>
-  <informaltable colsep="1" rowsep="1">
-   <tgroup cols="2">
-    <colspec colname="c1" colnum="1"/>
-    <colspec colname="c2" colnum="2"/>
-    <thead>
-     <row>
-      <entry>Manufacturer</entry>
-      <entry>Supported cpu_model options</entry>
-     </row>
-    </thead>
-    <tbody>
-     <row>
-      <entry>Intel</entry>
-      <entry>
-       <itemizedlist>
-        <listitem>
-         <para>
-          <literal>Conroe</literal>
-         </para>
-        </listitem>
-        <listitem>
-         <para>
-          <literal>Penryn</literal>
-         </para>
-        </listitem>
-        <listitem>
-         <para>
-          <literal>Nehalem</literal>
-         </para>
-        </listitem>
-        <listitem>
-         <para>
-          <literal>Westmere</literal> (see note below)
-         </para>
-        </listitem>
-        <listitem>
-         <para>
-          <literal>SandyBridge</literal>
-         </para>
-        </listitem>
-        <listitem>
-         <para>
-          <literal>IvyBridge</literal>
-         </para>
-        </listitem>
-        <listitem>
-         <para>
-          <literal>Haswell</literal>
-         </para>
-        </listitem>
-        <listitem>
-         <para>
-          <literal>Broadwell</literal>
-         </para>
-         <note>
-          <para>
-           The <literal>Westmere</literal> <literal>cpu_model</literal>
-           inherits all of the features from the <literal>Nehalem</literal>
-           model, so if the compute host's <literal>cpu_model</literal> is
-           <literal>Westmere</literal> and the requested
-           <literal>cpu_model</literal> is <literal>Nehalem</literal> then
-           the instance will run on that host.
-          </para>
-         </note>
-        </listitem>
-       </itemizedlist>
-      </entry>
-     </row>
-     <row>
-      <entry>AMD</entry>
-      <entry>
-       <itemizedlist xml:id="ul_k1m_m4b_ww">
-        <listitem>
-         <para>
-          <literal>Athlon</literal>
-         </para>
-        </listitem>
-        <listitem>
-         <para>
-          <literal>phenom</literal>
-         </para>
-        </listitem>
-        <listitem>
-         <para>
-          <literal>Opteron_G2</literal>
-         </para>
-        </listitem>
-        <listitem>
-         <para>
-          <literal>Opteron_G3</literal>
-         </para>
-        </listitem>
-        <listitem>
-         <para>
-          <literal>Opteron_G4</literal>
-         </para>
-        </listitem>
-        <listitem>
-         <para>
-          <literal>Opteron_G5</literal>
-         </para>
-        </listitem>
-       </itemizedlist>
-      </entry>
-     </row>
-    </tbody>
-   </tgroup>
-  </informaltable>
- </section>
  <section>
-  <title>Editing the flavor metadata in the Horizon dashboard</title>
+  <title>Editing the flavor metadata in the &o_dash; dashboard</title>
   <para>
-   These steps can be used to edit a flavor's metadata in the Horizon dashboard
-   to add the <literal>extra_specs</literal> for a
+   These steps can be used to edit a flavor's metadata in the &o_dash;
+   dashboard to add the <literal>extra_specs</literal> for a
    <literal>cpu_model</literal>:
   </para>
   <orderedlist>
    <listitem>
     <para>
-     Access the Horizon dashboard and log in with admin credentials.
+     Access the &o_dash; dashboard and log in with admin credentials.
     </para>
    </listitem>
    <listitem>
@@ -164,14 +55,14 @@
      to the Admin section, and then (C) clicking on Flavors:
     </para>
     <informalfigure>
-    <mediaobject>
-     <imageobject role="fo">
-      <imagedata fileref="media-hos.docs-operations-flavor_extraspecs_1.png" width="75%"/>
-     </imageobject>
-     <imageobject role="html">
-      <imagedata fileref="media-hos.docs-operations-flavor_extraspecs_1.png"/>
-     </imageobject>
-    </mediaobject>
+     <mediaobject>
+      <imageobject role="fo">
+       <imagedata fileref="media-hos.docs-operations-flavor_extraspecs_1.png" width="75%"/>
+      </imageobject>
+      <imageobject role="html">
+       <imagedata fileref="media-hos.docs-operations-flavor_extraspecs_1.png"/>
+      </imageobject>
+     </mediaobject>
     </informalfigure>
    </listitem>
    <listitem>


### PR DESCRIPTION
We support all CPU models; no need to spell out specifically
corrected as requested by TR Bosworth, 
with input from Mike Latimer (SES Engineer) and 
Michal Svec (Product Manager)