### PR TITLE
update netapp manila with DHSS=False & troubleshoot sections (bsc#1118201)

### DIFF
--- a/xml/installation-ardana-manila.xml
+++ b/xml/installation-ardana-manila.xml
@@ -241,7 +241,8 @@ openstack-manila-share openstack-manila-scheduler
   </procedure>
   <para>
    Mode 2: The back-end is <literal>NetApp</literal>,
-   <literal>driver_handles_share_servers = True</literal> (DHSS is enabled).
+   <literal>driver_handles_share_servers = True</literal> (DHSS is enabled). 
+   Procedure for driver_handles_share_servers = False is similar to Mode 1.
   </para>
   <procedure>
    <step>
@@ -304,42 +305,17 @@ default_share_type = default1</screen>
  </section>
  <section>
   <title>Troubleshooting</title>
-<!-- As of 2018-10-31 there has not been a successful demo of Manila with
-       NetApp back-end. Thus this Troubleshooting section may be changed.  -->
   <para>
    If manila-list shows share status in error, use <literal>storage aggregate
-   show</literal> to list available aggregates. Different errors that may be
-   shown in <filename>/var/log/manila/manila-share.log</filename>
+   show</literal> to list available aggregates. Errors may be found in 
+   <filename>/var/log/manila/manila-share.log</filename>
   </para>
-  <variablelist>
-   <varlistentry>
-    <term>NaApiError: NetApp API failed.</term>
-    <listitem>
-     <para>
-      Reason - 15675:Cannot provision volume <literal>root</literal> on root
-      aggregate. Provisioning a volume on a root aggregate is not supported.
-     </para>
-    </listitem>
-   </varlistentry>
-   <varlistentry>
-    <term>If aggregate = <replaceable>NODE1_data</replaceable></term>
-    <listitem>
-     <para>
-      Exception during message handling: NetAppException: Failed to create VLAN
-      on <replaceable>PORT</replaceable>
-     </para>
-    </listitem>
-   </varlistentry>
-   <varlistentry>
-    <term>If aggregate = <replaceable>NODE2_data</replaceable></term>
-    <listitem>
-     <para>
-      NetAppException: Failed to create a route to 0.0.0.0/0 via gateway None:
-      Invalid value specified for <literal>gateway</literal> element within
-      <literal>net-routes-create</literal>
-     </para>
-    </listitem>
-   </varlistentry>
-  </variablelist>
+  <para>
+   if the compute nodes does not have access to manila back-end server, use the 
+   manila-share service on controller nodes instead. You can do so by either running
+   <literal>sudo systemctl stop openstack-manila-share</literal> on compute to turn off
+   its share service or skipping adding "manila-share" to compute hosts in the input-model 
+   (<filename>control_plane.yml</filename> in /var/lib/ardana/openstack/my_cloud/definition/data).
+  </para> 
  </section>
 </chapter>

--- a/xml/installation-ardana-manila.xml
+++ b/xml/installation-ardana-manila.xml
@@ -311,7 +311,7 @@ default_share_type = default1</screen>
    <filename>/var/log/manila/manila-share.log</filename>
   </para>
   <para>
-   if the compute nodes does not have access to manila back-end server, use the 
+   if the compute nodes do not have access to manila back-end server, use the 
    manila-share service on controller nodes instead. You can do so by either running
    <literal>sudo systemctl stop openstack-manila-share</literal> on compute to turn off
    its share service or skipping adding "manila-share" to compute hosts in the input-model 


### PR DESCRIPTION
This patch updates the doc with manila netapp installation steps with DHSS=False mode. It also adds a troubleshooting section that states what to do if compute does not have outside access to netapp servers.