### PR TITLE
SCRD-3687 [doc] default pattern is missing (bsc# 1097127)

### DIFF
--- a/xml/preinstall-prepare-deployer.xml
+++ b/xml/preinstall-prepare-deployer.xml
@@ -177,6 +177,11 @@
       linkend="tip.depl.adm_inst.settings.smt"/>)
      </para>
     </listitem>
+    <listitem>
+     <para>
+      <guimenu>YaST2 configuration packages</guimenu>
+     </para>
+    </listitem> 
    </itemizedlist>
 
    <tip xml:id="tip.depl.adm_inst.settings.smt">


### PR DESCRIPTION
Added the missing default pattern "YAST2 configuration packages"