### PR TITLE
manila: install steps improvement (bsc#1116079)

### DIFF
--- a/xml/installation-ardana-manila.xml
+++ b/xml/installation-ardana-manila.xml
@@ -57,14 +57,26 @@
     </para>
 <screen>&prompt.ardana;cd ~/scratch/ansible/next/ardana/ansible
 &prompt.ardana;ansible-playbook -i hosts/verb_hosts percona-deploy.yml
-&prompt.ardana;ansible-playbook -i hosts/verb_hosts manila-deploy.yml
+&prompt.ardana;ansible-playbook -i hosts/verb_hosts manila-deploy.yml</screen>
+   </step>
+   <step>
+    <para>
+     Configure &o_sharefs;
+    </para>
+<screen>&prompt.ardana;cd ~/scratch/ansible/next/ardana/ansible
+&prompt.ardana;ansible-playbook -i hosts/verb_hosts clients-deploy.yml
+&prompt.ardana;ansible-playbook -i hosts/verb_hosts keystone-reconfigure.yml
+&prompt.ardana;ansible-playbook -i hosts/verb_hosts cloud-client-setup.yml
+&prompt.ardana;ansible-playbook -i hosts/verb_hosts ardana-gen-hosts-file.yml
+&prompt.ardana;ansible-playbook -i hosts/verb_hosts FND-CLU-reconfigure.yml
 &prompt.ardana;ansible-playbook -i hosts/verb_hosts ardana-reconfigure.yml</screen>
    </step>
    <step>
     <para>
      Verify the &o_sharefs; installation
     </para>
-<screen>&prompt.ardana;. manila.osrc; . service.osrc; manila api-version; manila service-list</screen>
+<screen>&prompt.ardana;cd
+&prompt.ardana;. manila.osrc; . service.osrc; manila api-version; manila service-list</screen>
     <para>
      The &o_sharefs; CLI can be run from &lcm; or controller nodes.
     </para>


### PR DESCRIPTION
1. added a configure section which asks customer to run several
playbooks to configure affected services e.g. keystone & haproxy.
also included playbooks to update /etc/hosts file on deployer and
controllers and a playbook to install manila client.
2. added a one-line command to make sure manila service verification
steps are run in the home directory.