### PR TITLE
bsc#1104269-deprecated driver names

### DIFF
--- a/xml/installation-installation-configure_3par.xml
+++ b/xml/installation-installation-configure_3par.xml
@@ -94,12 +94,9 @@
    <literal>cinder.conf.j2</literal> file using a comma-delimited list.
    Also create multiple volume types so you can specify a backend to utilize
    when creating volumes. Instructions are included below.
-   <!-- the following documentation is not accurate; it doesn't show up in a
-   quick search 2018-02-27; csymons -->
-   <!-- In addition to our documentation, you can also read
-   the OpenStack documentation at
-   <link xlink:href="http://docs.openstack.org/admin-guide-cloud/blockstorage_multi_backend.html">Configure
-   multiple storage backends</link> as well. -->
+   You can also read the OpenStack documentation about <link
+   xlink:href="https://wiki.openstack.org/wiki/Cinder-multi-backend">Cinder
+   multiple storage backends</link>.
   </para>
   <para>
    <emphasis role="bold">Concerning iSCSI and Fiber Channel:</emphasis> You
@@ -108,46 +105,15 @@
    compute server.
   </para>
   <para>
-   <emphasis role="bold">3PAR driver has updated name:</emphasis> In the
-   OpenStack Mitaka release, the 3PAR driver used for &productname; integration
-   had its name updated from <literal>HP3PARFCDriver</literal> and
+   <emphasis role="bold">3PAR driver correct name:</emphasis> In a previous
+   release, the 3PAR driver used for &productname; integration had its name
+   updated from <literal>HP3PARFCDriver</literal> and
    <literal>HP3PARISCSIDriver</literal> to <literal>HPE3PARFCDriver</literal>
-   and <literal>HPE3PARISCSIDriver</literal>. To prevent issues when upgrading
-   from previous &kw-hos; releases, we left the names as-is in the release and
-   provided a mapping so that the integration would continue to work. This will
-   produce a warning in the <literal>cinder-volume.log</literal> file advising
-   you of the deprecated name. The warning will look similar to this:
-   <quote>Option "hp3par_api_url" from group
-   "&lt;<replaceable>YOUR_SECTION</replaceable>>" is
-   deprecated. Use option "hpe3par_api_url" from group
-   "&lt;<replaceable>YOUR_SECTION</replaceable>>"'</quote>.
+   and <literal>HPE3PARISCSIDriver</literal> (<literal>HP</literal> changed to
+   <literal>HPE</literal>). You may get a warning or an error if the deprecated
+   filenames are used. The correct values are those in
+   <filename>~/openstack/my_cloud/config/cinder/cinder.conf.j2</filename>.
   </para>
-  <para>
-   These are just warnings and can be ignored.
-  </para>
-  <!-- FIXME: the following was commented in the DITA original. -->
-  <!--
-  <para>If you would like to remove these warnings, use the following steps:</para>
-  <procedure>
-     <step>Log in to the &lcm;.</step>
-     <step>Update the Cinder configuration file at the following
-       location:<screen>~/openstack/ardana/ansible/roles/_CND-CMN/templates/cinder.conf.j2</screen></step>
-     <step>Change each occurrence of <literal>hplefthand_</literal> to
-         <literal>hpelefthand_</literal> and each occurrence of <literal>hp3par_</literal> to
-         <literal>hpe3par_</literal> in the <literal>cinder.conf.j2</literal> file and save
-       it.</step>
-     <step>Commit your changes to
-       git:<screen>cd ~/openstack/ardana/ansible
-git add -A
-git commit -m "My config or other commit message"</screen></step>
-     <step>Update your deployment
-       directory:<screen>cd ~/openstack/ardana/ansible
-ansible-playbook -i hosts/localhost ready-deployment.yml</screen></step>
-     <step>Use the following playbook to reconfigure the Cinder service to implement the
-       changes:<screen>cd ~/scratch/ansible/next/ardana/ansible
-ansible-playbook -i hosts/verb_hosts cinder-reconfigure.yml</screen></step>
-   </procedure>
-          -->
  </section>
  <section xml:id="sec.3par-multipath">
   <title>Multipath Support</title>


### PR DESCRIPTION
Second issue in bug about support for deprecated filenames and cinder.conf.j2