### PR TITLE
Remove the statement about LDAP connection pool (bsc#11188198)

### DIFF
--- a/xml/operations-configuring-identity-identity_ldap.xml
+++ b/xml/operations-configuring-identity-identity_ldap.xml
@@ -78,14 +78,6 @@
    migrating to the Database store method via the identity service manager
    utility are provided as follows.
   </para>
-  <important>
-   <para>
-    We do not support enabling LDAP connection pool (that is,
-    <literal>use_pool: True</literal>) due
-    to an upstream bug. The <literal>use_pool</literal> parameter
-    must be present and must set to <literal>False</literal>.
-   </para>
-  </important>
  </section>
  <section xml:id="filestore">
   <title>Set up domain-specific driver configuration - file store</title>


### PR DESCRIPTION
It is no longer applicable to Cloud 9.