### PR TITLE
Fix the swift container-sync documentation

### DIFF
--- a/xml/operations-objectstorage-swift_container_sync.xml
+++ b/xml/operations-objectstorage-swift_container_sync.xml
@@ -328,6 +328,12 @@ Additional middleware: container_sync
 key = lQ8JjuZfO
 # key2 =
 cluster_thiscluster = http://&lt;Swift-Proxy-Vip&gt;:8080/v1/</screen>
+  <para>
+   The keys defined in <literal>/etc/swift/container-sync-realms.conf</literal>
+   are used by the container-sync daemon to determine trust. On top of this
+   the containers that will be in sync will need a seperate shared key they
+   both define in container metadata to establish their trust between each other.
+  </para>
   <orderedlist>
    <listitem>
     <para>
@@ -357,17 +363,16 @@ Containers in policy "erasure-code-ring": 3
    </listitem>
    <listitem>
     <para>
-     Configure container-src to sync to container-dst using the key specified
-     in the intracluster realm in
-     <literal>/etc/swift/container-sync-realms.conf</literal>
+     Configure container-src to sync to container-dst using a key specified
+     by both containers. Replace <replaceable>KEY</replaceable> with your key.
     </para>
-<screen>swift post -t '//intracluster/thiscluster/AUTH_1234/container-dst' -k 'lQ8JjuZfO' container-src</screen>
+<screen>swift post -t '//intracluster/thiscluster/AUTH_1234/container-dst' -k '<replaceable>KEY</replaceable>' container-src</screen>
    </listitem>
    <listitem>
     <para>
      Configure container-dst to accept synced objects with this key
     </para>
-<screen>swift post -k 'lQ8JjuZfO' container-dst</screen>
+<screen>swift post -k '<replaceable>KEY</replaceable>' container-dst</screen>
    </listitem>
    <listitem>
     <para>


### PR DESCRIPTION
The realm keys are used by container-sync to create a trust
with another cluster in the realm. They _should_ never be used
as the keys used in the container metadata when setting up the
sync between containers.

Container sync will use both the realm key(s) and the key specified
in the container metadata to generate a HMAC to authenticate the
container-sync request to push objects to the destination container.

The doc specifically said to use the realm key when setting up
sync between containers, which is not only incorrect but insecure.
General users should not know the realm keys. Ops should set up the
trust (realm keys). Users can use /info to see other clusters
and will generate their own keys to set up container sync relationships
with containers.