### PR TITLE
Remove references to hlm in ovsvapp setup document bsc#1102993

### DIFF
--- a/xml/create-vapp_template-vcenter.xml
+++ b/xml/create-vapp_template-vcenter.xml
@@ -131,7 +131,7 @@
       The contents of the &slsa; SDK ISO
       (<filename>SLE-12-SP3-SDK-DVD-x86_64-GM-DVD1.iso</filename>) must be
       mounted or copied to
-      <filename>/opt/hlm_packager/hlm/sles12/zypper/SDK/</filename>. If you
+      <filename>/opt/ardana_packager/ardana/sles12/zypper/SDK/</filename>. If you
       choose to mount the ISO, we recommend creating an
       <filename>/etc/fstab</filename> entry to ensure the ISO is mounted after
       a reboot.
@@ -141,14 +141,14 @@
      <para>
       Mount or copy the contents of
       <filename>SLE-12-SP3-Server-DVD-x86_64-GM-DVD1.iso</filename> to
-      <filename>/opt/hlm_packager/hlm/sles12/zypper/OS/</filename>.
+      <filename>/opt/ardana_packager/ardana/sles12/zypper/OS/</filename>.
      </para>
     </listitem>
     <listitem>
      <para>
       Mount or copy the contents of
       <filename>SLE-12-SP3-SDK-DVD-x86_64-GM-DVD1.iso</filename> to
-      <filename>/opt/hlm_packager/hlm/sles12/zypper/SDK/</filename>.
+      <filename>/opt/ardana_packager/ardana/sles12/zypper/SDK/</filename>.
      </para>
     </listitem>
    </itemizedlist>
@@ -333,9 +333,9 @@ STARTMODE='auto'</screen>
      </para>
      <screen>&prompt.sudo;<replaceable>DEPLOYER_IP</replaceable>=192.168.24.140
      &prompt.sudo;zypper addrepo --no-gpgcheck --refresh \
-     http://$deployer_ip:79/hlm/sles12/zypper/OS SLES-OS
+     http://$deployer_ip:79/ardana/sles12/zypper/OS SLES-OS
      &prompt.sudo;zypper addrepo --no-gpgcheck --refresh \
-     http://$deployer_ip:79/hlm/sles12/zypper/SDK SLES-SDK</screen>
+     http://$deployer_ip:79/ardana/sles12/zypper/SDK SLES-SDK</screen>
      <para>
       Verify that the repositories have been added.
      </para>


### PR DESCRIPTION
Remove "hlm" from pathnames in the document create-vapp_template-vcenter.xml.