### PR TITLE
Fix Apache directions for Glance on SUSE

### DIFF
--- a/xml/admin-glance.xml
+++ b/xml/admin-glance.xml
@@ -787,13 +787,8 @@ delete = context_is_admin]]></screen>
                 other services too) and just need to restart the local uwsgi daemon.</para>
           <para>The <literal>httpd/</literal> directory contains sample files for configuring HTTPD to run Glance
                 under uwsgi in this configuration. To use the sample configs simply copy
-                <literal>httpd/uwsgi-glance-api.conf</literal> to the appropriate location for your Apache
-                server.</para>
+                <literal>httpd/uwsgi-glance-api.conf</literal> to <literal>/etc/apache2/vhosts.d</literal></para>
           <para>Enable <literal>mod_proxy</literal> by running <literal>sudo a2enmod proxy</literal>.</para>
-          <para>Then on Ubuntu/Debian systems enable the site by creating a symlink from the
-                file in <literal>sites-available</literal> to <literal>sites-enabled</literal>. (This is not required on Red
-                Hat based systems):</para>
-          <screen><![CDATA[ln -s /etc/apache2/sites-available/uwsgi-glance-api.conf /etc/apache2/sites-enabled]]></screen>
           <para>Start or restart HTTPD to pick up the new configuration.</para>
           <para>Now we need to configure and start the uwsgi service. Copy the
                 <literal>httpd/glance-api-uwsgi.ini</literal> file to <literal>/etc/glance</literal>. Update the file to match


### PR DESCRIPTION
On SUSE systems the Apache virtualhost configuration is located in
/etc/apache2/vhosts.d/*.conf and there is no need to create a symlink.
The directions regarding enabling the mod_proxy module using a2enmod
still apply.