### PR TITLE
Renaming the deployment guide to include Crowbar

### DIFF
--- a/DC-suse-openstack-cloud-deployment
+++ b/DC-suse-openstack-cloud-deployment
@@ -1,6 +1,6 @@
 ## ----------------------------------------
 ## Doc Config File for SUSE OpenStack Cloud
-## Deployment Guide Crowbar
+## Deployment Guide using Crowbar
 ## ----------------------------------------
 
 ## Basics

--- a/DC-suse-openstack-cloud-deployment
+++ b/DC-suse-openstack-cloud-deployment
@@ -1,6 +1,6 @@
 ## ----------------------------------------
-## Doc Config File for SUSE OpenStack Cloud 
-## Deployment Guide
+## Doc Config File for SUSE OpenStack Cloud
+## Deployment Guide Crowbar
 ## ----------------------------------------
 
 ## Basics

--- a/xml/book_cloud_deploy.xml
+++ b/xml/book_cloud_deploy.xml
@@ -7,7 +7,7 @@
 <!-- Converted by suse-upgrade version 1.1 -->
 <book xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.0" xml:lang="en" xml:id="book.deployment">
  <info>
-  <title>&clouddeploy;</title><productname>&productname;</productname>
+  <title>Deployment Guide (Crowbar)</title><productname>&productname;</productname>
   <productnumber>&productnumber;</productnumber><date>
 <?dbtimestamp format="B d, Y"?></date>
   <xi:include href="copyright_suse_cloud.xml"/>

--- a/xml/book_cloud_deploy.xml
+++ b/xml/book_cloud_deploy.xml
@@ -7,7 +7,7 @@
 <!-- Converted by suse-upgrade version 1.1 -->
 <book xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.0" xml:lang="en" xml:id="book.deployment">
  <info>
-  <title>Deployment Guide (Crowbar)</title><productname>&productname;</productname>
+  <title>&clouddeploy; (&crow;)</title><productname>&productname;</productname>
   <productnumber>&productnumber;</productnumber><date>
 <?dbtimestamp format="B d, Y"?></date>
   <xi:include href="copyright_suse_cloud.xml"/>

--- a/xml/book_cloud_deploy.xml
+++ b/xml/book_cloud_deploy.xml
@@ -14,9 +14,9 @@
   <xi:include href="authors.xml"/>
  <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
      <dm:bugtracker>
-       <dm:assignee>fs@suse.com</dm:assignee>
+       <dm:assignee>dpopov@suse.com</dm:assignee>
      </dm:bugtracker>
-     <dm:maintainer>fs</dm:maintainer>
+     <dm:maintainer>asettle</dm:maintainer>
      <dm:status>editing</dm:status>
      <dm:deadline/>
      <dm:priority/>


### PR DESCRIPTION
Changes "Deployment Guide" to "Deployment Guide (Crowbar)"