### PR TITLE
Update incorrect references to /etc/swiftlm/builder_dir SCRD-3936

### DIFF
--- a/xml/operations-maintenance-controller-replace_dedicated_lm.xml
+++ b/xml/operations-maintenance-controller-replace_dedicated_lm.xml
@@ -114,7 +114,7 @@ ansible-playbook -i hosts/verb_hosts osconfig-run.yml -e rebuild=True --limit=&l
    <para>
     If the controller being replaced is the Swift ring builder (see
     <xref linkend="topic_rtc_s3t_mt"/>) you need to restore the Swift ring
-    builder files to the <literal>/etc/swiftlm/builder_dir</literal> directory.
+    builder files to the <literal>/etc/swiftlm/<replaceable>CLOUD-NAME</replaceable>/<replaceable>CONTROL-PLANE-NAME</replaceable>/builder_dir</literal> directory.
     See <xref linkend="topic_gbz_13t_mt"/> for details.
    </para>
   </step>

--- a/xml/operations-maintenance-swift-removing_swift_node.xml
+++ b/xml/operations-maintenance-swift-removing_swift_node.xml
@@ -117,7 +117,7 @@ ansible-playbook -i hosts/verb_hosts swift-deploy.yml</screen>
      on the Swift node you are removing. You can do this by SSH'ing into the
      first account server node and using these commands:
     </para>
-<screen>cd /etc/swiftlm/builder_dir/region-&lt;region_name&gt;
+<screen>cd /etc/swiftlm/cloud1/cp1/builder_dir/
 sudo swift-ring-builder &lt;ring_name&gt;.builder</screen>
     <para>
      For example, if the node you are removing was part of the object-o ring
@@ -129,7 +129,7 @@ sudo swift-ring-builder &lt;ring_name&gt;.builder</screen>
      drained. In the example below, the number of partitions of the drives on
      192.168.245.3 has reached zero for the object-0 ring:
     </para>
-<screen>$ cd /etc/swiftlm/builder_dir/region-region1/
+<screen>$ cd /etc/swiftlm/cloud1/cp1/builder_dir/
 $ sudo swift-ring-builder object-0.builder
 account.builder, build version 6
 4096 partitions, 3.000000 replicas, 1 regions, 1 zones, 6 devices, 0.00 balance, 0.00 dispersion

--- a/xml/operations-maintenance-swift-replacing_drives_swift_node.xml
+++ b/xml/operations-maintenance-swift-replacing_drives_swift_node.xml
@@ -74,7 +74,7 @@ ansible-playbook -i hosts/verb_hosts osconfig-run.yml -limit ardana-cp1-swobj000
     <para>
      If this is the first server running the swift-proxy service, restore the
      Swift Ring Builder files to the
-     <literal>/etc/swiftlm/builder_dir</literal> directory. For more
+     <literal>/etc/swiftlm/<replaceable>CLOUD-NAME</replaceable>/<replaceable>CONTROL-PLANE-NAME</replaceable>/builder_dir</literal> directory. For more
      information and instructions, see <xref linkend="topic_rtc_s3t_mt"/> and
      <xref linkend="topic_gbz_13t_mt"/>.
     </para>

--- a/xml/operations-maintenance-swift-replacing_swift_node.xml
+++ b/xml/operations-maintenance-swift-replacing_swift_node.xml
@@ -147,7 +147,7 @@ ansible-playbook -i hosts/verb_hosts osconfig-run.yml -limit &lt;hostname&gt;</s
      <listitem>
       <para>
        If this is the Swift ring builder server, restore the Swift ring builder
-       files to the <literal>/etc/swiftlm/builder_dir</literal> directory. For
+       files to the <literal>/etc/swiftlm/<replaceable>CLOUD-NAME</replaceable>/<replaceable>CONTROL-PLANE-NAME</replaceable>/builder_dir</literal> directory. For
        more information and instructions, see
        <xref linkend="topic_rtc_s3t_mt"/> and
        <xref linkend="topic_gbz_13t_mt"/>.

--- a/xml/operations-objectstorage-add_new_storage_policy.xml
+++ b/xml/operations-objectstorage-add_new_storage_policy.xml
@@ -121,7 +121,7 @@
 <screen>TASK: [swiftlm-ring-supervisor | build-rings | Build ring (make-delta, rebalance)] ***
 failed: [padawan-ccp-c1-m1-mgmt] =&gt; {"changed": true, "cmd": ["swiftlm-ring-supervisor", "--make-delta", "--rebalance"], "delta": "0:00:03.511929", "end": "2015-10-07 14:02:03.610226", "rc": 2, "start": "2015-10-07 14:02:00.098297", "warnings": []}
 ...
-Running: swift-ring-builder /etc/swiftlm/builder_dir/region-region1/object-2.builder rebalance 999
+Running: swift-ring-builder /etc/swiftlm/cloud1/cp1/builder_dir/object-2.builder rebalance 999
 ERROR: -------------------------------------------------------------------------------
 An error has occurred during ring validation. Common
 causes of failure are rings that are empty or do not

--- a/xml/operations-objectstorage-input_model_change_existing_rings.xml
+++ b/xml/operations-objectstorage-input_model_change_existing_rings.xml
@@ -199,7 +199,7 @@ ok: [padawan-ccp-c1-m1-mgmt] =&gt; {
      files were not changed so you do not need to deploy them to the Swift
      nodes:
     </para>
-<screen>"Running: swift-ring-builder /etc/swiftlm/builder_dir/region-region1/account.builder rebalance 999",
+<screen>"Running: swift-ring-builder /etc/swiftlm/cloud1/cp1/builder_dir/account.builder rebalance 999",
       "NOTE: No partitions could be reassigned.",
       "Either none need to be or none can be due to min_part_hours [16]."</screen>
     <para>

--- a/xml/operations-troubleshooting-objectstorage-restart_deploy_from_scratch.xml
+++ b/xml/operations-troubleshooting-objectstorage-restart_deploy_from_scratch.xml
@@ -15,11 +15,11 @@
    ring, the new ring uses the state of the old ring as a basis for the new
    ring. Rings are stored in the builder file. The
    <literal>swiftlm-ring-supervisor</literal> stores builder files in the
-   <literal>/etc/swiftlm/builder_dir/region-&lt;region-name&gt;</literal>
+   <literal>/etc/swiftlm/cloud1/cp1/builder_dir/</literal>
    directory on the Ring-Builder node. The builder files are named
    &lt;ring-name&gt; builder. Prior versions of the builder files are stored in
    the
-   <literal>/etc/swiftlm/builder_dir/region-&lt;region-name&gt;/backups</literal>
+   <literal>/etc/swiftlm/cloud1/cp1/builder_dir/backups</literal>
    directory.
   </para>
   <para>
@@ -57,10 +57,10 @@
   </para>
   <para>
    Delete the builder files in the
-   <filename>/etc/swiftlm/builder-dir/region-&lt;region-name>/</filename>
+   <filename>/etc/swiftlm/cloud1/cp1/builder-dir/region-&lt;region-name>/</filename>
    directory. For example, for the region2 Keystone region, do the following:
   </para>
-<screen>sudo rm /etc/swiftlm/builder_dir/region-region2/*.builder</screen>
+<screen>sudo rm /etc/swiftlm/cloud1/cp1/builder_dir/region-region2/*.builder</screen>
   <note>
    <para>
     If you have successfully deployed a system and accidentally delete the


### PR DESCRIPTION
* Update references to /etc/swiftlm/builder_dir to
  /etc/swiftlm/<cloud-name>/<control-plane-name>/builder_dir

* Remove references to "region-<region_name>"
  from /etc/swiftlm/builder_dir/region-<region_name>