### PR TITLE
Drop troubleshot section about config snippets

### DIFF
--- a/xml/depl_troubleshooting.xml
+++ b/xml/depl_troubleshooting.xml
@@ -834,52 +834,6 @@ EOF</screen>
      </answer>
     </qandaentry>
 
-    <qandaentry xml:id="sec.depl.trouble.faq.misc.change_openstack_config">
-     <question>
-      <para>
-       How to add or change a configuration value for an &ostack; service?
-      </para>
-     </question>
-     <answer>
-       <para>
-         Most of the &ostack; services (the ones that use the 
-         <literal>oslo.config library</literal>) support configuration snippet 
-         files to adjust the available configuration per service. This can be 
-         done without the need to change a &chef; cookbook. The main service 
-         configuration 
-         (<filename>/etc/<replaceable>$project</replaceable>/<replaceable>$project.conf</replaceable></filename>)
-         can still be used for configuration, but the preferred way is to add
-         config file snippets into 
-         <filename>/etc/<replaceable>$project</replaceable>/<replaceable>$project</replaceable>.conf.d/</filename>
-         instead. The default configuration file created by &crow; is usually
-         <filename>/etc/<replaceable>$project</replaceable>/<replaceable>$project</replaceable>.conf.d/100-<replaceable>$project</replaceable>.conf</filename>. To
-         override a configuration value (let's say for &o_comp;), proceed as follows:
-      </para>
-      <procedure>
-       <step>
-        <para>
-          Create a config file snippet under <filename>/etc/nova/nova.conf.d/500-myconfig.conf</filename>.
-          The .conf files are lexically sorted so it is important that the
-          config snippet file is sorted after the default configuration file
-          (the last configured key overwrites all previous ones).
-        </para>
-       </step>
-       <step>
-         <para>
-           Add your configuration sections and options to the created config
-           snippet file <filename>/etc/nova/nova.conf.d/500-myconfig.conf</filename>
-        </para>
-       </step>
-       <step>
-        <para>
-          Restart the &o_comp; service(s) where the configuration change should apply:
-        </para>
-        <screen>systemctl restart openstack-nova-compute</screen>
-       </step>
-      </procedure>
-     </answer>
-    </qandaentry>
-
     <!-- fs 2016-01-15:
         can be configured in the VNC part in Nova barclamp with >= SOC 6
         (bsc #956682)


### PR DESCRIPTION
This reverts b5bb2cd09923d019d9a8754c2e804974af548eaf because there is
already a section about configuration snippets. See
http://docserv.nue.suse.com/documents/SUSE_OpenStack_Cloud_9/suse-openstack-cloud-deployment/single-html/#cha.depl.ostack.configs