### PR TITLE
Rename “Installing with CLM” to “Deployment Guide using CLM”

### DIFF
--- a/xml/entity-decl.ent
+++ b/xml/entity-decl.ent
@@ -186,7 +186,7 @@ suggested official replacement from rsalevsky. -->
 <!ENTITY socmover       "<citetitle xmlns='http://docbook.org/ns/docbook'>Overview</citetitle>">
 <!ENTITY socmmsop       "<citetitle xmlns='http://docbook.org/ns/docbook'>Monitoring Service Operator's Guide</citetitle>">
 <!ENTITY socmosop       "<citetitle xmlns='http://docbook.org/ns/docbook'>&ostack; Operator's Guide</citetitle>">
-<!ENTITY soclcminstall  "<citetitle xmlns='http://docbook.org/ns/docbook'>Installing with &lcm;</citetitle>">
+<!ENTITY soclcminstall  "<citetitle xmlns='http://docbook.org/ns/docbook'>Deployment Guide using &lcm;</citetitle>">
 <!ENTITY rhel-install  "<citetitle xmlns='http://docbook.org/ns/docbook'>Installing &rhla;</citetitle>">
 <!ENTITY soclcmplan     "<citetitle xmlns='http://docbook.org/ns/docbook'>Planning an Installation with &lcm;</citetitle>">
 


### PR DESCRIPTION
This PR changes the entity declaration for "soclcminstall" so that it no longer says "Installing with &lcm;" but rather, "Deployment Guide using &lcm;". This is because we are updating the name of the Deployment guide and will infer a more permanent change than simply updating the book file.