### PR TITLE
Add MariaDB SSL configuration (bsc#1070999)

### DIFF
--- a/xml/depl_nodes.xml
+++ b/xml/depl_nodes.xml
@@ -783,6 +783,64 @@
       </para>
     </note>
 
+    <sect3 xml:id="sec.depl.ostack.db.mariadb.ssl">
+      <title>SSL Configuration</title>
+
+      <para>
+        SSL can be enabled with either a stand-alone or cluster deployment.
+        The replication traffic between database nodes is not encrypted,
+        whilst traffic between the database server(s) and clients are, so
+        a separate network for the database servers is recommended.
+      </para>
+
+      <para>
+        Certificates can be provided, or the barcamp can generate self-signed
+        certificates. The certificate filenames are configurable in the
+        barclamp, and the directories <literal>/etc/mysql/ssl/certs</literal>
+        and <literal>/etc/mysql/ssl/private</literal> to use the defaults will
+        need to be created before the barclamp is applied. The CA certificate
+        and the certificate for &mariadb; to use both go into
+        <literal>/etc/mysql/ssl/certs</literal>. The appropriate private key
+        for the certificate is placed into the
+        <literal>/etc/mysql/ssl/private</literal> directory. As long as the
+        files are readable when the barclamp is deployed, permissions can be
+        tightened after a successful deployment once the appropriate UNIX
+        groups exist.
+      </para>
+
+      <para>
+        The Common Name (CN) for the SSL certificate must be <literal>fully
+        qualified server name</literal> for single host deployments, and
+        cluster-<literal>cluster name</literal>.<literal>full domain
+        name</literal> for cluster deployments.
+      </para>
+
+      <note>
+        <title>Certificate validation errors</title>
+        <para>
+          If certificate validation errors are causing issues with deploying
+          other barclamps (for example, when creating databases or users) you
+          can check the configuration with
+          <command>mysql --ssl-verify-server-cert</command> which will perform
+          the same verification that Crowbar does when connecting to the
+          database server.
+        </para>
+      </note>
+
+      <para>
+        If certificates are supplied, the CA certificate and its full trust
+        chain must be in the <literal>ca.pem</literal> file. The certificate
+        must be trusted by the machine (or all cluster members in a cluster
+        deployment), and it must be available on all client machines &mdash;
+        IE, if the OpenStack services are deployed on separate machines or
+        cluster members they will all require the CA certificate to be in
+        <literal>/etc/mysql/ssl/certs</literal> as well as trusted by the
+        machine.
+      </para>
+    </sect3>
+
+  <sect3>
+  <title>&mariadb; Configuration Options</title>
   <figure>
    <title>&mariadb; Configuration</title>
    <mediaobject>
@@ -855,6 +913,7 @@
         &o_monitor; uses its own &mariadb; instance.
       </para>
     </warning>
+  </sect3>
 
   </sect2>
  </sect1>


### PR DESCRIPTION
Add some prose to the Database Barclamp section explaining how to
configure SSL with MariaDB, as long as with explaining how to debug
certificate issues.