### PR TITLE
Fix for bsc#1075104

### DIFF
--- a/xml/planning-planning-hw_support_hardwareconfig.xml
+++ b/xml/planning-planning-hw_support_hardwareconfig.xml
@@ -17,6 +17,10 @@
    <para>
     10Gb Ethernet
    </para>
+   <para>
+    QoS bandwidth limiting is only supported on Intel 82599 cards, it
+    is <emphasis>not</emphasis> supported on Mellanox Connectx-3 cards.
+   </para>
   </listitem>
   <listitem>
    <para>


### PR DESCRIPTION
QoS bandwidth limiting is not supported on the Mellanox ConnectX-3 cards