### PR TITLE
Manila requires restart after reconfiguration

### DIFF
--- a/xml/installation-ardana-manila.xml
+++ b/xml/installation-ardana-manila.xml
@@ -70,6 +70,10 @@
 &prompt.ardana;ansible-playbook -i hosts/verb_hosts ardana-gen-hosts-file.yml
 &prompt.ardana;ansible-playbook -i hosts/verb_hosts FND-CLU-reconfigure.yml
 &prompt.ardana;ansible-playbook -i hosts/verb_hosts ardana-reconfigure.yml</screen>
+    If &o_sharefs; has already been installed but is being reconfigured run the following for
+    the changes to take effect:
+<screen>&prompt.ardana;ansible-playbook -i hosts/verb_hosts manila-stop.yml
+ &prompt.ardana;ansible-playbook -i hosts/verb_hosts manila-start.yml</screen>
    </step>
    <step>
     <para>


### PR DESCRIPTION
If manila has already been installed and is being reconfigured, the service needs to be explicitly restarted.