### PR TITLE
Update Monasca Transform docs bsc#1086974

### DIFF
--- a/xml/operations-monitoring-crt_change_compute_host.xml
+++ b/xml/operations-monitoring-crt_change_compute_host.xml
@@ -18,31 +18,31 @@
  <para>
   <emphasis role="bold">Steps</emphasis>
  </para>
- <orderedlist>
-  <listitem>
+ <procedure>
+  <step>
    <para>
      On the deployer: Edit ~/openstack/my_cloud/config/monasca-transform/transform_specs.json.j2
    </para>
-  </listitem>
-  <listitem>
+  </step>
+  <step>
    <para>
     Look for all references of <literal>-comp[0-9]+-</literal> and change the
     regular expression to the desired pattern say for example
     <literal>-compute[0-9]+-</literal>.
    </para>
-<screen>{"aggregation_params_map":{"aggregation_pipeline":{"source":"streaming","usage":"fetch_quantity","setters":["rollup_quantity","set_aggregated_metric_name","set_aggregated_period"],"insert":["prepare_data","insert_data_pre_hourly"]},"aggregated_metric_name":"mem.total_mb_agg","aggregation_period":"hourly","aggregation_group_by_list": ["host", "metric_id", "tenant_id"],"usage_fetch_operation": "avg","filter_by_list": [{"field_to_filter": "host","filter_expression": "-comp[0-9]+-","filter_operation": "include"}],"setter_rollup_group_by_list":[],"setter_rollup_operation": "sum","dimension_list":["aggregation_period","host","project_id"],"pre_hourly_operation":"avg","pre_hourly_group_by_list":["default"]},"metric_group":"mem_total_all","metric_id":"mem_total_all"}</screen>
+<screen>{"aggregation_params_map":{"aggregation_pipeline":{"source":"streaming", "usage":"fetch_quantity", "setters":["rollup_quantity", "set_aggregated_metric_name", "set_aggregated_period"], "insert":["prepare_data","insert_data_pre_hourly"]}, "aggregated_metric_name":"mem.total_mb_agg", "aggregation_period":"hourly", "aggregation_group_by_list": ["host", "metric_id", "tenant_id"], "usage_fetch_operation": "avg", "filter_by_list": [{"field_to_filter": "host", "filter_expression": "-comp[0-9]+-", "filter_operation": "include"}], "setter_rollup_group_by_list":[], "setter_rollup_operation": "sum", "dimension_list":["aggregation_period", "host", "project_id"], "pre_hourly_operation":"avg", "pre_hourly_group_by_list":["default"]}, "metric_group":"mem_total_all", "metric_id":"mem_total_all"}</screen>
    <para>
     to
    </para>
-<screen>{"aggregation_params_map":{"aggregation_pipeline":{"source":"streaming","usage":"fetch_quantity","setters":["rollup_quantity","set_aggregated_metric_name","set_aggregated_period"],"insert":["prepare_data","insert_data_pre_hourly"]},"aggregated_metric_name":"mem.total_mb_agg","aggregation_period":"hourly","aggregation_group_by_list": ["host", "metric_id", "tenant_id"],"usage_fetch_operation": "avg","filter_by_list": [{"field_to_filter": "host","filter_expression": "-compute[0-9]+-","filter_operation": "include"}],"setter_rollup_group_by_list":[],"setter_rollup_operation": "sum","dimension_list":["aggregation_period","host","project_id"],"pre_hourly_operation":"avg","pre_hourly_group_by_list":["default"]},"metric_group":"mem_total_all","metric_id":"mem_total_all"}</screen>
+<screen>{"aggregation_params_map":{"aggregation_pipeline":{"source":"streaming", "usage":"fetch_quantity", "setters":["rollup_quantity", "set_aggregated_metric_name", "set_aggregated_period"], "insert":["prepare_data", "insert_data_pre_hourly"]}, "aggregated_metric_name":"mem.total_mb_agg", "aggregation_period":"hourly", "aggregation_group_by_list": ["host", "metric_id", "tenant_id"],"usage_fetch_operation": "avg","filter_by_list": [{"field_to_filter": "host","filter_expression": "-compute[0-9]+-", "filter_operation": "include"}], "setter_rollup_group_by_list":[], "setter_rollup_operation": "sum", "dimension_list":["aggregation_period", "host", "project_id"], "pre_hourly_operation":"avg", "pre_hourly_group_by_list":["default"]}, "metric_group":"mem_total_all", "metric_id":"mem_total_all"}</screen>
    <note>
     <para>
      The filter_expression has been changed to the <emphasis>new</emphasis>
      pattern.
     </para>
    </note>
-  </listitem>
-  <listitem>
+  </step>
+  <step>
    <para>
     Repeat Step 2 to change all host metric transformation specs in the same
     json file.
@@ -54,8 +54,8 @@
     "disk_usable_all", "cpu_total_all", "cpu_total_host", "cpu_util_all",
     "cpu_util_host"
    </para>
-  </listitem>
-  <listitem>
+  </step>
+  <step>
    <para>
      Run Configuration Processor
    </para>
@@ -64,20 +64,20 @@ git add -A
 git commit -m "Changing Monasca Transform specs"
 cd ~/openstack/ardana/ansible
 ansible-playbook -i hosts/localhost config-processor-run.yml</screen>
-  </listitem>
-  <listitem>
+  </step>
+  <step>
    <para>
      Run Ready Deployment
    </para>
 <screen>cd ~/openstack/ardana/ansible
 ansible-playbook -i hosts/localhost ready-deployment.yml</screen>
-  </listitem>
-  <listitem>
+  </step>
+  <step>
    <para>
      Run Monasca Transform Reconfigure
    </para>
 <screen>cd ~/scratch/ansible/next/ardana/ansible
 ansible-playbook -i hosts/verb_hosts monasca-transform-reconfigure.yml</screen>
-  </listitem>
- </orderedlist>
+  </step>
+ </procedure>
 </section>

--- a/xml/operations-monitoring-crt_change_compute_host.xml
+++ b/xml/operations-monitoring-crt_change_compute_host.xml
@@ -21,20 +21,8 @@
  <orderedlist>
   <listitem>
    <para>
-    Back up the existing <filename>transform_specs.json</filename>
+     On the deployer: Edit ~/openstack/my_cloud/config/monasca-transform/transform_specs.json.j2
    </para>
-<screen>sudo cp /opt/stack/venv/monasca_transform-20161213T224923Z/lib/python2.7/site-packages/monasca_transform/data_driven_specs/transform_specs/transform_specs.json /opt/stack/venv/monasca_transform-20161213T224923Z/lib/python2.7/site-packages/monasca_transform/data_driven_specs/transform_specs/transform_specs.json.backup</screen>
-  </listitem>
-  <listitem>
-   <para>
-    Edit <filename>transform_specs.json</filename> on
-    <emphasis role="bold">all the three controller nodes.</emphasis>
-   </para>
-   <para>
-    <filename>transform_specs.json</filename> is in the directory
-    <filename>/opt/stack/venv/monasca_transform-XXXXXX/lib/python2.7/site-packages/monasca_transform/data_driven_specs/transform_specs/</filename>
-   </para>
-<screen>sudo vi /opt/stack/venv/monasca_transform-20161213T224923Z/lib/python2.7/site-packages/monasca_transform/data_driven_specs/transform_specs/transform_specs.json</screen>
   </listitem>
   <listitem>
    <para>
@@ -56,7 +44,7 @@
   </listitem>
   <listitem>
    <para>
-    Repeat step 3 to change all host metric transformation specs in the same
+    Repeat Step 2 to change all host metric transformation specs in the same
     json file.
     <!-- FIXME: <xref/> for step 3? -->
    </para>
@@ -69,24 +57,27 @@
   </listitem>
   <listitem>
    <para>
-    Repeat steps 1 to 4 on three controller nodes
-    <!-- FIXME: <xref/> for step 1 - 4? -->
+     Run Configuration Processor
    </para>
+<screen>cd ~/openstack/my_cloud/definition
+git add -A
+git commit -m "Changing Monasca Transform specs"
+cd ~/openstack/ardana/ansible
+ansible-playbook -i hosts/localhost config-processor-run.yml</screen>
   </listitem>
   <listitem>
    <para>
-    Run Monasca Transform Reconfigure
+     Run Ready Deployment
+   </para>
+<screen>cd ~/openstack/ardana/ansible
+ansible-playbook -i hosts/localhost ready-deployment.yml</screen>
+  </listitem>
+  <listitem>
+   <para>
+     Run Monasca Transform Reconfigure
    </para>
 <screen>cd ~/scratch/ansible/next/ardana/ansible
 ansible-playbook -i hosts/verb_hosts monasca-transform-reconfigure.yml</screen>
   </listitem>
  </orderedlist>
- <warning>
-  <para>
-   In &kw-hos;, transform_specs.json is not managed by
-   the &lcm; and is part of the monasca-transform code base, so if
-   an upgrade is done these changes will be wiped out and will have to be
-   re-instated by following the steps above.
-  </para>
- </warning>
 </section>


### PR DESCRIPTION
* Update the change hosts filter step to refer
  to a transform_specs.json.j2 template which
  is now managed by CLM.