### PR TITLE
Swift Backup/Restore: Fix swift restore paths (bsc#1099567)

### DIFF
--- a/xml/operations-maintenance-controller-pit_swiftrings_recovery.xml
+++ b/xml/operations-maintenance-controller-pit_swiftrings_recovery.xml
@@ -131,7 +131,11 @@ ardana-qe102-cp1-c1-m1 : ok=12 changed=0 unreachable=0 failed=0```</screen>
     <para>
      Copy the restored files.
     </para>
-<screen>&prompt.sudo;cp -pr /tmp/swift_builder_dir_restore/* /etc/swiftlm/builder_dir/</screen>
+<screen>&prompt.sudo;cp -pr /tmp/swift_builder_dir_restore/<replaceable>cloud-name</replaceable>/<replaceable>control-plane-name</replaceable>/builder_dir/* \
+    /etc/swiftlm/<replaceable>cloud-name</replaceable>/<replaceable>control-plane-name</replaceable>/builder_dir/</screen>
+    <para>For example</para>
+<screen>&prompt.sudo;cp -pr /tmp/swift_builder_dir_restore/entry-scale-kvm/control-plane-1/builder_dir/* \
+    /etc/swiftlm/entry-scale-kvm/control-plane-1/builder_dir/</screen>
    </step>
    <step>
     <para>

--- a/xml/operations-maintenance-controller-pit_swiftrings_recovery.xml
+++ b/xml/operations-maintenance-controller-pit_swiftrings_recovery.xml
@@ -131,8 +131,8 @@ ardana-qe102-cp1-c1-m1 : ok=12 changed=0 unreachable=0 failed=0```</screen>
     <para>
      Copy the restored files.
     </para>
-<screen>&prompt.sudo;cp -pr /tmp/swift_builder_dir_restore/<replaceable>cloud-name</replaceable>/<replaceable>control-plane-name</replaceable>/builder_dir/* \
-    /etc/swiftlm/<replaceable>cloud-name</replaceable>/<replaceable>control-plane-name</replaceable>/builder_dir/</screen>
+<screen>&prompt.sudo;cp -pr /tmp/swift_builder_dir_restore/<replaceable>CLOUD_NAME</replaceable>/<replaceable>CONTROL_PLANE_NAME</replaceable>/builder_dir/* \
+    /etc/swiftlm/<replaceable>CLOUD_NAME</replaceable>/<replaceable>CONTROL_PLANE_NAME</replaceable>/builder_dir/</screen>
     <para>For example</para>
 <screen>&prompt.sudo;cp -pr /tmp/swift_builder_dir_restore/entry-scale-kvm/control-plane-1/builder_dir/* \
     /etc/swiftlm/entry-scale-kvm/control-plane-1/builder_dir/</screen>

--- a/xml/operations-maintenance-controller-swiftrings_recovery.xml
+++ b/xml/operations-maintenance-controller-swiftrings_recovery.xml
@@ -94,10 +94,15 @@ EOF</screen>
    <listitem>
     <para>
      If the SWF-PRX[0] is already deployed, copy the contents of the restored
-     directory (<literal>/tmp/swift_builder_dir_restore/</literal>) to
-     <literal>/etc/swiftlm/builder_dir/</literal> on the SWF-PRX[0] Then from
+     directory (<literal>/tmp/swift_builder_dir_restore/<replaceable>cloud-name</replaceable>/<replaceable>control-plane-name</replaceable>/builder_dir/</literal>) to
+     <literal>/etc/swiftlm/<replaceable>cloud-name</replaceable>/<replaceable>control-plane-name</replaceable>/builder_dir/</literal> on the SWF-PRX[0] Then from
      the &lcm; run:
     </para>
+<screen>&prompt.sudo;cp -pr /tmp/swift_builder_dir_restore/<replaceable>cloud-name</replaceable>/<replaceable>control-plane-name</replaceable>/builder_dir/* \
+    /etc/swiftlm/<replaceable>cloud-name</replaceable>/<replaceable>control-plane-name</replaceable>/builder_dir/</screen>
+    <para>For example</para>
+<screen>&prompt.sudo;cp -pr /tmp/swift_builder_dir_restore/entry-scale-kvm/control-plane-1/builder_dir/* \
+    /etc/swiftlm/entry-scale-kvm/control-plane-1/builder_dir/</screen>
 <screen>cd ~/scratch/ansible/next/ardana/ansible
 ansible-playbook -i hosts/verb_hosts swift-reconfigure.yml</screen>
    </listitem>
@@ -113,11 +118,16 @@ ansible-playbook -i hosts/verb_hosts osconfig-run.yml --limit &lt;SWF-ACC[0]-hos
    <listitem>
     <para>
      Copy the contents of the restored directory
-     (<literal>/tmp/swift_builder_dir_restore/</literal>) to
-     <literal>/etc/swiftlm/builder_dir/</literal> on the SWF-ACC[0] You will
+     (<literal>/tmp/swift_builder_dir_restore/<replaceable>cloud-name</replaceable>/<replaceable>control-plane-name</replaceable>/builder_dir/</literal>) to
+     <literal>/etc/swiftlm/<replaceable>cloud-name</replaceable>/<replaceable>control-plane-name</replaceable>/builder_dir/</literal> on the SWF-ACC[0] You will
      have to create the directories :
-     <literal>/etc/swiftlm/builder_dir/</literal>
+     <literal>/etc/swiftlm/<replaceable>cloud-name</replaceable>/<replaceable>control-plane-name</replaceable>/builder_dir/</literal>
     </para>
+<screen>&prompt.sudo;cp -pr /tmp/swift_builder_dir_restore/<replaceable>cloud-name</replaceable>/<replaceable>control-plane-name</replaceable>/builder_dir/* \
+    /etc/swiftlm/<replaceable>cloud-name</replaceable>/<replaceable>control-plane-name</replaceable>/builder_dir/</screen>
+    <para>For example</para>
+<screen>&prompt.sudo;cp -pr /tmp/swift_builder_dir_restore/entry-scale-kvm/control-plane-1/builder_dir/* \
+    /etc/swiftlm/entry-scale-kvm/control-plane-1/builder_dir/</screen>
    </listitem>
    <listitem>
     <para>

--- a/xml/operations-maintenance-controller-swiftrings_recovery.xml
+++ b/xml/operations-maintenance-controller-swiftrings_recovery.xml
@@ -94,48 +94,48 @@ EOF</screen>
    <listitem>
     <para>
      If the SWF-PRX[0] is already deployed, copy the contents of the restored
-     directory (<literal>/tmp/swift_builder_dir_restore/<replaceable>cloud-name</replaceable>/<replaceable>control-plane-name</replaceable>/builder_dir/</literal>) to
-     <literal>/etc/swiftlm/<replaceable>cloud-name</replaceable>/<replaceable>control-plane-name</replaceable>/builder_dir/</literal> on the SWF-PRX[0] Then from
+     directory (<literal>/tmp/swift_builder_dir_restore/<replaceable>CLOUD_NAME</replaceable>/<replaceable>CONTROL_PLANE_NAME</replaceable>/builder_dir/</literal>) to
+     <literal>/etc/swiftlm/<replaceable>CLOUD_NAME</replaceable>/<replaceable>CONTROL_PLANE_NAME</replaceable>/builder_dir/</literal> on the SWF-PRX[0] Then from
      the &lcm; run:
     </para>
-<screen>&prompt.sudo;cp -pr /tmp/swift_builder_dir_restore/<replaceable>cloud-name</replaceable>/<replaceable>control-plane-name</replaceable>/builder_dir/* \
-    /etc/swiftlm/<replaceable>cloud-name</replaceable>/<replaceable>control-plane-name</replaceable>/builder_dir/</screen>
+<screen>&prompt.sudo;cp -pr /tmp/swift_builder_dir_restore/<replaceable>CLOUD_NAME</replaceable>/<replaceable>CONTROL_PLANE_NAME</replaceable>/builder_dir/* \
+    /etc/swiftlm/<replaceable>CLOUD_NAME</replaceable>/<replaceable>CONTROL_PLANE_NAME</replaceable>/builder_dir/</screen>
     <para>For example</para>
 <screen>&prompt.sudo;cp -pr /tmp/swift_builder_dir_restore/entry-scale-kvm/control-plane-1/builder_dir/* \
     /etc/swiftlm/entry-scale-kvm/control-plane-1/builder_dir/</screen>
-<screen>cd ~/scratch/ansible/next/ardana/ansible
-ansible-playbook -i hosts/verb_hosts swift-reconfigure.yml</screen>
+<screen>&prompt.ardana;cd ~/scratch/ansible/next/ardana/ansible
+&prompt.ardana;ansible-playbook -i hosts/verb_hosts swift-reconfigure.yml</screen>
    </listitem>
    <listitem>
     <para>
      If the SWF-ACC[0] is<emphasis role="bold"> not </emphasis>deployed, from
      the &lcm; run these playbooks:
     </para>
-<screen>cd ~/scratch/ansible/next/ardana/ansible
-ansible-playbook -i hosts/verb_hosts guard-deployment.yml
-ansible-playbook -i hosts/verb_hosts osconfig-run.yml --limit &lt;SWF-ACC[0]-hostname&gt;</screen>
+<screen>&prompt.ardana;cd ~/scratch/ansible/next/ardana/ansible
+&prompt.ardana;ansible-playbook -i hosts/verb_hosts guard-deployment.yml
+&prompt.ardana;ansible-playbook -i hosts/verb_hosts osconfig-run.yml --limit &lt;SWF-ACC[0]-hostname&gt;</screen>
    </listitem>
    <listitem>
     <para>
      Copy the contents of the restored directory
-     (<literal>/tmp/swift_builder_dir_restore/<replaceable>cloud-name</replaceable>/<replaceable>control-plane-name</replaceable>/builder_dir/</literal>) to
-     <literal>/etc/swiftlm/<replaceable>cloud-name</replaceable>/<replaceable>control-plane-name</replaceable>/builder_dir/</literal> on the SWF-ACC[0] You will
+     (<literal>/tmp/swift_builder_dir_restore/<replaceable>CLOUD_NAME</replaceable>/<replaceable>CONTROL_PLANE_NAME</replaceable>/builder_dir/</literal>) to
+     <literal>/etc/swiftlm/<replaceable>CLOUD_NAME</replaceable>/<replaceable>CONTROL_PLANE_NAME</replaceable>/builder_dir/</literal> on the SWF-ACC[0] You will
      have to create the directories :
-     <literal>/etc/swiftlm/<replaceable>cloud-name</replaceable>/<replaceable>control-plane-name</replaceable>/builder_dir/</literal>
+     <literal>/etc/swiftlm/<replaceable>CLOUD_NAME</replaceable>/<replaceable>CONTROL_PLANE_NAME</replaceable>/builder_dir/</literal>
     </para>
-<screen>&prompt.sudo;cp -pr /tmp/swift_builder_dir_restore/<replaceable>cloud-name</replaceable>/<replaceable>control-plane-name</replaceable>/builder_dir/* \
-    /etc/swiftlm/<replaceable>cloud-name</replaceable>/<replaceable>control-plane-name</replaceable>/builder_dir/</screen>
+<screen>&prompt.sudo;cp -pr /tmp/swift_builder_dir_restore/<replaceable>CLOUD_NAME</replaceable>/<replaceable>CONTROL_PLANE_NAME</replaceable>/builder_dir/* \
+    /etc/swiftlm/<replaceable>CLOUD_NAME</replaceable>/<replaceable>CONTROL_PLANE_NAME</replaceable>/builder_dir/</screen>
     <para>For example</para>
 <screen>&prompt.sudo;cp -pr /tmp/swift_builder_dir_restore/entry-scale-kvm/control-plane-1/builder_dir/* \
     /etc/swiftlm/entry-scale-kvm/control-plane-1/builder_dir/</screen>
    </listitem>
    <listitem>
     <para>
-     From the &lcm;, run the <literal>ardana-deploy.yml</literal>
+     From the &lcm;, run the <filename>ardana-deploy.yml</filename>
      playbook:
     </para>
-<screen>cd ~/scratch/ansible/next/ardana/ansible
-ansible-playbook -i hosts/verb_hosts ardana-deploy.yml</screen>
+<screen>&prompt.ardana;cd ~/scratch/ansible/next/ardana/ansible
+&prompt.ardana;ansible-playbook -i hosts/verb_hosts ardana-deploy.yml</screen>
    </listitem>
   </orderedlist>
  </section>

--- a/xml/operations-troubleshooting-objectstorage-recovering_builder_file.xml
+++ b/xml/operations-troubleshooting-objectstorage-recovering_builder_file.xml
@@ -62,12 +62,12 @@
   </step>
   <step>
    <para>
-    Create the <literal>/etc/swiftlm/builder_dir</literal> directory structure
+    Create the <literal>/etc/swiftlm/<replaceable>cloud-name</replaceable>/<replaceable>control-plane-name</replaceable>/builder_dir</literal> directory structure
     with these commands:
    </para>
    <para>
-    Replace <literal>&lt;cloud-name&gt;</literal> with the name of your cloud
-    and <literal>&lt;control-plane-name&gt;</literal> with the name of your
+    Replace <replaceable>cloud-name</replaceable> with the name of your cloud
+    and <replaceable>control-plane-name</replaceable> with the name of your
     control plane.
    </para>
 <screen>sudo mkdir -p /etc/swiftlm/&lt;cloud-name&gt;/&lt;control-plane-name&gt;/builder_dir/
@@ -87,7 +87,7 @@ sudo chown -R stack.stack /etc/swiftlm/</screen>
     <literal>cloud1</literal> is the cloud, and <literal>cp1</literal> is the
     control plane name::
    </para>
-<screen>scp /etc/swiftlm//cloud1/cp1/* swpac-ccp-c1-m1-mgmt:/etc/swiftlm/builder_dir/cloud1/cp1</screen>
+<screen>scp /etc/swiftlm//cloud1/cp1/* swpac-ccp-c1-m1-mgmt:/etc/swiftlm/cloud1/cp1/builder_dir/</screen>
   </step>
   <step>
    <para>

--- a/xml/operations-troubleshooting-objectstorage-recovering_builder_file.xml
+++ b/xml/operations-troubleshooting-objectstorage-recovering_builder_file.xml
@@ -62,16 +62,16 @@
   </step>
   <step>
    <para>
-    Create the <literal>/etc/swiftlm/<replaceable>cloud-name</replaceable>/<replaceable>control-plane-name</replaceable>/builder_dir</literal> directory structure
+    Create the <literal>/etc/swiftlm/<replaceable>CLOUD_NAME</replaceable>/<replaceable>CONTROL_PLANE_NAME</replaceable>/builder_dir</literal> directory structure
     with these commands:
    </para>
    <para>
-    Replace <replaceable>cloud-name</replaceable> with the name of your cloud
-    and <replaceable>control-plane-name</replaceable> with the name of your
+    Replace <replaceable>CLOUD_NAME</replaceable> with the name of your cloud
+    and <replaceable>CONTROL_PLANE_NAME</replaceable> with the name of your
     control plane.
    </para>
-<screen>sudo mkdir -p /etc/swiftlm/&lt;cloud-name&gt;/&lt;control-plane-name&gt;/builder_dir/
-sudo chown -R stack.stack /etc/swiftlm/</screen>
+<screen>&prompt.sudo;mkdir -p /etc/swiftlm/&lt;cloud-name&gt;/&lt;control-plane-name&gt;/builder_dir/
+&prompt.sudo;chown -R stack.stack /etc/swiftlm/</screen>
   </step>
   <step>
    <para>
@@ -87,7 +87,7 @@ sudo chown -R stack.stack /etc/swiftlm/</screen>
     <literal>cloud1</literal> is the cloud, and <literal>cp1</literal> is the
     control plane name::
    </para>
-<screen>scp /etc/swiftlm//cloud1/cp1/* swpac-ccp-c1-m1-mgmt:/etc/swiftlm/cloud1/cp1/builder_dir/</screen>
+<screen>&prompt.ardana;scp /etc/swiftlm//cloud1/cp1/* swpac-ccp-c1-m1-mgmt:/etc/swiftlm/cloud1/cp1/builder_dir/</screen>
   </step>
   <step>
    <para>
@@ -99,8 +99,8 @@ sudo chown -R stack.stack /etc/swiftlm/</screen>
     Run the Swift reconfigure playbook to make sure every Swift node has the
     same rings:
    </para>
-<screen>cd ~/scratch/ansible/next/ardana/ansible
-ansible-playbook -i hosts/verb_hosts swift-reconfigure.yml</screen>
+<screen>&prompt.ardana;cd ~/scratch/ansible/next/ardana/ansible
+&prompt.ardana;ansible-playbook -i hosts/verb_hosts swift-reconfigure.yml</screen>
   </step>
  </procedure>
 </section>


### PR DESCRIPTION
* change directory where swift backup gets copied to /etc/swiftlm/<cloud_name>/<control-plane-name>/builder_dir/