### PR TITLE
manila: add workaround for manila-manage log ownership problem (bsc#1116511)

### DIFF
--- a/xml/installation-ardana-manila.xml
+++ b/xml/installation-ardana-manila.xml
@@ -64,12 +64,20 @@
      Configure &o_sharefs;
     </para>
 <screen>&prompt.ardana;cd ~/scratch/ansible/next/ardana/ansible
-&prompt.ardana;ansible-playbook -i hosts/verb_hosts clients-deploy.yml
-&prompt.ardana;ansible-playbook -i hosts/verb_hosts keystone-reconfigure.yml
-&prompt.ardana;ansible-playbook -i hosts/verb_hosts cloud-client-setup.yml
 &prompt.ardana;ansible-playbook -i hosts/verb_hosts ardana-gen-hosts-file.yml
-&prompt.ardana;ansible-playbook -i hosts/verb_hosts FND-CLU-reconfigure.yml
-&prompt.ardana;ansible-playbook -i hosts/verb_hosts ardana-reconfigure.yml</screen>
+&prompt.ardana;ansible-playbook -i hosts/verb_hosts ardana-reconfigure.yml
+&prompt.ardana;ansible-playbook -i hosts/verb_hosts clients-deploy.yml</screen>
+   </step>
+   <step>
+    <para>
+     Workaround to fix manila-manage.log ownership problem &o_sharefs;
+    </para>
+<screen>on controller1:
+&prompt.ardana;cd /var/log/manila
+&prompt.ardana;sudo chown manila:manila manila-manage.log
+on &lcm;:
+&prompt.ardana;ansible-playbook -i hosts/verb_hosts manila-stop.yml
+&prompt.ardana;ansible-playbook -i hosts/verb_hosts manila-start.yml</screen>
    </step>
    <step>
     <para>


### PR DESCRIPTION
https://bugzilla.suse.com/show_bug.cgi?id=1116511 Fix manila-manage log ownership and restart services.
https://bugzilla.suse.com/show_bug.cgi?id=1116079 Enhance running sequence of playbooks to install manila