### PR TITLE
Operations Guide Review - Monasca SCRD-3961

### DIFF
--- a/xml/esx-remove_existing_cluster_compute_resource_pool.xml
+++ b/xml/esx-remove_existing_cluster_compute_resource_pool.xml
@@ -185,7 +185,7 @@ ansible-playbook -i hosts/verb_hosts neutron-stop --limit &lt;hostname&gt;;</scr
      the monasca-agent on each of those servers by executing the following
      command.
     </para>
-<screen>sudo service monasca-agent restart</screen>
+    <screen>&prompt.sudo;service openstack-monasca-agent restart</screen>
    </listitem>
    <listitem>
     <para>
@@ -282,7 +282,7 @@ ansible-playbook -i hosts/verb_hosts neutron-stop --limit &lt;hostname&gt;;</scr
      execute the following command to restart the monasca-agent on each of
      those servers.
     </para>
-<screen>sudo service monasca-agent restart</screen>
+<screen>&prompt.sudo;service openstack-monasca-agent restart</screen>
    </listitem>
    <listitem>
     <para>

--- a/xml/esx-removing_esx_host_from_cluster.xml
+++ b/xml/esx-removing_esx_host_from_cluster.xml
@@ -223,7 +223,7 @@
      the monasca-agent on each of those servers by executing the following
      command.
     </para>
-<screen>sudo service monasca-agent restart</screen>
+<screen>&prompt.sudo;service openstack-monasca-agent restart</screen>
    </listitem>
    <listitem>
     <para>

--- a/xml/operations-configuring_alarm_definitions.xml
+++ b/xml/operations-configuring_alarm_definitions.xml
@@ -56,7 +56,7 @@
   directory, illustrate how Monasca sets up the default alarm definitions.
  </para>
  <para>
-  <emphasis role="bold">monasca_default_method</emphasis>
+  <emphasis role="bold">Monasca Notification Methods</emphasis>
  </para>
  <para>
   The monasca-api-spec, found in the following link, provides details about

--- a/xml/operations-configuring_check_plugins.xml
+++ b/xml/operations-configuring_check_plugins.xml
@@ -35,7 +35,7 @@
  </para>
  <para>
   After the plugin is configured, you can verify that the configuration file
-  has your changes (see the <emphasis role="bold">Verify that your check plugin
+  has your changes (see the next <emphasis role="bold">Verify that your check plugin
   is configured</emphasis> section).
  </para>
  <para>

--- a/xml/operations-integrating_nagios.xml
+++ b/xml/operations-integrating_nagios.xml
@@ -190,10 +190,12 @@
    another could retrieve all monasca alarms related to that host.
   </para>
   <para>
-   To build this configuration, a custom Nagios plugin was created with the
-   following options:
+   To build this configuration, a custom Nagios plugin
+   (Please see example plugin at:
+   <link xlink:href="https://github.com/openstack/python-monascaclient/tree/stable/pike/examples"/>) 
+   was created with the following options:
   </para>
-<screen>check_monasca –c &lt;credentials&gt; -d &lt;dimension&gt; -v &lt;value&gt;</screen>
+<screen>check_monasca –c <replaceable>CREDENTIALS</replaceable> -d <replaceable>DIMENSION</replaceable> -v <replaceable>VALUE</replaceable></screen>
   <para>
    Examples:
   </para>

--- a/xml/operations-integration_of_plugins_with_monasca-agent.xml
+++ b/xml/operations-integration_of_plugins_with_monasca-agent.xml
@@ -18,7 +18,7 @@
   are no guarantees that code will be approved or merged by a deadline.
   Open-source contributors are expected to help with codereviews in order to get
   their code accepted. Once changes are approved and integrated into the
-  openstack/monasca-agent and that version of themonasca-agent is integrated
+  openstack/monasca-agent and that version of the monasca-agent is integrated
   with &kw-hos-phrase;, the third party can remove the custom plugin
   installation steps since they would be installed in the default monasca-agent
   venv.

--- a/xml/operations-maintenance-compute-remove_compute_node.xml
+++ b/xml/operations-maintenance-compute-remove_compute_node.xml
@@ -436,6 +436,22 @@ ansible-playbook -i hosts/localhost cobbler-deploy.yml</screen>
    trigger so there are additional steps to take to resolve this issue.
   </para>
   <para>
+    To find all Monasca API servers 
+  </para>
+<screen>&prompt.sudo;cat /etc/haproxy/haproxy.cfg | grep MON
+listen ardana-cp1-vip-public-MON-API-extapi-8070
+    bind ardana-cp1-vip-public-MON-API-extapi:8070  ssl crt /etc/ssl/private//my-public-cert-entry-scale                                          
+    server ardana-cp1-c1-m1-mgmt-MON_API-8070 ardana-cp1-c1-m1-mgmt:8070 check inter 5000 rise 2 fall 5                                          
+    server ardana-cp1-c1-m2-mgmt-MON_API-8070 ardana-cp1-c1-m2-mgmt:8070 check inter 5000 rise 2 fall 5                                          
+    server ardana-cp1-c1-m3-mgmt-MON_API-8070 ardana-cp1-c1-m3-mgmt:8070 check inter 5000 rise 2 fall 5        
+listen ardana-cp1-vip-MON-API-mgmt-8070
+    bind ardana-cp1-vip-MON-API-mgmt:8070  ssl crt /etc/ssl/private//ardana-internal-cert                                          
+    server ardana-cp1-c1-m1-mgmt-MON_API-8070 ardana-cp1-c1-m1-mgmt:8070 check inter 5000 rise 2 fall 5                                          
+    server ardana-cp1-c1-m2-mgmt-MON_API-8070 ardana-cp1-c1-m2-mgmt:8070 check inter 5000 rise 2 fall 5                                          
+    server ardana-cp1-c1-m3-mgmt-MON_API-8070 ardana-cp1-c1-m3-mgmt:8070 check inter 5000 rise 2 fall 5</screen>
+  <para>In above example <literal>ardana-cp1-c1-m1-mgmt</literal>,<literal>ardana-cp1-c1-m2-mgmt</literal>,
+  <literal>ardana-cp1-c1-m3-mgmt</literal> are Monasa API servers</para>
+  <para>
    You will want to SSH to each of the Monasca API servers and edit the
    <literal>/etc/monasca/agent/conf.d/host_alive.yaml</literal> file to remove
    references to the Compute node you removed. This will require
@@ -451,7 +467,7 @@ ansible-playbook -i hosts/localhost cobbler-deploy.yml</screen>
    then need to restart the monasca-agent on each of those servers with this
    command:
   </para>
-<screen>sudo service monasca-agent restart</screen>
+<screen>&prompt.sudo;service openstack-monasca-agent restart</screen>
   <para>
    With the Compute node references removed and the monasca-agent restarted,
    you can then delete the corresponding alarm to finish this process. To do so

--- a/xml/operations-maintenance-swift-removing_swift_node.xml
+++ b/xml/operations-maintenance-swift-removing_swift_node.xml
@@ -393,7 +393,7 @@ ansible-playbook -i hosts/verb_hosts swift-deploy.yml</screen>
    then need to restart the monasca-agent on each of those servers with this
    command:
   </para>
-<screen>sudo service monasca-agent restart</screen>
+<screen>&prompt.sudo;service openstack-monasca-agent restart</screen>
   <para>
    With the Swift node references removed and the monasca-agent restarted, you
    can then delete the corresponding alarm to finish this process. To do so we

--- a/xml/operations-monasca_agent.xml
+++ b/xml/operations-monasca_agent.xml
@@ -71,9 +71,8 @@
   metrics, is used as a basis for a custom process detection plugin.
  </para>
  <para>
-  Find more information about the &o_monitor; agent in your &lcm;'s
-  <literal>/openstack/monasca-agent/docs</literal> directory. Further
-  documentation can be found in the following locations
+  More information about the &o_monitor; agent 
+  can be found in the following locations
  </para>
  <itemizedlist>
   <listitem>

--- a/xml/operations-writing_custom_plugins.xml
+++ b/xml/operations-writing_custom_plugins.xml
@@ -32,8 +32,8 @@
  <para>
   Each plugin needs a corresponding YAML configuration file with the same stem
   name as the plugin check file. For example, the plugin file <filename>http_check.py</filename>
-  should have a corresponding configuration file, <filename>http_check.yaml</filename>. The stem
-  name <literal>http_check</literal> must be the same for both
+  (Please see <literal>/usr/lib/python2.7/site-packages/monasca_agent/collector/checks_d/http_check.py</literal>)should have a corresponding configuration file, <filename>http_check.yaml</filename> (Please see <literal>/etc/monasca/agent/conf.d/http_check.yaml</literal>)).
+  The stem name <literal>http_check</literal> must be the same for both
   files.
  </para>
  <para>
@@ -42,10 +42,11 @@
   must also own the file), and <emphasis role="bold">read</emphasis> for the
   mon-agent group. Permissions for the file must be restricted to the
   <emphasis role="bold">mon-agent</emphasis> user and
-  <emphasis role="bold">mon-agent</emphasis> group. The following example shows
+  <emphasis role="bold">monasca</emphasis> group. The following example shows
   correct permissions settings for the file <filename>http_check.yaml</filename>.
  </para>
-<screen>-rw-r----- 1 mon-agent mon-agent 10043 Sep 21 19:05 http_check.yml</screen>
+<screen>&prompt.ardana;ls -alt /etc/monasca/agent/conf.d/http_check.yaml
+-rw-r----- 1 monasca-agent monasca 10590 Jul 26 05:44 http_check.yaml</screen>
  <para>
   A check plugin YAML configuration file has the following structure.
  </para>
@@ -140,7 +141,7 @@ class MonascaTransformDetect(monasca_setup.detection.ServicePlugin):
  <para>
   A custom detection plugin class should derive from either the Plugin or
   ArgsPlugin classes provided in the
-  <filename>monasca-agent/monasca_setup/detection</filename> directory.
+  <filename>/usr/lib/python2.7/site-packages/monasca_setup/detection</filename> directory.
  </para>
  <para>
   If the plugin parses command line arguments, the <literal>ArgsPlugin</literal> class is useful.
@@ -254,7 +255,7 @@ class HttpCheck(monasca_setup.detection.ArgsPlugin):
 <screen>monasca_agent_detection_plugin_dir: /usr/lib/monasca/agent/custom_detect.d/</screen>
  <para>
   Example Ansible <literal>monasca_configure</literal> task to install the
-  plugin.
+  plugin. (Note: that monasca_configure task can be added to any service playbook)
  </para>
 <screen>---
 - name: _CEI-CMN | monasca_configure |
@@ -286,7 +287,7 @@ class HttpCheck(monasca_setup.detection.ArgsPlugin):
   If your check runs a command, you should provide a timeout to prevent the
   check from running longer than the default 30-second window. You can use the
   <literal>monasca_agent.common.util.timeout_command</literal> to set a timeout
-  for your checks.
+  for in your custom check plugin python code.
  </para>
  <para>
   Find a description of how to write custom check plugins at


### PR DESCRIPTION
* Incorporating comments from Gloria for monasca

* 3.2.4 Integration Approaches
  Added a link to example nagios plugin check_monasca

* 3.4 Monitoring Third-Party Components With Monasca
  Incorporated comments from two pdfs attached to SCRD-3961
  - removed pointer to non-existent monasca-agent/docs directory
  - added a link to http_check.yaml, http_check.py
  - corrected calls to restart monasca-agent to openstack-monasca-agent

* 13.1.3.5.10 Remove the Compute Host from Monitoring
  Added section to find Monasca API servers