### PR TITLE
Fix for bsc#1046336

### DIFF
--- a/xml/depl_policy_json.xml
+++ b/xml/depl_policy_json.xml
@@ -343,8 +343,11 @@
      <screen>"deactivate": "role:admin"
 "reactivate": "role:admin"</screen>
      <para>
-      These <emphasis role="bold">settings should not be changed!</emphasis>
-     </para>
+      &suse; suggests these settings should <emphasis>not</emphasis> be
+      changed. If you do change them please refer to the OSSN-0075 <link
+      xlink:href="https://wiki.openstack.org/wiki/OSSN/OSSN-0075"/> for details
+      on the exact scope of the security issue.
+      </para>
     </warning>
    </listitem>
   </itemizedlist>

--- a/xml/depl_policy_json.xml
+++ b/xml/depl_policy_json.xml
@@ -277,4 +277,76 @@
    </step>
   </procedure>
  </sect1>
+
+ <sect1 xml:id="sec.deploy.policy_json.admin">
+  <title>Pre-Installed Service Admin Role Components</title>
+  <para>
+   The following are the roles defined in &productname;. These roles serve as a
+   way to group common administrative needs at the &ostack; service
+   level. Each role represents administrative privilege into each
+   service. Multiple roles can be assigned to a user. You can assign a Service
+   Admin Role to a user once you have determined that the user is authorized to
+   perform administrative actions and access resources in that service.
+  </para>
+  <para>
+   The main components of Service Administrator Roles are:
+  </para>
+  <itemizedlist>
+   <listitem>
+    <para>
+     <literal>nova_admin</literal> role in the identity service (&o_ident;) and
+     support in <filename>nova policy.json</filename>. Assign this role to
+     users whose job function it is to perform Nova compute-related
+     administrative tasks.
+    </para>
+   </listitem>
+   <listitem>
+    <para>
+     <literal>neutron_admin</literal> role in the identity service and support
+     in <filename>neutron policy.json</filename>. Assign this role to users
+     whose job function it is to perform neutron networking-related
+     administrative tasks.
+    </para>
+   </listitem>
+   <listitem>
+    <para>
+     <literal>cinder_admin</literal> role in the identity service and support
+     in <filename>cinder policy.json</filename>. Assign this role to users
+     whose job function it is to perform Cinder storage-related administrative
+     tasks.
+    </para>
+   </listitem>
+   <listitem>
+    <para>
+     <literal>glance_admin</literal> role in the identity service and support
+     in <filename>glance policy.json</filename>. Assign this role to users
+     whose job function it is to perform Cinder storage-related administrative
+     tasks.
+    </para>
+    <warning>
+     <title>
+      Changing <filename>glance_policy.json</filename> may Introduce a
+      Security Issue
+     </title>
+     <para>
+      The OpenStack Security Note OSSN-0075 <link
+      xlink:href="https://wiki.openstack.org/wiki/OSSN/OSSN-0075"/> describes a
+      scenario where a malicious tenant is able to reuse deleted Glance image
+      IDs to share malicious images with other tenants in a manner that is
+      undetectable to the victim tenant.
+     </para>
+     <para>
+      The default policy <filename>glance_policy.json</filename> that is
+      shipped with &productname; prevents this by ensuring only admins can
+      deactivate/reactivate images:
+     </para>
+     <screen>"deactivate": "role:admin"
+"reactivate": "role:admin"</screen>
+     <para>
+      These <emphasis role="bold">settings should not be changed!</emphasis>
+     </para>
+    </warning>
+   </listitem>
+  </itemizedlist>
+ </sect1>
 </chapter>

--- a/xml/security-admin_role_segregation.xml
+++ b/xml/security-admin_role_segregation.xml
@@ -60,8 +60,33 @@
      <literal>glance_admin</literal> role in the identity service and support
      in <filename>glance policy.json</filename>
     </para>
+
+    <warning>
+     <title>
+      Changing <filename>glance_policy.json</filename> may Introduce a
+      Security Issue
+     </title>
+     <para>
+      The OpenStack Security Note OSSN-0075 <link
+      xlink:href="https://wiki.openstack.org/wiki/OSSN/OSSN-0075"/> describes a
+      scenario where a malicious tenant is able to reuse deleted Glance image
+      IDs to share malicious images with other tenants in a manner that is
+      undetectable to the victim tenant.
+     </para>
+     <para>
+      The default policy <filename>glance_policy.json</filename> that is
+      shipped with &productname; prevents this by ensuring only admins can
+      deactivate/reactivate images:
+     </para>
+     <screen>"deactivate": "role:admin"
+"reactivate": "role:admin"</screen>
+     <para>
+      These <emphasis role="bold">settings should not be changed!</emphasis>
+     </para>
+    </warning>
    </listitem>
   </itemizedlist>
+
  </section>
  <section>
   <title>Features and Benefits</title>

--- a/xml/security-admin_role_segregation.xml
+++ b/xml/security-admin_role_segregation.xml
@@ -81,7 +81,10 @@
      <screen>"deactivate": "role:admin"
 "reactivate": "role:admin"</screen>
      <para>
-      These <emphasis role="bold">settings should not be changed!</emphasis>
+      It is suggested to <emphasis>not</emphasis> change these settings. If you
+      do change them please refer to the OSSN-0075 <link
+      xlink:href="https://wiki.openstack.org/wiki/OSSN/OSSN-0075"/> for details
+      on the exact scope of the security issue.
      </para>
     </warning>
    </listitem>


### PR DESCRIPTION
CVE-2016-4383: openstack-glance: Reuse of image IDs may allow malicious users
to replace images for other users