### PR TITLE
Fix start database procedure in disaster recovery test (bsc#1081097)

### DIFF
--- a/xml/operations-maintenance-controller-full_recovery_test.xml
+++ b/xml/operations-maintenance-controller-full_recovery_test.xml
@@ -35,7 +35,7 @@
        <para>Re-install &kw-hos; on Controller 1, 2, 3</para>
      </listitem>
      <listitem>
-       <para>Recover the backup of the MariaDB database</para>
+       <para>Recover the backup of the &mariadb; database</para>
      </listitem>
      <listitem>
        <para>Recover the Cassandra Database</para>
@@ -542,8 +542,8 @@ ansible-playbook -i hosts/verb_hosts site.yml --limit doc-cp1-c1-m1-mgmt,doc-cp1
      <title>Databases restore</title>
      <para>Databases restore</para>
      <section>
-       <title>MariaDB database restore</title>
-       <para>MariaDB database restore</para>
+       <title>&mariadb; database restore</title>
+       <para>&mariadb; database restore</para>
        <orderedlist>
          <listitem>
            <para>Source the backup credentials file</para>
@@ -758,12 +758,20 @@ var/cassandra/data/data/monasca/alarm_state_history-e6bbdc20488d11e8bdabc3266640
        <para>Restart &kw-hos; services</para>
        <orderedlist>
          <listitem>
-           <para>Restart the MariaDB Database</para>
+           <para>Restart the &mariadb; Database</para>
 <screen>&prompt.ardana;cd ~/scratch/ansible/next/ardana/ansible
-&prompt.ardana;ansible-playbook -i hosts/verb_hosts percona-bootstrap.yml
-&prompt.ardana;ansible-playbook -i hosts/verb_hosts percona-start.yml
-</screen>
-
+&prompt.ardana;ansible-playbook -i hosts/verb_hosts galera-bootstrap.yml</screen>
+           <para>
+             On the deployer node, execute the
+             <filename>galera-bootstrap.yml</filename> playbook which will
+             automatically determine the log sequence number, bootstrap the main node,
+             and start the database cluster.
+           </para>
+           <para>
+             If this process fails to recover the database cluster, please refer to
+             <xref linkend="mysql"/>. There Scenario 3: Recovering the database manually covers the process
+             of manually starting the database
+           </para>
          </listitem>
          <listitem>
            <para>Restart &kw-hos; services limited to the three controllers (replace the hostnames of the controllers in the command)</para>

--- a/xml/operations-maintenance-controller-full_recovery_test.xml
+++ b/xml/operations-maintenance-controller-full_recovery_test.xml
@@ -769,13 +769,17 @@ var/cassandra/data/data/monasca/alarm_state_history-e6bbdc20488d11e8bdabc3266640
            </para>
            <para>
              If this process fails to recover the database cluster, please refer to
-             <xref linkend="mysql"/>. There Scenario 3: Recovering the database manually covers the process
-             of manually starting the database
+             <xref linkend="mysql"/>. There Scenario 3 covers the process of manually
+             starting the database.
            </para>
          </listitem>
          <listitem>
-           <para>Restart &kw-hos; services limited to the three controllers (replace the hostnames of the controllers in the command)</para>
-<screen>ansible-playbook -i hosts/verb_hosts ardana-start.yml --limit doc-cp1-c1-m1-mgmt,doc-cp1-c1-m2-mgmt,doc-cp1-c1-m3-mgmt,localhost</screen>
+           <para>
+            Restart &kw-hos; services limited to the three controllers (replace the
+            the hostnames of the controllers in the command).
+          </para>
+<screen>ansible-playbook -i hosts/verb_hosts ardana-start.yml \
+ --limit doc-cp1-c1-m1-mgmt,doc-cp1-c1-m2-mgmt,doc-cp1-c1-m3-mgmt,localhost</screen>
          </listitem>
          <listitem>
            <para>Re-configure &kw-hos;</para>


### PR DESCRIPTION
Remove reference to percona-bootstrap playbook and replace with
galera-bootstrap.yml which also starts the db cluster.
Also added a note to  refer to section to manually start
mariadb database if the playbook fails to start db cluster.