### PR TITLE
Changing the entity file for Deployment Guide using Crowbar

### DIFF
--- a/xml/book_cloud_deploy.xml
+++ b/xml/book_cloud_deploy.xml
@@ -14,9 +14,9 @@
   <xi:include href="authors.xml"/>
  <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
      <dm:bugtracker>
-       <dm:assignee>fs@suse.com</dm:assignee>
+       <dm:assignee>dpovov@suse.com</dm:assignee>
      </dm:bugtracker>
-     <dm:maintainer>fs</dm:maintainer>
+     <dm:maintainer>asettle</dm:maintainer>
      <dm:status>editing</dm:status>
      <dm:deadline/>
      <dm:priority/>

--- a/xml/entity-decl.ent
+++ b/xml/entity-decl.ent
@@ -181,7 +181,7 @@ suggested official replacement from rsalevsky. -->
 
 <!-- SOC -->
 
-<!ENTITY clouddeploy    "<citetitle xmlns='http://docbook.org/ns/docbook'>Deploying With &crow;</citetitle>">
+<!ENTITY clouddeploy    "<citetitle xmlns='http://docbook.org/ns/docbook'>Deployment Guide using &crow;</citetitle>">
 <!ENTITY cloudadmin     "<citetitle xmlns='http://docbook.org/ns/docbook'>Administrator Guide</citetitle>">
 <!ENTITY clouduser      "<citetitle xmlns='http://docbook.org/ns/docbook'>End User Guide</citetitle>">
 <!ENTITY cloudsuppl     "<citetitle xmlns='http://docbook.org/ns/docbook'>Supplement to &cloudadmin; and &clouduser;</citetitle>">


### PR DESCRIPTION
This PR changes the entity declaration for "clouddeploy" so that it no longer says "Deploying With &crow;" but rather, "Deployment Guide using &crow;". This is because we are updating the name of the Deployment guide and will infer a more permanent change than simply updating the book file.
This PR also updates the Cloud owners to myself and Dmitri Popov. 