### PR TITLE
Update Cinder deployment doc with Pure Storage FlashArray information

### DIFF
--- a/xml/depl_nodes.xml
+++ b/xml/depl_nodes.xml
@@ -2253,8 +2253,8 @@ and admins can see the available options in the barclamp -->
   <para>
    &o_blockstore; can provide volume storage by using different back-ends such
    as local file, one or more local disks, &ceph; (RADOS), &vmware;, or network
-   storage solutions from EMC, EqualLogic, Fujitsu, or NetApp. Since
-   &productname; 5, &o_blockstore; supports using several back-ends
+   storage solutions from EMC, EqualLogic, Fujitsu, NetApp or Pure Storage.
+   Since &productname; 5, &o_blockstore; supports using several back-ends
    simultaneously. It is also possible to deploy the same network storage
    back-end multiple times and therefore use different installations at the
    same time.
@@ -2542,6 +2542,45 @@ host1:/srv/nfs/share1 /mnt/nfs/share1 -o rsize=8192,wsize=8192,timeo=14,intr
     </listitem>
    </varlistentry>
   </variablelist>
+
+  <bridgehead renderas="sect2"><guimenu>Pure Storage (FlashArray)</guimenu>
+  </bridgehead>
+
+  <variablelist>
+   <varlistentry>
+    <term><guimenu>IP address of the management VIP</guimenu>
+    </term>
+    <listitem>
+     <para>
+      IP address of the FlashArray management VIP
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><guimenu>API token for the FlashArray</guimenu>
+    </term>
+    <listitem>
+     <para>
+      API token for access to the FlashArray
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><guimenu>iSCSI CHAP authentication enabled</guimenu>
+    </term>
+    <listitem>
+     <para>
+      Enable or disable iSCSI CHAP authentication
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+
+  <para>
+   For more information on the Pure Storage FlashArray driver refer to the &ostack; documentation
+   at
+   <link xlink:href="https://docs.openstack.org/ocata/config-reference/block-storage/drivers/pure-storage-driver.html"/>.
+  </para>
 
   <bridgehead renderas="sect3"><guimenu>RADOS</guimenu> (&ceph;)
   </bridgehead>


### PR DESCRIPTION
Pure Storage FlashArray is now a supported Cinder backend in Cinder Barclamp 
https://github.com/crowbar/crowbar-openstack/pull/1618
so adding the required information into the Cinder deployment doc page