### PR TITLE
SCRD-3598 remove refrence of newton in HPE docs (bsc#1076233)

### DIFF
--- a/xml/operations-configuring-identity-identity_ldap.xml
+++ b/xml/operations-configuring-identity-identity_ldap.xml
@@ -117,8 +117,8 @@ domain_configurations_from_database = False</screen>
     <note>
      <para>
       Please refer to the LDAP section of the
-      <link xlink:href="http://docs.openstack.org/liberty/config-reference/content/keystone-configuration-file.html">Keystone</link>
-      documentation for OpenStack Newton for the full option list and
+      <link xlink:href="https://github.com/openstack/keystone/blob/stable/pike/etc/keystone.conf.sample">Keystone</link>
+      configuration example for OpenStack for the full option list and
       description.
      </para>
     </note>

--- a/xml/operations-troubleshooting-ts_magnum.xml
+++ b/xml/operations-troubleshooting-ts_magnum.xml
@@ -92,7 +92,7 @@
 | flavor                               | m1.small (2)                                                                                                  |
 | hostId                               | eb101a0293a9c4c3a2d79cee4297ab6969e0f4ddd105f4d207df67d2                                                      |
 | id                                   | 4d96510e-c202-4c62-8157-c0e3dddff6d5                                                                          |
-| image                                | fedora-atomic-newton (4277115a-f254-46c0-9fb0-fffc45d2fd38)                                                   |
+| image                                | fedora-atomic-26-20170723.0.x86_64 (4277115a-f254-46c0-9fb0-fffc45d2fd38)                                                   |
 | key_name                             | testkey                                                                                                       |
 | metadata                             | {}                                                                                                            |
 | name                                 | my-zaqshggwge-0-sqhpyez4dig7-kube_master-wc4vv7ta42r6                                                         |

--- a/xml/operations-troubleshooting-ts_magnum.xml
+++ b/xml/operations-troubleshooting-ts_magnum.xml
@@ -92,7 +92,7 @@
 | flavor                               | m1.small (2)                                                                                                  |
 | hostId                               | eb101a0293a9c4c3a2d79cee4297ab6969e0f4ddd105f4d207df67d2                                                      |
 | id                                   | 4d96510e-c202-4c62-8157-c0e3dddff6d5                                                                          |
-| image                                | fedora-atomic-26-20170723.0.x86_64 (4277115a-f254-46c0-9fb0-fffc45d2fd38)                                                   |
+| image                                | fedora-atomic-26-20170723.0.x86_64 (4277115a-f254-46c0-9fb0-fffc45d2fd38)                                     |
 | key_name                             | testkey                                                                                                       |
 | metadata                             | {}                                                                                                            |
 | name                                 | my-zaqshggwge-0-sqhpyez4dig7-kube_master-wc4vv7ta42r6                                                         |

--- a/xml/userguide-container_service-deploying_apache_mesos_ubuntu.xml
+++ b/xml/userguide-container_service-deploying_apache_mesos_ubuntu.xml
@@ -24,7 +24,7 @@
     <para>
      Deploying an Apache Mesos Cluster requires the Fedora Atomic image
      prepared specifically for the OpenStack Newton release. You can download
-     the <emphasis role="bold">ubuntu-mesos-newton.qcow2</emphasis>
+     the <emphasis role="bold">ubuntu-mesos-latest.qcow2</emphasis>
      image from
      <link xlink:href="https://fedorapeople.org/groups/magnum/"/>
     </para>
@@ -61,14 +61,14 @@
       requires a proxy.
      </para>
     </note>
-<screen>$ https_proxy=http://proxy.yourcompany.net:8080 wget https://fedorapeople.org/groups/magnum/ubuntu-mesos-newton.qcow2</screen>
+<screen>$ https_proxy=http://proxy.yourcompany.net:8080 wget https://fedorapeople.org/groups/magnum/ubuntu-mesos-latest.qcow2</screen>
    </step>
    <step>
     <para>
      Create a Glance image.
     </para>
 <screen>
-$ glance image-create --name ubuntu-mesos-newton --visibility public --disk-format qcow2 --os-distro ubuntu --container-format bare --file ubuntu-mesos-newton.qcow2 --progress
+$ glance image-create --name ubuntu-mesos-latest --visibility public --disk-format qcow2 --os-distro ubuntu --container-format bare --file ubuntu-mesos-latest.qcow2 --progress
 [=============================&gt;] 100%
 +------------------+--------------------------------------+
 | Property         | Value                                |
@@ -80,8 +80,8 @@ $ glance image-create --name ubuntu-mesos-newton --visibility public --disk-form
 | id               | d6a4e6f9-9e34-4816-99fe-227e0131244f |
 | min_disk         | 0                                    |
 | min_ram          | 0                                    |
-| name             | ubuntu-mesos-newton                  |
-| os_distro        | ubuntu                               |
+| name             | ubuntu-mesos-latest                  |
+| os_distro        | ubuntu                              |
 | owner            | 2f5b83ab49d54aaea4b39f5082301d09     |
 | protected        | False                                |
 | size             | 753616384                            |

--- a/xml/userguide-container_service-deploying_apache_mesos_ubuntu.xml
+++ b/xml/userguide-container_service-deploying_apache_mesos_ubuntu.xml
@@ -81,7 +81,7 @@ $ glance image-create --name ubuntu-mesos-latest --visibility public --disk-form
 | min_disk         | 0                                    |
 | min_ram          | 0                                    |
 | name             | ubuntu-mesos-latest                  |
-| os_distro        | ubuntu                              |
+| os_distro        | ubuntu                               |
 | owner            | 2f5b83ab49d54aaea4b39f5082301d09     |
 | protected        | False                                |
 | size             | 753616384                            |

--- a/xml/userguide-container_service-deploying_docker_fedora_atomic.xml
+++ b/xml/userguide-container_service-deploying_docker_fedora_atomic.xml
@@ -77,7 +77,7 @@
 | id               | 4277115a-f254-46c0-9fb0-fffc45d2fd38 |
 | min_disk         | 0                                    |
 | min_ram          | 0                                    |
-| name             | fedora-atomic-26-20170723.0.x86_64                  |
+| name             | fedora-atomic-26-20170723.0.x86_64   |
 | os_distro        | fedora-atomic                        |
 | owner            | 2f5b83ab49d54aaea4b39f5082301d09     |
 | protected        | False                                |

--- a/xml/userguide-container_service-deploying_docker_fedora_atomic.xml
+++ b/xml/userguide-container_service-deploying_docker_fedora_atomic.xml
@@ -24,11 +24,11 @@
     <para>
      Deploying a Docker Swarm Cluster on Fedora Atomic requires the Fedora
      Atomic image
-     <emphasis role="bold">fedora-atomic-newton.qcow2</emphasis>
-     prepared specifically for the OpenStack Newton release. You can download
-     the <emphasis role="bold">fedora-atomic-newton.qcow2</emphasis>
+     <emphasis role="bold">fedora-atomic-26-20170723.0.x86_64.qcow2</emphasis>
+     prepared specifically for the OpenStack Pike release. You can download
+     the <emphasis role="bold">fedora-atomic-26-20170723.0.x86_64.qcow2</emphasis>
      image from
-     <link xlink:href="https://fedorapeople.org/groups/magnum/"/>
+     <link xlink:href="https://download.fedoraproject.org/pub/alt/atomic/stable/Fedora-Atomic-26-20170723.0/CloudImages/x86_64/"/>
     </para>
    </listitem>
   </itemizedlist>
@@ -55,17 +55,17 @@
    <listitem>
     <para>
      If you haven't already, download Fedora Atomic image, prepared for
-     Openstack Newton release.
+     Openstack Pike release.
     </para>
-<screen>$ wget https://fedorapeople.org/groups/magnum/fedora-atomic-newton.qcow2</screen>
+<screen>$ wget https://download.fedoraproject.org/pub/alt/atomic/stable/Fedora-Atomic-26-20170723.0/CloudImages/x86_64/images/Fedora-Atomic-26-20170723.0.x86_64.qcow2</screen>
    </listitem>
    <listitem>
     <para>
      Create a Glance image.
     </para>
-<screen>$ glance image-create --name fedora-atomic-newton --visibility public \
+<screen>$ glance image-create --name fedora-atomic-26-20170723.0.x86_64 --visibility public \
   --disk-format qcow2 --os-distro fedora-atomic --container-format bare \
-  --file fedora-atomic-newton.qcow2 --progress
+  --file Fedora-Atomic-26-20170723.0.x86_64.qcow2 --progress
 [=============================&gt;] 100%
 +------------------+--------------------------------------+
 | Property         | Value                                |
@@ -77,7 +77,7 @@
 | id               | 4277115a-f254-46c0-9fb0-fffc45d2fd38 |
 | min_disk         | 0                                    |
 | min_ram          | 0                                    |
-| name             | fedora-atomic-newton                 |
+| name             | fedora-atomic-26-20170723.0.x86_64                  |
 | os_distro        | fedora-atomic                        |
 | owner            | 2f5b83ab49d54aaea4b39f5082301d09     |
 | protected        | False                                |

--- a/xml/userguide-container_service-deploying_kubernetes_fedora_atomic.xml
+++ b/xml/userguide-container_service-deploying_kubernetes_fedora_atomic.xml
@@ -23,9 +23,9 @@
    <listitem>
     <para>
      Deploying a Kubernetes Cluster on Fedora Atomic requires the Fedora Atomic
-     image <emphasis role="bold">fedora-atomic-newton.qcow2</emphasis> prepared
-     specifically for the OpenStack Newton release. You can download the
-     <emphasis role="bold">fedora-atomic-newton.qcow2</emphasis>
+     image <emphasis role="bold">fedora-atomic-26-20170723.0.x86_64.qcow2</emphasis> prepared
+     specifically for the OpenStack release. You can download the
+     <emphasis role="bold">fedora-atomic-26-20170723.0.x86_64.qcow2</emphasis>
      image from
      <link xlink:href="https://fedorapeople.org/groups/magnum/"/>
     </para>
@@ -54,17 +54,17 @@
    <listitem>
     <para>
      If you haven't already, download Fedora Atomic image, prepared for the
-     Openstack Newton release.
+     Openstack Pike release.
     </para>
-<screen>$ wget https://fedorapeople.org/groups/magnum/fedora-atomic-newton.qcow2</screen>
+<screen>$ wget https://download.fedoraproject.org/pub/alt/atomic/stable/Fedora-Atomic-26-20170723.0/CloudImages/x86_64/images/Fedora-Atomic-26-20170723.0.x86_64.qcow2</screen>
    </listitem>
    <listitem>
     <para>
      Create a Glance image.
     </para>
-<screen>$ glance image-create --name fedora-atomic-newton --visibility public \
+<screen>$ glance image-create --name fedora-atomic-26-20170723.0.x86_64 --visibility public \
   --disk-format qcow2 --os-distro fedora-atomic --container-format bare \
-  --file fedora-atomic-newton.qcow2 --progress
+  --file Fedora-Atomic-26-20170723.0.x86_64.qcow2 --progress
 [=============================&gt;] 100%
 +------------------+--------------------------------------+
 | Property         | Value                                |
@@ -76,7 +76,7 @@
 | id               | 4277115a-f254-46c0-9fb0-fffc45d2fd38 |
 | min_disk         | 0                                    |
 | min_ram          | 0                                    |
-| name             | fedora-atomic-newton                 |
+| name             | fedora-atomic-26-20170723.0.x86_64                   |
 | os_distro        | fedora-atomic                        |
 | owner            | 2f5b83ab49d54aaea4b39f5082301d09     |
 | protected        | False                                |

--- a/xml/userguide-container_service-deploying_kubernetes_fedora_atomic.xml
+++ b/xml/userguide-container_service-deploying_kubernetes_fedora_atomic.xml
@@ -76,7 +76,7 @@
 | id               | 4277115a-f254-46c0-9fb0-fffc45d2fd38 |
 | min_disk         | 0                                    |
 | min_ram          | 0                                    |
-| name             | fedora-atomic-26-20170723.0.x86_64                   |
+| name             | fedora-atomic-26-20170723.0.x86_64   |
 | os_distro        | fedora-atomic                        |
 | owner            | 2f5b83ab49d54aaea4b39f5082301d09     |
 | protected        | False                                |


### PR DESCRIPTION
This checkin includes:
1. in HPE operation guide, update keystone configuration link to use git keystone sample
and removed the Newton refrence
2. in HPE user guide, updated mangnum images to use later bits close to pike release
and removed the Newton refrerence