### PR TITLE
SCRD-3598 remove reference of newton in HPE and SUSE  docs (bsc#1076233)

### DIFF
--- a/xml/book_cloud_suppl.xml
+++ b/xml/book_cloud_suppl.xml
@@ -239,20 +239,14 @@
         </para>
         <para>
          For a list of supported image types, refer to
-         <link xlink:href="http://docs.openstack.org/liberty/config-reference/content/vmware.html"/>,
+         <link xlink:href="https://docs.openstack.org/nova/pike/admin/configuration/hypervisor-vmware.html"/>,
          section <citetitle>Supported image types</citetitle>.
-         <remark>taroth 2016-12-28: @DEVs: help! could not find the same info for Newton 
-         (would have guessed it might be available in the Virtual Machine Image
-         Guide, but could not find it there)</remark>
         </para>
         <para>
          For details on how to convert a sparse image into different formats,
          refer to
-         <link xlink:href="http://docs.openstack.org/liberty/config-reference/content/vmware.html"/>,
+         <link xlink:href="https://docs.openstack.org/nova/pike/admin/configuration/hypervisor-vmware.html"/>,
          section <citetitle>Optimize images</citetitle>.
-         <remark>taroth 2016-12-28: @DEVs: help! could not find the same info for Newton 
-          (would have guessed it might be available in the Virtual Machine Image
-          Guide, but could not find it there)</remark>
         </para>
        </note>
       </listitem>
@@ -538,11 +532,9 @@
          <literal>vmware_disktype</literal> accordingly. For an overview of
          which values to use, refer to
          <link
-          xlink:href="http://docs.openstack.org/liberty/config-reference/content/vmware.html"/>,
-         <citetitle>Table 2.8. &ostack; Image Service disk type
+          xlink:href="https://docs.openstack.org/nova/pike/admin/configuration/hypervisor-vmware.html"/>,
+         <citetitle>section &ostack; Image Service disk type
          settings</citetitle>.
-         <remark>taroth 2016-12-28: DEVs, the link above needs an update for Newton - any
-         idea where to find this content nowadays?</remark>
         </para>
        </note>
       </listitem>
@@ -691,11 +683,9 @@
          <literal>vmware_disktype</literal> accordingly. For an overview of
          which values to use, refer to
          <link
-          xlink:href="http://docs.openstack.org/liberty/config-reference/content/vmware.html"/>,
-         <citetitle>Table 2.8. &ostack; Image Service disk type
+          xlink:href="https://docs.openstack.org/glance/latest/admin/useful-image-properties.html"/>,
+         <citetitle>section &ostack; Image Service disk type
          settings</citetitle>.
-         <remark>taroth 2016-12-28: @DEVs, the link above needs an update for Newton - any
-          idea where to find this content nowadays?</remark>
         </para>
        </note>
       </listitem>
@@ -706,10 +696,8 @@
    <para>
     For more information about the <systemitem>architecture</systemitem>,
     <systemitem>hypervisor_type</systemitem>, and
-    <systemitem>vm_mode</systemitem> properties, refer to
-    <link xlink:href="http://docs.openstack.org/image-guide/content/image-metadata.html"/>.
-    <remark>taroth 2016-12-28: @DEVs, the link above needs an update for Newton - any
-     idea where to find this content nowadays?</remark>
+    <systemitem>vm_mode</systemitem> properties, refer toq
+    <link xlink:href="https://docs.openstack.org/glance/latest/admin/useful-image-properties.html"/>.
    </para>
   </sect1>
   <sect1 xml:id="sec.suppl.img.custom.kernel">

--- a/xml/depl_nodes.xml
+++ b/xml/depl_nodes.xml
@@ -1039,7 +1039,7 @@ Verify return code: 18 (self signed certificate)
      <para>
       The last step is to configure client services to use SSL to access the
       RabbitMQ service. (See
-      <link xlink:href="https://docs.openstack.org/developer/oslo.messaging/newton/opts.html#oslo-messaging-rabbit"/> for a complete reference).
+      <link xlink:href="https://docs.openstack.org/oslo.messaging/pike/#oslo-messaging-rabbit"/> for a complete reference).
      </para>
     </step>
 </procedure>
@@ -2441,7 +2441,7 @@ and admins can see the available options in the barclamp -->
 
   <para>
    For information on configuring the Hitachi HUSVM back-end, refer to
-   <link xlink:href="http://docs.openstack.org/newton/config-reference/block-storage/drivers/hitachi-storage-volume-driver.html"/>.
+   <link xlink:href="http://docs.openstack.org/ocata/config-reference/block-storage/drivers/hitachi-storage-volume-driver.html"/>.
   </para>
 
   <bridgehead renderas="sect2"><guimenu>NetApp</guimenu>

--- a/xml/depl_poc.xml
+++ b/xml/depl_poc.xml
@@ -29,7 +29,7 @@
 <sect1 xml:id="sec.depl.poc.features">
   <title>&cloud; Key Features</title>
   <para>
-    The latest version 7 of &cloud; supports all OpenStack Newton release components for best-in-class capabilities to deploy an open source private cloud. Here is a brief overview of &cloud; features and functionality.
+    The latest version 8 of &cloud; supports all OpenStack Pike release components for best-in-class capabilities to deploy an open source private cloud. Here is a brief overview of &cloud; features and functionality.
   </para>
   <itemizedlist mark="bullet" spacing="normal">
     <listitem>

--- a/xml/userguide-container_service-deploying_apache_mesos_ubuntu.xml
+++ b/xml/userguide-container_service-deploying_apache_mesos_ubuntu.xml
@@ -23,7 +23,7 @@
    <listitem>
     <para>
      Deploying an Apache Mesos Cluster requires the Fedora Atomic image
-     prepared specifically for the OpenStack Newton release. You can download
+     that is compatible for the OpenStack release. You can download
      the <emphasis role="bold">ubuntu-mesos-latest.qcow2</emphasis>
      image from
      <link xlink:href="https://fedorapeople.org/groups/magnum/"/>
@@ -52,8 +52,8 @@
    </step>
    <step>
     <para>
-     If you haven't already, download Fedora Atomic image, prepared for
-     Openstack Newton release.
+     If you haven't already, download Fedora Atomic image that is compatible for the
+     OpenStack release.
     </para>
     <note>
      <para>

--- a/xml/userguide-container_service-deploying_kubernetes_coreos.xml
+++ b/xml/userguide-container_service-deploying_kubernetes_coreos.xml
@@ -50,8 +50,8 @@
    </listitem>
    <listitem>
     <para>
-     If you haven't already, download CoreOS image, prepared for Openstack
-     Newton release.
+     If you haven't already, download CoreOS image that is compatible for the OpenStack
+     release.
     </para>
     <note>
      <para>


### PR DESCRIPTION
This is part 2. This checkin includes:

1. Continue cleanuping the ref for  newton in HPE user guide.
2. Updated links to get close to pike related links and removed some
dev comments in SUSE supplement guide
3. Removed reference of newton and updated links in SUSE deployment
guide