### PR TITLE
migration guide limitation (bsc#1108867)

### DIFF
--- a/xml/art_migration.xml
+++ b/xml/art_migration.xml
@@ -74,7 +74,11 @@
    </listitem>
    <listitem>
     <para>
-     All &compnode;s are running supported Linux distributions:
+     All &compnode;s are running supported Linux distributions, and any prior
+     hLinux &compnodes; have been removed from the cloud. (For details about
+     migrating instances from hLinux to &slsa; or &rhla; &compnode;s, please
+     review the following HOS 5 documentation: Release Notes, Installation
+     Guide, and Operations Guide.)
     </para>
     <itemizedlist>
      <listitem>
@@ -88,14 +92,6 @@
       </para>
      </listitem>
     </itemizedlist>
-   </listitem>
-   <listitem>
-    <para>
-     There are some limitations to migrating instances. For details about
-     migrating instances from hLinux to &slsa; or &rhla; &compnode;s, please
-     review the following HOS 5 documentation: Release Notes, Installation
-     Guide and Operations Guide.
-     </para>
    </listitem>
    <listitem>
     <para>

--- a/xml/art_migration.xml
+++ b/xml/art_migration.xml
@@ -91,6 +91,14 @@
    </listitem>
    <listitem>
     <para>
+     There are some limitations to migrating instances. For details about
+     migrating instances from hLinux to &slsa; or &rhla; &compnode;s, please
+     review the following HOS 5 documentation: Release Notes, Installation
+     Guide and Operations Guide.
+     </para>
+   </listitem>
+   <listitem>
+    <para>
      The cloud data model does not contain services which are not included in
      &productname; &productnumber;, such as Ceph and VSA.
     </para>


### PR DESCRIPTION
hLinux VM compute nodes can't migrate to SLES
information previously added to HPE Operations Guide. This PR adds to the HPE Migration Guide.