### PR TITLE
Add disaster recovery testing docs (bsc#1081097)

### DIFF
--- a/xml/operations-maintenance-controller-full_recovery_test.xml
+++ b/xml/operations-maintenance-controller-full_recovery_test.xml
@@ -1,0 +1,902 @@
+<?xml version="1.0"?>
+<?xml-stylesheet href="urn:x-suse:xslt:profiling:docbook51-profile.xsl"
+ type="text/xml"
+ title="Profiling step"?>
+<!DOCTYPE section [
+ <!ENTITY % entities SYSTEM "entities.ent"> %entities;
+]>
+<section xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="full_recovery_test">
+ <title>Full Disaster Recovery Test</title>
+ <para>
+  Full Disaster Recovery Test
+ </para>
+ <section>
+   <title>Prerequisites</title>
+   <para>An &kw-hos; platform</para>
+   <para>An external server to store backups to via SSH</para>
+ </section>
+ <section>
+   <title>Goals</title>
+   <para>Here is a high level view of how we expect to test the disaster recovery of the platform.</para>
+   <orderedlist>
+     <listitem>
+       <para>Backup the control plane using Freezer to an SSH target</para>
+     </listitem>
+     <listitem>
+       <para>Backup the Cassandra Database</para>
+     </listitem>
+     <listitem>
+       <para>Re-install Controller 1 with the &kw-hos; ISO</para>
+     </listitem>
+     <listitem>
+       <para>Use Freezer to recover deployment data (model …)</para>
+     </listitem>
+     <listitem>
+       <para>Re-install &kw-hos; on Controller 1, 2, 3</para>
+     </listitem>
+     <listitem>
+       <para>Recover the backup of the MariaDB database</para>
+     </listitem>
+     <listitem>
+       <para>Recover the Cassandra Database</para>
+     </listitem>
+   </orderedlist>
+ </section>
+ <section>
+   <title>Description of the testing environment</title>
+   <para>The testing environment is very similar to the Entry Scale model.</para>
+   <para>It used 5 servers: 3 Controllers and 2 computes.</para>
+   <para>The controller node have three disks. The first one is reserved for the system, while others are used for swift.</para>
+   <note>
+     <para>During this Disaster Recovery exercise, we have saved the data on disk 2 and 3 of the swift controllers.</para>
+     <para>This allow to restore the swift objects after the recovery.</para>
+     <para>If these disks were to be wiped as well, swift data would be lost but the procedure would not change.</para>
+     <para>The only difference is that Glance images would be lost and they will have to be re-uploaded.</para>
+   </note>
+ </section>
+ <section>
+   <title>Disaster recovery test note</title>
+   <para>If it is not specified otherwise, all the commands should be executed on controller 1, which is also the deployer node.</para>
+ </section>
+ <section>
+   <title>Pre-Disaster testing</title>
+   <para>In order to validate the procedure after recovery, we need to create some workloads.</para>
+   <orderedlist>
+     <listitem>
+       <para>
+         Source the service credential file
+       </para>
+<screen>&prompt.ardana;source ~/service.osrc</screen>
+     </listitem>
+     <listitem>
+       <para>
+         Copy an image to the platform and create a Glance image with it.
+         In this example, Cirros is used
+       </para>
+<screen>&prompt.ardana;openstack image create --disk-format raw --container-format bare --public --file ~/cirros-0.3.5-x86_64-disk.img cirros</screen>
+     </listitem>
+     <listitem>
+       <para>Create a network</para>
+       <screen>&prompt.ardana;openstack network create test_net</screen>
+     </listitem>
+     <listitem>
+       <para>Create a subnet</para>
+<screen>&prompt.ardana;neutron subnet-create 07c35d11-13f9-41d4-8289-fa92147b1d44 192.168.42.0/24 --name test_subnet</screen>
+     </listitem>
+     <listitem>
+       <para>Create some instances</para>
+       <screen>&prompt.ardana;openstack server create server_1 --image 411a0363-7f4b-4bbc-889c-b9614e2da52e --flavor m1.small --nic net-id=07c35d11-13f9-41d4-8289-fa92147b1d44
+&prompt.ardana;openstack server create server_2 --image 411a0363-7f4b-4bbc-889c-b9614e2da52e --flavor m1.small --nic net-id=07c35d11-13f9-41d4-8289-fa92147b1d44
+&prompt.ardana;openstack server create server_3 --image 411a0363-7f4b-4bbc-889c-b9614e2da52e --flavor m1.small --nic net-id=07c35d11-13f9-41d4-8289-fa92147b1d44
+&prompt.ardana;openstack server create server_4 --image 411a0363-7f4b-4bbc-889c-b9614e2da52e --flavor m1.small --nic net-id=07c35d11-13f9-41d4-8289-fa92147b1d44
+&prompt.ardana;openstack server create server_5 --image 411a0363-7f4b-4bbc-889c-b9614e2da52e --flavor m1.small --nic net-id=07c35d11-13f9-41d4-8289-fa92147b1d44
+&prompt.ardana;openstack server list</screen>
+     </listitem>
+     <listitem>
+       <para>Create containers and objects</para>
+<screen>&prompt.ardana;swift upload container_1 ~/service.osrc
+var/lib/ardana/service.osrc
+
+&prompt.ardana;swift upload container_1 ~/backup.osrc
+swift upload container_1 ~/backup.osrc
+
+&prompt.ardana;swift list container_1
+var/lib/ardana/backup.osrc
+var/lib/ardana/service.osrc</screen>
+     </listitem>
+   </orderedlist>
+ </section>
+ <section>
+   <title>Preparation of the backup server</title>
+   <para>Preparation of the backup server</para>
+   <section> 
+     <title>Preparation to store Freezer backups</title>
+     <para>In this example, we want to store the backups on the server 192.168.69.132</para>
+     <para>Freezer will connect with the user backupuser on port 22 and store the backups in the the /mnt/backups/ directory.</para>
+     <orderedlist>
+     <listitem>
+       <para>Connect to the backup server</para>
+     </listitem>
+     <listitem>
+       <para>Create the user</para>
+<screen>&prompt.root;useradd backupuser --create-home --home-dir /mnt/backups/</screen>
+     </listitem>
+     <listitem>
+       <para>Switch to that user</para>
+<screen>&prompt.root;su backupuser</screen>
+     </listitem>
+     <listitem>
+       <para>Create the SSH keypair</para>
+<screen><prompt>backupuser &gt; </prompt>ssh-keygen -t rsa
+> # Just leave the default for the first question and don't set any passphrase
+> Generating public/private rsa key pair.
+> Enter file in which to save the key (/mnt/backups//.ssh/id_rsa):
+> Created directory '/mnt/backups//.ssh'.
+> Enter passphrase (empty for no passphrase):
+> Enter same passphrase again:
+> Your identification has been saved in /mnt/backups//.ssh/id_rsa
+> Your public key has been saved in /mnt/backups//.ssh/id_rsa.pub
+> The key fingerprint is:
+> a9:08:ae:ee:3c:57:62:31:d2:52:77:a7:4e:37:d1:28 backupuser@padawan-ccp-c0-m1-mgmt
+> The key's randomart image is:
+> +---[RSA 2048]----+
+> |          o      |
+> |   . . E + .     |
+> |  o . . + .      |
+> | o +   o +       |
+> |  + o o S .      |
+> | . + o o         |
+> |  o + .          |
+> |.o .             |
+> |++o              |
+> +-----------------+
+</screen>
+     </listitem>
+     <listitem>
+       <para>Add the public key to the list of the keys authorized to connect to that user on this server</para>
+<screen><prompt>backupuser &gt; </prompt>cat /mnt/backups/.ssh/id_rsa.pub >> /mnt/backups/.ssh/authorized_keys</screen>
+     </listitem>
+     <listitem>
+       <para>Print the private key. This is what we will use for the backup configuration (ssh_credentials.yml file)</para>
+<screen><prompt>backupuser &gt; </prompt>cat /mnt/backups/.ssh/id_rsa
+
+> -----BEGIN RSA PRIVATE KEY-----
+> MIIEogIBAAKCAQEAvjwKu6f940IVGHpUj3ffl3eKXACgVr3L5s9UJnb15+zV3K5L
+> BZuor8MLvwtskSkgdXNrpPZhNCsWSkryJff5I335Jhr/e5o03Yy+RqIMrJAIa0X5
+> ...
+> ...
+> ...
+> iBKVKGPhOnn4ve3dDqy3q7fS5sivTqCrpaYtByJmPrcJNjb2K7VMLNvgLamK/AbL
+> qpSTZjicKZCCl+J2+8lrKAaDWqWtIjSUs29kCL78QmaPOgEvfsw=
+> -----END RSA PRIVATE KEY-----</screen>
+     </listitem>
+   </orderedlist>
+   </section>
+   <section>
+     <title>Preparation to store Cassandra backups</title>
+     <para>In this example, we want to store the backups on the server 192.168.69.132. We will store the backups in the the /mnt/backups/cassandra_backups/ directory.</para>
+     <orderedlist>
+       <listitem>
+         <para>Create a directory on the backup server to store cassandra backups</para>
+<screen><prompt>backupuser &gt; </prompt>mkdir /mnt/backups/cassandra_backups</screen>
+       </listitem>
+       <listitem>
+         <para>Copy private ssh key from backupserver to all controller nodes</para>
+<screen><prompt>backupuser &gt; </prompt>scp /mnt/backups/.ssh/id_rsa ardana@<replaceable>CONTROLLER</replaceable>:~/.ssh/id_rsa_backup
+         Password:
+         id_rsa     100% 1675     1.6KB/s   00:00</screen>
+         <para><replaceable>Replace CONTROLLER with each control node e.g. doc-cp1-c1-m1-mgmt, doc-cp1-c1-m2-mgmt etc</replaceable></para>
+       </listitem>
+       <listitem>
+         <para>Login to each controller node and copy private ssh key to the root user's .ssh directory</para>
+<screen>&prompt.sudo;cp /var/lib/ardana/.ssh/id_rsa_backup /root/.ssh/</screen>
+       </listitem>
+       <listitem>
+         <para>Verify that you can ssh to backup server as backup user using the private key</para>
+<screen>&prompt.root;ssh -i ~/.ssh/id_rsa_backup backupuser@doc-cp1-comp0001-mgmt</screen>
+       </listitem>
+     </orderedlist>
+   </section>
+ </section>
+ <section>
+   <title>Perform Backups for disaster recovery test</title>
+   <para>Perform Backups for disaster recovery</para>
+   <section>
+     <title>Execute backup of Cassandra</title>
+     <para>Execute backup of Cassandra</para>
+     <para>Create cassandra-backup-extserver.sh script on all
+     controller nodes</para>
+<screen>&prompt.root;cat &gt; ~/cassandra-backup-extserver.sh &lt;&lt; EOF
+#!/bin/sh
+
+# backup user
+BACKUP_USER=backupuser
+# backup server
+BACKUP_SERVER=192.168.69.132
+# backup directory
+BACKUP_DIR=/mnt/backups/cassandra_backups/
+
+# Setup variables
+DATA_DIR=/var/cassandra/data/data
+NODETOOL=/usr/bin/nodetool
+
+# e.g. cassandra-snp-2018-06-26-1003
+SNAPSHOT_NAME=cassandra-snp-\$(date +%F-%H%M)
+HOST_NAME=\$(/bin/hostname)_
+
+# Take a snapshot of cassandra database
+\$NODETOOL snapshot -t \$SNAPSHOT_NAME monasca
+
+# Collect a list of directories that make up the snapshot
+SNAPSHOT_DIR_LIST=\$(find \$DATA_DIR -type d -name \$SNAPSHOT_NAME)
+for d in \$SNAPSHOT_DIR_LIST
+  do
+    # copy snapshot directories to external server
+    rsync -avR -e "ssh -i /root/.ssh/id_rsa_backup" \$d \$BACKUP_USER@\$BACKUP_SERVER:\$BACKUP_DIR/\$HOST_NAME\$SNAPSHOT_NAME
+  done
+
+\$NODETOOL clearsnapshot monasca
+EOF</screen>
+<screen>&prompt.root;chmod +x ~/cassandra-backup-extserver.sh</screen>
+     <para>Execute following steps on all the controller nodes</para>
+     <note>
+       <para>/usr/local/sbin/cassandra-backup-extserver.sh should be
+       executed on all the three controller nodes at the same time
+       (within seconds of each other) for a successful backup
+       </para>
+     </note>
+     <orderedlist>
+       <listitem>
+         <para>Edit /usr/local/sbin/cassandra-backup-extserver.sh script</para>
+         <para>Set <replaceable>BACKUP_USER</replaceable>,<replaceable>BACKUP_SERVER</replaceable> to backup user (e.g. backupuser) and desired backup server (e.g. 192.168.68.132)</para>
+<screen>
+BACKUP_USER=backupuser
+BACKUP_SERVER=192.168.69.132
+BACKUP_DIR=/mnt/backups/cassandra_backups/
+</screen>
+       </listitem>
+       <listitem>
+         <para>Execute ~/cassandra-backup-extserver.sh</para>
+<screen>&prompt.root;~/cassandra-backup-extserver.sh (on all controller nodes which are also cassandra nodes)
+
+Requested creating snapshot(s) for [monasca] with snapshot name [cassandra-snp-2018-06-28-0251] and options {skipFlush=false}
+Snapshot directory: cassandra-snp-2018-06-28-0251
+sending incremental file list
+created directory /mnt/backups/cassandra_backups//doc-cp1-c1-m1-mgmt_cassandra-snp-2018-06-28-0251
+/var/
+/var/cassandra/
+/var/cassandra/data/
+/var/cassandra/data/data/
+/var/cassandra/data/data/monasca/
+
+...
+...
+...
+
+/var/cassandra/data/data/monasca/measurements-e29033d0488d11e8bdabc32666406af1/snapshots/cassandra-snp-2018-06-28-0306/mc-72-big-Summary.db
+/var/cassandra/data/data/monasca/measurements-e29033d0488d11e8bdabc32666406af1/snapshots/cassandra-snp-2018-06-28-0306/mc-72-big-TOC.txt
+/var/cassandra/data/data/monasca/measurements-e29033d0488d11e8bdabc32666406af1/snapshots/cassandra-snp-2018-06-28-0306/schema.cql
+sent 173,691 bytes  received 531 bytes  116,148.00 bytes/sec
+total size is 171,378  speedup is 0.98
+Requested clearing snapshot(s) for [monasca]
+</screen>
+       </listitem>
+       <listitem>
+         <para>Verify cassandra backup directory on backup server</para>
+<screen><prompt>backupuser &gt; </prompt>ls -alt /mnt/backups/cassandra_backups
+total 16
+drwxr-xr-x 4 backupuser users 4096 Jun 28 03:06 .
+drwxr-xr-x 3 backupuser users 4096 Jun 28 03:06 doc-cp1-c1-m2-mgmt_cassandra-snp-2018-06-28-0306
+drwxr-xr-x 3 backupuser users 4096 Jun 28 02:51 doc-cp1-c1-m1-mgmt_cassandra-snp-2018-06-28-0251
+drwxr-xr-x 8 backupuser users 4096 Jun 27 20:56 ..
+
+$backupuser@backupserver> du -shx /mnt/backups/cassandra_backups/*
+6.2G    /mnt/backups/cassandra_backups/doc-cp1-c1-m1-mgmt_cassandra-snp-2018-06-28-0251
+6.3G    /mnt/backups/cassandra_backups/doc-cp1-c1-m2-mgmt_cassandra-snp-2018-06-28-0306</screen>
+       </listitem>
+     </orderedlist>
+   </section>
+   <section>
+     <title>Execute backup of &kw-hos;</title>
+     <para>Execute backup of &kw-hos;</para>
+     <orderedlist>
+       <listitem>
+         <para>Edit the configuration file for SSH backups (be careful to format the private key as requested: pipe on the first line and two spaces indentation). The private key is the key we created on the backup server earlier.</para>
+<screen>&prompt.ardana;vi ~/openstack/my_cloud/config/freezer/ssh_credentials.yml
+
+$ cat ~/openstack/my_cloud/config/freezer/ssh_credentials.yml
+freezer_ssh_host: 192.168.69.132
+freezer_ssh_port: 22
+freezer_ssh_username: backupuser
+freezer_ssh_base_dir: /mnt/backups
+freezer_ssh_private_key: |
+  -----BEGIN RSA PRIVATE KEY-----
+  MIIEowIBAAKCAQEAyzhZ+F+sXQp70N8zCDDb6ORKAxreT/qD4zAetjOTuBoFlGb8
+  pRBY79t9vNp7qvrKaXHBfb1OkKzhqyUwEqNcC9bdngABbb8KkCq+OkfDSAZRrmja
+  wa5PzgtSaZcSJm9jQcF04Fq19mZY2BLK3OJL4qISp1DmN3ZthgJcpksYid2G3YG+
+  bY/EogrQrdgHfcyLaoEkiBWQSBTEENKTKFBB2jFQYdmif3KaeJySv9cJqihmyotB
+  s5YTdvB5Zn/fFCKG66THhKnIm19NftbJcKc+Y3Z/ZX4W9SpMSj5dL2YW0Y176mLy
+  gMLyZK9u5k+fVjYLqY7XlVAFalv9+HZsvQ3OQQIDAQABAoIBACfUkqXAsrrFrEDj
+  DlCDqwZ5gBwdrwcD9ceYjdxuPXyu9PsCOHBtxNC2N23FcMmxP+zs09y+NuDaUZzG
+  vCZbCFZ1tZgbLiyBbiOVjRVFLXw3aNkDSiT98jxTMcLqTi9kU5L2xN6YSOPTaYRo
+  IoSqge8YjwlmLMkgGBVU7y3UuCmE/Rylclb1EI9mMPElTF+87tYK9IyA2QbIJm/w
+  4aZugSZa3PwUvKGG/TCJVD+JfrZ1kCz6MFnNS1jYT/cQ6nzLsQx7UuYLgpvTMDK6
+  Fjq63TmVg9Z1urTB4dqhxzpDbTNfJrV55MuA/z9/qFHs649tFB1/hCsG3EqWcDnP
+  mcv79nECgYEA9WdOsDnnCI1bamKA0XZxovb2rpYZyRakv3GujjqDrYTI97zoG+Gh
+  gLcD1EMLnLLQWAkDTITIf8eurkVLKzhb1xlN0Z4xCLs7ukgMetlVWfNrcYEkzGa8
+  wec7n1LfHcH5BNjjancRH0Q1Xcc2K7UgGe2iw/Iw67wlJ8i5j2Wq3sUCgYEA0/6/
+  irdJzFB/9aTC8SFWbqj1DdyrpjJPm4yZeXkRAdn2GeLU2jefqPtxYwMCB1goeORc
+  gQLspQpxeDvLdiQod1Y1aTAGYOcZOyAatIlOqiI40y3Mmj8YU/KnL7NMkaYBCrJh
+  aW//xo+l20dz52pONzLFjw1tW9vhCsG1QlrCaU0CgYB03qUn4ft4JDHUAWNN3fWS
+  YcDrNkrDbIg7MD2sOIu7WFCJQyrbFGJgtUgaj295SeNU+b3bdCU0TXmQPynkRGvg
+  jYl0+bxqZxizx1pCKzytoPKbVKCcw5TDV4caglIFjvoz58KuUlQSKt6rcZMHz7Oh
+  BX4NiUrpCWo8fyh39Tgh7QKBgEUajm92Tc0XFI8LNSyK9HTACJmLLDzRu5d13nV1
+  XHDhDtLjWQUFCrt3sz9WNKwWNaMqtWisfl1SKSjLPQh2wuYbqO9v4zRlQJlAXtQo
+  yga1fxZ/oGlLVe/PcmYfKT91AHPvL8fB5XthSexPv11ZDsP5feKiutots47hE+fc
+  U/ElAoGBAItNX4jpUfnaOj0mR0L+2R2XNmC5b4PrMhH/+XRRdSr1t76+RJ23MDwf
+  SV3u3/30eS7Ch2OV9o9lr0sjMKRgBsLZcaSmKp9K0j/sotwBl0+C4nauZMUKDXqg
+  uGCyWeTQdAOD9QblzGoWy6g3ZI+XZWQIMt0pH38d/ZRbuSUk5o5v
+  -----END RSA PRIVATE KEY----- </screen>
+
+       </listitem>
+       <listitem>
+         <para>Save the modifications in the GIT repository</para>
+<screen>&prompt.ardana;cd ~/openstack/
+&prompt.ardana;git add -A
+&prompt.ardana;git commit -a -m "SSH backup configuration"
+&prompt.ardana;cd ~/openstack/ardana/ansible
+&prompt.ardana;ansible-playbook -i hosts/localhost config-processor-run.yml
+&prompt.ardana;ansible-playbook -i hosts/localhost ready-deployment.yml</screen>
+       </listitem>
+       <listitem>
+         <para>Create the Freezer jobs</para>
+<screen>&prompt.ardana;cd ~/scratch/ansible/next/ardana/ansible
+&prompt.ardana;ansible-playbook -i hosts/verb_hosts _freezer_manage_jobs.yml</screen>
+       </listitem>
+       <listitem>
+         <para>Wait until all the SSH backup jobs have finished running</para>
+         <note>
+           <para>Freezer backup jobs are scheduled at interval specified in job specification</para>
+           <para>You will have to wait for the scheduled time interval for the backup job to run</para>
+           <para>To find the interval:</para>
+<screen>&prompt.ardana;freezer job-list | grep SSH
+
+| 34c1364692f64a328c38d54b95753844 | Ardana Default: deployer backup to SSH      |         7 | success | scheduled |       |            |
+| 944154642f624bb7b9ff12c573a70577 | Ardana Default: swift backup to SSH         |         1 | success | scheduled |       |            |
+| 22c6bab7ac4d43debcd4f5a9c4c4bb19 | Ardana Default: mysql backup to SSH         |         1 | success | scheduled |       |            |
+
+&prompt.ardana;freezer job-show 944154642f624bb7b9ff12c573a70577
++-------------+---------------------------------------------------------------------------------+
+| Field       | Value                                                                           |
++-------------+---------------------------------------------------------------------------------+
+| Job ID      | 944154642f624bb7b9ff12c573a70577                                                |
+| Client ID   | ardana-qe201-cp1-c1-m1-mgmt                                                     |
+| User ID     | 33a6a77adc4b4799a79a4c3bd40f680d                                                |
+| Session ID  |                                                                                 |
+| Description | Ardana Default: swift backup to SSH                                             |
+| Actions     | [{u'action_id': u'e8373b03ca4b41fdafd83f9ba7734bfa',                            |
+|             |   u'freezer_action': {u'action': u'backup',                                     |
+|             |                       u'backup_name': u'freezer_swift_builder_dir_backup',      |
+|             |                       u'container': u'/mnt/backups/freezer_rings_backups',      |
+|             |                       u'log_config_append': u'/etc/freezer/agent-logging.conf', |
+|             |                       u'max_level': 14,                                         |
+|             |                       u'path_to_backup': u'/etc/swiftlm/',                      |
+|             |                       u'remove_older_than': 90,                                 |
+|             |                       u'snapshot': True,                                        |
+|             |                       u'ssh_host': u'192.168.69.132',                           |
+|             |                       u'ssh_key': u'/etc/freezer/ssh_key',                      |
+|             |                       u'ssh_port': u'22',                                       |
+|             |                       u'ssh_username': u'backupuser',                           |
+|             |                       u'storage': u'ssh'},                                      |
+|             |   u'max_retries': 5,                                                            |
+|             |   u'max_retries_interval': 60,                                                  |
+|             |   u'user_id': u'33a6a77adc4b4799a79a4c3bd40f680d'}]                             |
+| Start Date  |                                                                                 |
+| End Date    |                                                                                 |
+| Interval    | 24 hours                                                                        |
++-------------+---------------------------------------------------------------------------------+</screen>
+<para>Swift SSH backup job has Interval of 24 hours, so the next backup would run after 24 hours.</para>
+<para>In the default installation Interval for various backup jobs are:</para>
+<table xml:id="FreezerBackupJobScheduleTable" colsep="1" rowsep="1">
+  <title>Default Interval for Freezer backup jobs</title>
+  <tgroup cols="4">
+   <colspec colname="c1" colnum="1" colwidth="1.0*"/>
+   <colspec colname="c2" colnum="2" colwidth="1.0*"/>
+   <colspec colname="c3" colnum="3" colwidth="1.0*"/>
+   <colspec colname="c4" colnum="4" colwidth="1.0*"/>
+   <thead>
+    <row>
+     <entry>Job Name</entry>
+     <entry>Interval</entry>
+    </row>
+   </thead>
+   <tbody>
+     <row>
+       <entry>Ardana Default: deployer backup to SSH</entry>
+       <entry>48 hours</entry>
+     </row>
+     <row>
+       <entry>Ardana Default: mysql backup to SSH</entry>
+       <entry>12 hours</entry>
+     </row>
+     <row>
+       <entry>Ardana Default: swift backup to SSH</entry>
+       <entry>24 hours</entry>
+     </row>
+   </tbody>
+  </tgroup>
+</table>
+<para>You will have to wait for as long as 48 hours for all the backup jobs to run</para>
+</note>
+</listitem>
+<listitem>
+  <para>On the backup server, you can verify that the backup files are present</para>
+<screen><prompt>backupuser &gt; </prompt>ls -lah  /mnt/backups/
+total 16
+drwxr-xr-x 2 backupuser users 4096 Jun 27  2017 bin
+drwxr-xr-x 2 backupuser users 4096 Jun 29 14:04 freezer_database_backups
+drwxr-xr-x 2 backupuser users 4096 Jun 29 14:05 freezer_lifecycle_manager_backups
+drwxr-xr-x 2 backupuser users 4096 Jun 29 14:05 freezer_rings_backups
+</screen>
+<screen><prompt>backupuser &gt; </prompt>du -shx *
+4.0K    bin
+509M    freezer_audit_logs_backups
+2.8G    freezer_database_backups
+24G     freezer_lifecycle_manager_backups
+160K    freezer_rings_backups</screen>
+       </listitem>
+     </orderedlist>
+   </section>
+ </section>
+ <section>
+   <title>Restore of the first controller</title>
+   <para>Restore of the first controller</para>
+   <orderedlist>
+       <listitem>
+         <para>Edit the SSH backup configuration (re-enter the same information as earlier)</para>
+<screen>&prompt.ardana;vi ~/openstack/my_cloud/config/freezer/ssh_credentials.yml</screen>
+       </listitem>
+       <listitem>
+         <para>Execute the restore helper. When prompted, enter the hostname the the first controller had. In this example: doc-cp1-c1-m1-mgmt</para>
+<screen>&prompt.ardana;cd ~/openstack/ardana/ansible
+&prompt.ardana;ansible-playbook -i hosts/localhost _deployer_restore_helper.yml</screen>
+       </listitem>
+       <listitem>
+         <para>Execute the restore. When prompted, leave the first value empty (none) and validate the restore by typing 'yes'.</para>
+<screen>&prompt.ardana;sudo su
+cd /root/deployer_restore_helper/
+./deployer_restore_script.sh</screen>
+       </listitem>
+       <listitem>
+         <para>Create a restore file for Swift rings</para>
+<screen>&prompt.ardana;nano swift_rings_restore.ini
+&prompt.ardana;cat swift_rings_restore.ini</screen>
+<para>Help:</para>
+<screen>[default]
+action = restore
+storage = ssh
+# backup server ip
+ssh_host = <replaceable>192.168.69.132</replaceable>
+# username to connect to the backup server
+ssh_username = <replaceable>backupuser</replaceable>
+ssh_key = /etc/freezer/ssh_key
+# base directory for backups on the backup server 
+container = <replaceable>/mnt/backups/freezer_ring_backups</replaceable>
+backup_name = freezer_swift_builder_dir_backup
+restore_abs_path = /etc/swiftlm
+log_file = /var/log/freezer-agent/freezer-agent.log
+# hostname that the controller
+hostname = <replaceable>doc-cp1-c1-m1-mgmt</replaceable>
+overwrite = True</screen>
+       </listitem>
+       <listitem>
+         <para>Execute the restore of the swift rings</para>
+<screen>&prompt.ardana;freezer-agent --config ./swift_rings_restore.ini</screen>
+       </listitem>
+     </orderedlist>
+   </section>
+   <section>
+     <title>Re-deployment of controllers 1, 2 and 3</title>
+     <para>Re-deployment of controllers 1, 2 and 3</para>
+     <orderedlist>
+       <listitem>
+         <para>Change back to the default ardana user</para>
+       </listitem>
+       <listitem>
+         <para>Deactivate the freezer backup jobs (otherwise empty backups would be added on top of the current good backups)</para>
+<screen>&prompt.ardana;nano ~/openstack/my_cloud/config/freezer/activate_jobs.yml
+&prompt.ardana;cat ~/openstack/my_cloud/config/freezer/activate_jobs.yml
+
+# If set to false, We wont create backups jobs.
+freezer_create_backup_jobs: false
+
+# If set to false, We wont create restore jobs.
+freezer_create_restore_jobs: true</screen>
+       </listitem>
+       <listitem>
+         <para>Save the modification in the GIT repository</para>
+<screen>&prompt.ardana;cd ~/openstack/
+&prompt.ardana;git add -A
+&prompt.ardana;git commit -a -m "De-Activate SSH backup jobs during re-deployment"
+&prompt.ardana;ansible-playbook -i hosts/localhost config-processor-run.yml
+&prompt.ardana;ansible-playbook -i hosts/localhost ready-deployment.yml</screen>
+       </listitem>
+       <listitem>
+         <para>Run the cobbler-deploy.yml playbook</para>
+<screen>&prompt.ardana;~/openstack/ardana/ansible
+&prompt.ardana;ansible-playbook -i hosts/localhost cobbler-deploy.xml</screen>
+       </listitem>
+       <listitem>
+         <para>Run the bm-reimage.yml playbook limited to the second and third controller</para>
+<screen>&prompt.ardana;ansible-playbook -i hosts/localhost bm-reimage.yml -e nodelist=controller2,controller3</screen>
+         <para>controller2 and controller3 names can vary. You can use the bm-power-status.yml playbook in order to check the cobbler names of these nodes.</para>
+       </listitem>
+       <listitem>
+         <para>Run the site.yml playbook limited to the three controllers and localhost. In this example, this means: doc-cp1-c1-m1-mgmt, doc-cp1-c1-m2-mgmt, doc-cp1-c1-m3-mgmt and localhost</para>
+<screen>&prompt.ardana;cd ~/scratch/ansible/next/ardana/ansible
+ansible-playbook -i hosts/verb_hosts site.yml --limit doc-cp1-c1-m1-mgmt,doc-cp1-c1-m2-mgmt,doc-cp1-c1-m3-mgmt,localhost</screen>
+       </listitem>
+     </orderedlist>
+   </section>
+   <section>
+     <title>Databases restore</title>
+     <para>Databases restore</para>
+     <section>
+       <title>MariaDB database restore</title>
+       <para>MariaDB database restore</para>
+       <orderedlist>
+         <listitem>
+           <para>Source the backup credentials file</para>
+<screen>&prompt.ardana;source ~/backup.osrc</screen>
+         </listitem>
+         <listitem>
+           <para>List Freezer jobs</para>
+           <para>Gather the id of the job corresponding the the first controller and with the description. For example:</para>
+           <screen>&prompt.ardana;freezer job-list | grep "mysql restore from SSH"
++----------------------------------+---------------------------------------------+-----------+---------+-----------+-------+------------+
+| Job ID                           | Description                                 | # Actions | Result  | Status    | Event | Session ID |
++----------------------------------+---------------------------------------------+-----------+---------+-----------+-------+------------+
+| 64715c6ce8ed40e1b346136083923260 | Ardana Default: mysql restore from SSH      |         1 |         | stop      |       |            |
+
+&prompt.ardana;freezer job-show 64715c6ce8ed40e1b346136083923260
++-------------+---------------------------------------------------------------------------------+
+| Field       | Value                                                                           |
++-------------+---------------------------------------------------------------------------------+
+| Job ID      | 64715c6ce8ed40e1b346136083923260                                                |
+| Client ID   | doc-cp1-c1-m1-mgmt                                                     |
+| User ID     | 33a6a77adc4b4799a79a4c3bd40f680d                                                |
+| Session ID  |                                                                                 |
+| Description | Ardana Default: mysql restore from SSH                                          |
+| Actions     | [{u'action_id': u'19dfb0b1851e41c682716ecc6990b25b',                            |
+|             |   u'freezer_action': {u'action': u'restore',                                    |
+|             |                       u'backup_name': u'freezer_mysql_backup',                  |
+|             |                       u'container': u'/mnt/backups/freezer_database_backups',   |
+|             |                       u'hostname': u'doc-cp1-c1-m1-mgmt',              |
+|             |                       u'log_config_append': u'/etc/freezer/agent-logging.conf', |
+|             |                       u'restore_abs_path': u'/tmp/mysql_restore/',              |
+|             |                       u'ssh_host': u'192.168.69.132',                           |
+|             |                       u'ssh_key': u'/etc/freezer/ssh_key',                      |
+|             |                       u'ssh_port': u'22',                                       |
+|             |                       u'ssh_username': u'backupuser',                           |
+|             |                       u'storage': u'ssh'},                                      |
+|             |   u'max_retries': 5,                                                            |
+|             |   u'max_retries_interval': 60,                                                  |
+|             |   u'user_id': u'33a6a77adc4b4799a79a4c3bd40f680d'}]                             |
+| Start Date  |                                                                                 |
+| End Date    |                                                                                 |
+| Interval    |                                                                                 |
++-------------+---------------------------------------------------------------------------------+</screen>
+         </listitem>
+         <listitem>
+           <para>Start the job using its id</para>
+<screen>&prompt.ardana;freezer job-start 64715c6ce8ed40e1b346136083923260
+Start request sent for job 64715c6ce8ed40e1b346136083923260</screen>
+         </listitem>
+         <listitem>
+           <para>Wait for the job result to be success</para>
+<screen>&prompt.ardana;freezer job-list | grep "mysql restore from SSH"
++----------------------------------+---------------------------------------------+-----------+---------+-----------+-------+------------+
+| Job ID                           | Description                                 | # Actions | Result  | Status    | Event | Session ID |
++----------------------------------+---------------------------------------------+-----------+---------+-----------+-------+------------+
+| 64715c6ce8ed40e1b346136083923260 | Ardana Default: mysql restore from SSH      |         1 |         | running      |       |            |</screen>
+
+<screen>&prompt.ardana;freezer job-list | grep "mysql restore from SSH"
++----------------------------------+---------------------------------------------+-----------+---------+-----------+-------+------------+
+| Job ID                           | Description                                 | # Actions | Result  | Status    | Event | Session ID |
++----------------------------------+---------------------------------------------+-----------+---------+-----------+-------+------------+
+| 64715c6ce8ed40e1b346136083923260 | Ardana Default: mysql restore from SSH      |         1 | success | completed |       |            |</screen>
+       </listitem>
+       <listitem>
+         <para>Verify that the files have been restored on the controller</para>
+<screen>&prompt.ardana;sudo du -shx /tmp/mysql_restore/*
+
+16K     /tmp/mysql_restore/aria_log.00000001
+4.0K    /tmp/mysql_restore/aria_log_control
+3.4M    /tmp/mysql_restore/barbican
+8.0K    /tmp/mysql_restore/ceilometer
+4.2M    /tmp/mysql_restore/cinder
+2.9M    /tmp/mysql_restore/designate
+129M    /tmp/mysql_restore/galera.cache
+2.1M    /tmp/mysql_restore/glance
+4.0K    /tmp/mysql_restore/grastate.dat
+4.0K    /tmp/mysql_restore/gvwstate.dat
+2.6M    /tmp/mysql_restore/heat
+752K    /tmp/mysql_restore/horizon
+4.0K    /tmp/mysql_restore/ib_buffer_pool
+76M     /tmp/mysql_restore/ibdata1
+128M    /tmp/mysql_restore/ib_logfile0
+128M    /tmp/mysql_restore/ib_logfile1
+12M     /tmp/mysql_restore/ibtmp1
+16K     /tmp/mysql_restore/innobackup.backup.log
+313M    /tmp/mysql_restore/keystone
+716K    /tmp/mysql_restore/magnum
+12M     /tmp/mysql_restore/mon
+8.3M    /tmp/mysql_restore/monasca_transform
+0       /tmp/mysql_restore/multi-master.info
+11M     /tmp/mysql_restore/mysql
+4.0K    /tmp/mysql_restore/mysql_upgrade_info
+14M     /tmp/mysql_restore/nova
+4.4M    /tmp/mysql_restore/nova_api
+14M     /tmp/mysql_restore/nova_cell0
+3.6M    /tmp/mysql_restore/octavia
+208K    /tmp/mysql_restore/opsconsole
+38M     /tmp/mysql_restore/ovs_neutron
+8.0K    /tmp/mysql_restore/performance_schema
+24K     /tmp/mysql_restore/tc.log
+4.0K    /tmp/mysql_restore/test
+8.0K    /tmp/mysql_restore/winchester
+4.0K    /tmp/mysql_restore/xtrabackup_galera_info</screen>
+       </listitem>
+       <listitem>
+         <para>Stop &kw-hos; services on the three controllers (replace the hostnames of the controllers in the command)</para>
+<screen>&prompt.ardana;cd ~/scratch/ansible/next/ardana/ansible
+&prompt.ardana;ansible-playbook -i hosts/verb_hosts ardana-stop.yml --limit doc-cp1-c1-m1-mgmt,doc-cp1-c1-m2-mgmt,doc-cp1-c1-m3-mgmt,localhost</screen>
+       </listitem>
+       <listitem>
+         <para>Clean the mysql directory and copy the restored backup</para>
+<screen>&prompt.root;cd /var/lib/mysql/
+&prompt.root;rm -rf ./*
+&prompt.root;cp -pr /tmp/mysql_restore/* ./</screen>
+<para>Switch back to the ardana user once the copy is finished</para>
+       </listitem>
+       </orderedlist>
+     </section>
+     <section>
+       <title>Cassandra database restore</title>
+       <para>Cassandra database restore</para>
+       <para>Create a script cassandra-restore-extserver.sh on all
+       controller nodes</para>
+<screen>&prompt.root;cat &gt; ~/cassandra-restore-extserver.sh &lt;&lt; EOF
+#!/bin/sh
+
+# backup user
+BACKUP_USER=backupuser
+# backup server
+BACKUP_SERVER=192.168.69.132
+# backup directory
+BACKUP_DIR=/mnt/backups/cassandra_backups/
+
+# Setup variables
+DATA_DIR=/var/cassandra/data/data
+NODETOOL=/usr/bin/nodetool
+
+HOST_NAME=\$(/bin/hostname)_
+
+#Get snapshot name from command line.
+if [ -z "\$*"  ]
+then
+  echo "usage \$0 &lt;snapshot to restore&gt;"
+  exit 1
+fi
+SNAPSHOT_NAME=\$1
+
+# restore
+rsync -av -e "ssh -i /root/.ssh/id_rsa_backup" \$BACKUP_USER@\$BACKUP_SERVER:\$BACKUP_DIR/\$HOST_NAME\$SNAPSHOT_NAME/ /
+
+# set ownership of newley restored files
+chown -R cassandra:cassandra \$DATA_DIR/monasca/*
+
+# Get a list of snapshot directories that have files to be restored.
+RESTORE_LIST=\$(find \$DATA_DIR -type d -name \$SNAPSHOT_NAME)
+
+# use RESTORE_LIST to move snapshot files back into place of database.
+for d in \$RESTORE_LIST
+do
+  cd \$d
+  mv * ../..
+  KEYSPACE=\$(pwd | rev | cut -d '/' -f4 | rev)
+  TABLE_NAME=\$(pwd | rev | cut -d '/' -f3 |rev | cut -d '-' -f1)
+  \$NODETOOL refresh \$KEYSPACE \$TABLE_NAME
+done
+cd
+# Cleanup snapshot directories
+\$NODETOOL clearsnapshot \$KEYSPACE
+EOF</screen>
+<screen>&prompt.root;chmod +x ~/cassandra-restore-extserver.sh</screen>
+          <para>Execute following steps on all the controller nodes</para>
+          <orderedlist>
+            <listitem>
+              <para>Edit ~/cassandra-restore-extserver.sh script</para>
+              <para>Set <replaceable>BACKUP_USER</replaceable>,<replaceable>BACKUP_SERVER</replaceable> to backup user (e.g. backupuser) and desired backup server (e.g. 192.168.68.132)</para>
+<screen>
+BACKUP_USER=backupuser
+BACKUP_SERVER=192.168.69.132
+BACKUP_DIR=/mnt/backups/cassandra_backups/</screen>
+            </listitem>
+            <listitem>
+              <para>Execute ~/cassandra-restore-extserver.sh <replaceable>SNAPSHOT_NAME</replaceable></para>
+              <para>You will have to find out <replaceable>SNAPSHOT_NAME</replaceable> from listing of /mnt/backups/cassandra_backups.
+              All the directories are of format <replaceable>HOST</replaceable>_<replaceable>SNAPSHOT_NAME</replaceable></para>
+<screen>ls -alt /mnt/backups/cassandra_backups
+total 16
+drwxr-xr-x 4 backupuser users 4096 Jun 28 03:06 .
+drwxr-xr-x 3 backupuser users 4096 Jun 28 03:06 doc-cp1-c1-m2-mgmt_cassandra-snp-2018-06-28-0306</screen>
+<screen>&prompt.root;~/cassandra-restore-extserver.sh cassandra-snp-2018-06-28-0306
+
+receiving incremental file list
+./
+var/
+var/cassandra/
+var/cassandra/data/
+var/cassandra/data/data/
+var/cassandra/data/data/monasca/
+var/cassandra/data/data/monasca/alarm_state_history-e6bbdc20488d11e8bdabc32666406af1/
+var/cassandra/data/data/monasca/alarm_state_history-e6bbdc20488d11e8bdabc32666406af1/snapshots/
+var/cassandra/data/data/monasca/alarm_state_history-e6bbdc20488d11e8bdabc32666406af1/snapshots/cassandra-snp-2018-06-28-0306/
+var/cassandra/data/data/monasca/alarm_state_history-e6bbdc20488d11e8bdabc32666406af1/snapshots/cassandra-snp-2018-06-28-0306/manifest.json
+var/cassandra/data/data/monasca/alarm_state_history-e6bbdc20488d11e8bdabc32666406af1/snapshots/cassandra-snp-2018-06-28-0306/mc-37-big-CompressionInfo.db
+var/cassandra/data/data/monasca/alarm_state_history-e6bbdc20488d11e8bdabc32666406af1/snapshots/cassandra-snp-2018-06-28-0306/mc-37-big-Data.db
+...
+...
+...
+/usr/bin/nodetool clearsnapshot monasca</screen>
+            </listitem>
+          </orderedlist>
+     </section>
+    <section>
+       <title>Restart &kw-hos; services</title>
+       <para>Restart &kw-hos; services</para>
+       <orderedlist>
+         <listitem>
+           <para>Restart the MariaDB Database</para>
+<screen>&prompt.ardana;cd ~/scratch/ansible/next/ardana/ansible
+&prompt.ardana;ansible-playbook -i hosts/verb_hosts percona-bootstrap.yml
+&prompt.ardana;ansible-playbook -i hosts/verb_hosts percona-start.yml
+</screen>
+
+         </listitem>
+         <listitem>
+           <para>Restart &kw-hos; services limited to the three controllers (replace the hostnames of the controllers in the command)</para>
+<screen>ansible-playbook -i hosts/verb_hosts ardana-start.yml --limit doc-cp1-c1-m1-mgmt,doc-cp1-c1-m2-mgmt,doc-cp1-c1-m3-mgmt,localhost</screen>
+         </listitem>
+         <listitem>
+           <para>Re-configure &kw-hos;</para>
+<screen>ansible-playbook -i hosts/verb_hosts ardana-reconfigure.yml</screen>
+         </listitem>
+       </orderedlist>
+    </section>
+    <section>
+      <title>Re-enable SSH backups</title>
+      <para>Re-enable SSH backups</para>
+      <orderedlist>
+        <listitem>
+          <para>Re-activate Freezer backup jobs</para>
+<screen>&prompt.ardana;vi ~/openstack/my_cloud/config/freezer/activate_jobs.yml
+&prompt.ardana;cat ~/openstack/my_cloud/config/freezer/activate_jobs.yml
+
+# If set to false, We wont create backups jobs.
+freezer_create_backup_jobs: true
+
+# If set to false, We wont create restore jobs.
+freezer_create_restore_jobs: true</screen>
+        </listitem>
+        <listitem>
+          <para>Save the modifications in the GIT repository</para>
+<screen>cd ~/openstack/ardana/ansible/
+git add -A
+git commit -a -m “Re-Activate SSH backup jobs”
+ansible-playbook -i hosts/localhost config-processor-run.yml
+ansible-playbook -i hosts/localhost ready-deployment.yml</screen>
+        </listitem>
+        <listitem>
+          <para>Create Freezer jobs</para>
+<screen>cd ~/scratch/ansible/next/hos/ansible
+ansible-playbook -i hosts/verb_hosts _freezer_manage_jobs.yml</screen>
+        </listitem>
+      </orderedlist>
+   </section>
+ </section>
+ <section>
+   <title>Post restore testing</title>
+     <para>Post restore testing</para>
+     <orderedlist>
+       <listitem>
+         <para>Source the service credential file</para>
+<screen>&prompt.ardana;source ~/service.osrc</screen>
+       </listitem>
+       <listitem>
+         <para>Swift</para>
+<screen>&prompt.ardana;swift list
+container_1
+volumebackups
+
+&prompt.ardana;swift list container_1
+var/lib/ardana/backup.osrc
+var/lib/ardana/service.osrc
+
+&prompt.ardana;swift download container_1 /tmp/backup.osrc</screen>
+       </listitem>
+       <listitem>
+         <para>Neutron</para>
+<screen>&prompt.ardana;openstack network list
++--------------------------------------+---------------------+--------------------------------------+
+| ID                                   | Name                | Subnets                              |
++--------------------------------------+---------------------+--------------------------------------+
+| 07c35d11-13f9-41d4-8289-fa92147b1d44 | test-net             | 02d5ca3b-1133-4a74-a9ab-1f1dc2853ec8|
++--------------------------------------+---------------------+--------------------------------------+</screen>
+       </listitem>
+       <listitem>
+         <para>Glance</para>
+<screen>&prompt.ardana;openstack image list
++--------------------------------------+----------------------+--------+
+| ID                                   | Name                 | Status |
++--------------------------------------+----------------------+--------+
+| 411a0363-7f4b-4bbc-889c-b9614e2da52e | cirros-0.4.0-x86_64  | active |
++--------------------------------------+----------------------+--------+
+&prompt.ardana;openstack image save --file /tmp/cirros f751c39b-f1e3-4f02-8332-3886826889ba
+&prompt.ardana;ls -lah /tmp/cirros
+-rw-r--r-- 1 ardana ardana 12716032 Jul  2 20:52 /tmp/cirros</screen>
+       </listitem>
+       <listitem>
+         <para>Nova</para>
+<screen>&prompt.ardana;openstack server list
+
+&prompt.ardana;openstack server list
+
+&prompt.ardana;openstack server create server_6 --image 411a0363-7f4b-4bbc-889c-b9614e2da52e  --flavor m1.small --nic net-id=07c35d11-13f9-41d4-8289-fa92147b1d44
++-------------------------------------+------------------------------------------------------------+
+| Field                               | Value                                                      |
++-------------------------------------+------------------------------------------------------------+
+| OS-DCF:diskConfig                   | MANUAL                                                     |
+| OS-EXT-AZ:availability_zone         |                                                            |
+| OS-EXT-SRV-ATTR:host                | None                                                       |
+| OS-EXT-SRV-ATTR:hypervisor_hostname | None                                                       |
+| OS-EXT-SRV-ATTR:instance_name       |                                                            |
+| OS-EXT-STS:power_state              | NOSTATE                                                    |
+| OS-EXT-STS:task_state               | scheduling                                                 |
+| OS-EXT-STS:vm_state                 | building                                                   |
+| OS-SRV-USG:launched_at              | None                                                       |
+| OS-SRV-USG:terminated_at            | None                                                       |
+| accessIPv4                          |                                                            |
+| accessIPv6                          |                                                            |
+| addresses                           |                                                            |
+| adminPass                           | iJBoBaj53oUd                                               |
+| config_drive                        |                                                            |
+| created                             | 2018-07-02T21:02:01Z                                       |
+| flavor                              | m1.small (2)                                               |
+| hostId                              |                                                            |
+| id                                  | ce7689ff-23bf-4fe9-b2a9-922d4aa9412c                       |
+| image                               | cirros-0.4.0-x86_64 (f751c39b-f1e3-4f02-8332-3886826889ba) |
+| key_name                            | None                                                       |
+| name                                | server_6                                                   |
+| progress                            | 0                                                          |
+| project_id                          | cca416004124432592b2949a5c5d9949                           |
+| properties                          |                                                            |
+| security_groups                     | name='default'                                             |
+| status                              | BUILD                                                      |
+| updated                             | 2018-07-02T21:02:01Z                                       |
+| user_id                             | 8cb1168776d24390b44c3aaa0720b532                           |
+| volumes_attached                    |                                                            |
++-------------------------------------+------------------------------------------------------------+
+
+&prompt.ardana;openstack server list
++--------------------------------------+----------+--------+---------------------------------+---------------------+-----------+
+| ID                                   | Name     | Status | Networks                        | Image               | Flavor    |
++--------------------------------------+----------+--------+---------------------------------+---------------------+-----------+
+| ce7689ff-23bf-4fe9-b2a9-922d4aa9412c | server_6 | ACTIVE | n1=1.1.1.8                      | cirros-0.4.0-x86_64 | m1.small  |
+
+&prompt.ardana;openstack server delete ce7689ff-23bf-4fe9-b2a9-922d4aa9412c</screen>
+       </listitem>
+     </orderedlist>
+ </section>
+</section>

--- a/xml/operations-maintenance-whole_unplanned.xml
+++ b/xml/operations-maintenance-whole_unplanned.xml
@@ -11,4 +11,5 @@
   Unplanned maintenance procedures for your whole cloud.
  </para>
  <xi:include href="operations-maintenance-controller-full_recovery.xml"/>
+ <xi:include href="operations-maintenance-controller-full_recovery_test.xml"/>
 </section>


### PR DESCRIPTION
SCRD-3662 Added instructions for disaster recovery testing which includes:
* Setup and execute scripts to backup a cassandra snapshot backup
  to external server via SSH and to restore from that saved backup.
* Setup and execute freezer backup jobs to backup controller, swift and mysql to
  external server via SSH.
* Added a note regarding freezer backup jobs interval, they are scheduled at the interval
  specified in the job specification which can be upto 48 hours in default deployment.
* Restore controller, MySQL and Swift from saved backups using freezer
  restore jobs via SSH.
* Verify openstack services are functioning after backup and recovery test.
