### PR TITLE
Update tftpboot path to refer to 12.3 instead of 12.2 (bsc#1102550)

### DIFF
--- a/xml/depl_conf_admin_crowbar.xml
+++ b/xml/depl_conf_admin_crowbar.xml
@@ -582,7 +582,7 @@
       If you use different sources for your repositories or are using
       non-standard locations, choose this option and manually provide a
       location for each repository. This can either be a local directory
-      (<filename>/srv/tftpboot/suse-12.2/x86_64/repos/SLES12-SP3-Pool/</filename>)
+      (<filename>/srv/tftpboot/suse-12.3/x86_64/repos/SLES12-SP3-Pool/</filename>)
       or a remote location
       (<literal>http://manager.example.com/ks/dist/child/sles12-sp3-updates-x86_64/sles12-sp3-x86_64/</literal>).
       Activating <guimenu>Ask On Error</guimenu> ensures that you will be

--- a/xml/depl_conf_admin_repos.xml
+++ b/xml/depl_conf_admin_repos.xml
@@ -109,7 +109,7 @@
        </entry>
        <entry>
         <para>
-         <filename>/srv/tftpboot/suse-12.2/x86_64/install</filename>
+         <filename>/srv/tftpboot/suse-12.3/x86_64/install</filename>
         </para>
        </entry>
       </row>
@@ -121,7 +121,7 @@
        </entry>
        <entry>
         <para>
-         <filename>/srv/tftpboot/suse-12.2/x86_64/repos/Cloud</filename>
+         <filename>/srv/tftpboot/suse-12.3/x86_64/repos/Cloud</filename>
         </para>
        </entry>
       </row>

--- a/xml/depl_troubleshooting.xml
+++ b/xml/depl_troubleshooting.xml
@@ -379,7 +379,7 @@ EOF</screen>
      <answer>
       <para>
        The installation repository on the
-       &admserv; at <filename>/srv/tftpboot/suse-12.2/install</filename>
+       &admserv; at <filename>/srv/tftpboot/suse-12.3/install</filename>
        has not been set up correctly to contain the &cloudos;
        installation media. Review the instructions at
        <xref linkend="sec.depl.adm_conf.repos.product"/>.

--- a/xml/entity-decl.ent
+++ b/xml/entity-decl.ent
@@ -269,9 +269,9 @@ suggested official replacement from rsalevsky. -->
 <!ENTITY cloud_repo  "<phrase xmlns='http://docbook.org/ns/docbook'><phrase vendor='suse;suse-crow'>SUSE-OpenStack-Cloud-8</phrase><phrase vendor='hpe'>HPE-Helion-OpenStack-8</phrase></phrase>">
 <!ENTITY smt_os       "sle-12-x86_64">
 <!ENTITY smt_dir      "/srv/www/htdocs/repo/SUSE">
-<!ENTITY tftp_dir     "/srv/tftpboot/suse-12.2/x86_64">
+<!ENTITY tftp_dir     "/srv/tftpboot/suse-12.3/x86_64">
 <!ENTITY www_dir      "/srv/www/suse-12.3/x86_64">
-<!ENTITY ztftp_dir     "/srv/tftpboot/suse-12.2/s390x">
+<!ENTITY ztftp_dir     "/srv/tftpboot/suse-12.3/s390x">
 
 <!ENTITY repospace    "30 GB">
 <!ENTITY mediaspace   "350 MB">


### PR DESCRIPTION
Update the version in the tftp path per https://bugzilla.suse.com/show_bug.cgi?id=1102550

This looked like a good low-hanging-fruit high-value defect that I could try to fix to understand the build and review process. 