### PR TITLE
restart Crowbar manually (bsc#1069434)

### DIFF
--- a/xml/depl_crowbar_extra-features.xml
+++ b/xml/depl_crowbar_extra-features.xml
@@ -25,7 +25,7 @@
    <emphasis role="bold">Enabling the Feature</emphasis>
   </para>
   <para>
-   In <filename>/opt/dell/crowbar_framework/config/crowbar.yml</filename> set
+   In <filename>/opt/dell/crowbar_framework/config/crowbar.yml</filename>, set
    the option <literal>skip_unready_nodes</literal> to <literal>true</literal>.
   </para>
 <screen>default: &amp;default
@@ -104,5 +104,198 @@ skip_unready_nodes:
   <screen>default: &amp;default
 skip_unchanged_nodes:
   enabled: false &lt;&lt;&lt; change to true</screen>
+ </section>
+ <section>
+  <title>Controlling Chef Restarts Manually</title>
+  <para>
+   When a service configuration has changed, &chef; forces this service to
+   restart. Sometimes it is useful to have manual control of these
+   restarts. This feature supports avoiding automatic restart of services and
+   including them in a pending restart list.  Disabling restarts is
+   enabled/disabled by &barcl; and cannot be done on a service level. In other
+   words, enabling this feature on the &o_blockstore; &barcl; will disable
+   automatic restarts for all &o_blockstore;-* services.
+  </para>
+  <para>
+   Two steps are necessary to activate this feature:
+  </para>
+  <procedure>
+   <step>
+    <para>
+     Enable <literal>disallow_restart</literal> in the &crow; configuration file
+    </para>
+   </step>
+   <step>
+    <para>
+     Set the <literal>disable_restart</literal> flag for a specific &barcl;
+     using <literal>crowbar-client</literal> or API
+    </para>
+   </step>
+  </procedure>
+  <para>
+   <emphasis role="bold">Enabling the Feature</emphasis>
+  </para>
+  <procedure>
+   <step>
+    <para>
+     In <filename>/opt/dell/crowbar_framework/config/crowbar.yml</filename>, set
+     the option <literal>disallow_restart</literal> to <literal>true</literal>.
+    </para>
+    <screen>default: &amp;default
+disallow_restart:
+  enabled: false &lt;&lt;&lt; change to true</screen>
+   </step>
+   <step>
+    <para>
+     The <literal>disable_restart</literal> flag can be set with the &crow;
+     client or with the API.
+    </para>
+    <itemizedlist>
+     <listitem>
+      <para>
+       Set Flag with &crow; Client
+      </para>
+      <para>
+       The crowbar client options for this feature are accessed with the
+       <command>crowbarctl services</command> command, and only work for
+       &ostack-bare; services. The options are:
+      </para>
+      <variablelist>
+       <varlistentry>
+        <term>disable_restart</term>
+        <listitem>
+         <para>
+          The parameters are the &barcl; name and the flag value
+          (<literal>true</literal> to disable automatic restart and
+          <literal>false</literal> to enable automatic restart). The command is
+          <literal>crowbarctl services disable_restart
+          <replaceable>BARCLAMP</replaceable> &lt;true|false&gt;</literal>. For
+          example, to disable restart of the &o_ident; &barcl;, enter the
+          command <command>crowbarctl services disable_restart keystone
+          true</command>.
+         </para>
+        </listitem>
+       </varlistentry>
+       <varlistentry>
+        <term>restart_flags</term>
+        <listitem>
+         <para>
+          Used to check the <literal>disable_restart</literal> flag for each
+          barclamp
+         </para>
+         <screen>crowbarctl services restart_flags
+{
+  "nova": true,
+  "keystone": true,
+  "database": true
+}</screen>
+        </listitem>
+       </varlistentry>
+       <varlistentry>
+        <term>list_restarts</term>
+        <listitem>
+         <para>
+          Displays the list of pending restarts. The <literal>pending
+          restart</literal> flag indicates that a service tried to
+          restart due to the &chef; run but it did not due to the automatic
+          restart being disabled. It also indicates that the service might have
+          a new configuration and it will not be applied until it is manually
+          restarted.
+         </para>
+         <para>
+          In the following example, the <literal>pacemaker_service</literal>
+          attribute indicates whether this service is managed by Pacemaker
+          (usually in an HA environment) or it is a standalone service managed
+          by <literal>systemd</literal> (usually in non-HA environments). More
+          on Pacemaker at <xref linkend="sec.depl.ostack.pacemaker"/>. The
+          service to restart will be <literal>apache2</literal> not managed by
+          Pacemaker.
+         </para>
+         <screen>crowbarctl services list_restarts
+{
+  "<replaceable>NODE_IP</replaceable>": {
+    "alias": "controller1",
+    "keystone": {
+      "apache2": {
+        "pacemaker_service": false,
+        "timestamp": "2017-11-22 11:17:49 UTC"
+      }
+    }
+  }
+}</screen>
+        </listitem>
+       </varlistentry>
+       <varlistentry>
+        <term>clear_restart</term>
+        <listitem>
+         <para>
+          Removes the flag on a specific node for a specific service. It can
+          be executed when the service has restarted manually. The command is
+          <literal>crowbarctl services clear_restart
+          <replaceable>NODE</replaceable>
+          <replaceable>SERVICE</replaceable></literal>. For example, <command>crowbarctl
+          services clear_restart <replaceable>NODE_IP</replaceable>
+          apache2</command>
+         </para>
+        </listitem>
+       </varlistentry>
+      </variablelist>
+     </listitem>
+     <listitem>
+      <para>
+       Using the API to List, Get Status, Set and Clear Flags
+      </para>
+      <itemizedlist>
+       <listitem>
+        <para>
+         /restart_management/configuration
+        </para>
+        <variablelist>
+         <varlistentry>
+          <term>GET</term>
+         <listitem>
+          <para>
+           Lists the barclamps and the status of service reboots disallowed
+          </para>
+         </listitem>
+         </varlistentry>
+         <varlistentry>
+          <term>POST (parameters: disallow_restarts, barclamp)</term>
+          <listitem>
+           <para>
+            Sets the disallow_restart flag for a barclamp
+           </para>
+          </listitem>
+         </varlistentry>
+        </variablelist>
+       </listitem>
+       <listitem>
+        <para>
+         /restart_management/restarts
+        </para>
+        <variablelist>
+         <varlistentry>
+          <term>GET</term>
+         <listitem>
+          <para>
+           Lists all of the services needing restarts
+          </para>
+         </listitem>
+         </varlistentry>
+         <varlistentry>
+          <term>POST (parameters: node, service)</term>
+          <listitem>
+           <para>
+            Clears the restart flag for the given service in the given node
+           </para>
+          </listitem>
+         </varlistentry>
+        </variablelist>
+       </listitem>
+      </itemizedlist>
+     </listitem>
+    </itemizedlist>
+   </step>
+  </procedure>
  </section>
 </chapter>


### PR DESCRIPTION
please check example for list_restarts, shouldn't keystone be flagged "false" if only apache2 is being restarted?

In the following example, the service to restart will be apache2.
<screen>crowbarctl services list_restarts
{
  "Node_IP_Example": {
    "alias": "controller1",
    "keystone": {
      "apache2": {
        "pacemaker_service": false,
        "timestamp": "2017-11-22 11:17:49 UTC"
      }
    }
  }
}