### PR TITLE
Remove references to diskimage-builder

### DIFF
--- a/xml/admin-ironic.xml
+++ b/xml/admin-ironic.xml
@@ -862,8 +862,8 @@ openstack flavor set --property "capabilities:boot_option"="netboot" ironic-flav
                 PXE-less deployment by using iLO virtual media to boot up the bare metal node.
                 These drivers send management info through the management channel and separate
                 it from the data channel which is used for deployment.</para>
-                <para><literal>iscsi_ilo</literal> and <literal>agent_ilo</literal> drivers use deployment ramdisk
-                built from <literal>diskimage-builder</literal>. The <literal>iscsi_ilo</literal> driver deploys from
+                <para><literal>iscsi_ilo</literal> and <literal>agent_ilo</literal> drivers use deployment ramdisk.
+                The <literal>iscsi_ilo</literal> driver deploys from
                 ironic conductor and supports both net-boot and local-boot of instance.
                 <literal>agent_ilo</literal> deploys from bare metal node and supports both net-boot
                 and local-boot of instance.</para>
@@ -1941,13 +1941,7 @@ nova boot --flavor ironic-test-3 --image test-image instance-1</screen>
                             machine that matches with user specified flavors.</para>
                     </listitem>
                   </itemizedlist>
-                  <para>The automatic boot ISO creation for UEFI boot mode has been enabled in Kilo.
-                    The manual creation of boot ISO for UEFI boot mode is also supported.
-                    For the latter, the boot ISO for the deploy image needs to be built
-                    separately and the deploy image’s <literal>boot_iso</literal> property in glance should
-                    contain the glance UUID of the boot ISO. For building boot ISO, add <literal>iso</literal>
-                    element to the diskimage-builder command to build the image. For example:</para>
-                  <screen>disk-image-create ubuntu baremetal iso</screen>
+                  <para>The automatic boot ISO creation for UEFI boot mode has been enabled in Kilo.</para>
                 </section>
                 <section xml:id="ilo-uefi-secure-boot-support">
                   <title>UEFI Secure Boot Support</title>
@@ -1979,15 +1973,6 @@ nova boot --flavor ironic-test-3 --image test-image instance-1</screen>
                     specified flavors but deployment would not use its secure boot capability.
                     Secure boot deploy would happen only when it is explicitly specified through
                     flavor.</para>
-                  <para>Use element <literal>suse</literal> to build signed deploy iso and
-                    user images from the <link
-		      xlink:href="https://build.opensuse.org/">openSUSE Build Service</link>.
-                    Refer to <link xlink:href="https://docs.openstack.org/ironic/pike/install/deploy-ramdisk.html#deploy-ramdisk">Building or downloading a deploy ramdisk image</link>
-                    for more information on building deploy ramdisk.</para>
-                  <para>The below command creates files named <literal>cloud-image-boot.iso</literal>, <literal>cloud-image.initrd</literal>,
-                    <literal>cloud-image.vmlinuz</literal> and <literal>cloud-image.qcow2</literal> in the current working directory:</para>
-                  <screen>cd &lt;path-to-diskimage-builder&gt;
-./bin/disk-image-create -o cloud-image ubuntu-signed baremetal iso</screen>
                   <note>
                     <para>In UEFI secure boot, digitally signed bootloader should be able to validate
                         digital signatures of kernel during boot process. This requires that the
@@ -2049,8 +2034,7 @@ nova boot --flavor ironic-test-3 --image test-image instance-1</screen>
                                         An inband clean step that performs disk erase on all the disks including
                                         the disks visible to OS as well as the raw disks visible to Smart
                                         Storage Administrator (SSA). This step supports erasing of the raw disks
-                                        visible to SSA in Proliant servers only with the ramdisk created using
-                                        <literal>diskimage-builder</literal> from Ocata release. By default, this step is disabled.
+                                        visible to SSA in Proliant servers only with the ramdisk. By default, this step is disabled.
                                         See <xref linkend="disk-erase-support"/> for more details.</para>
                           </listitem>
                         </itemizedlist>
@@ -2701,12 +2685,6 @@ nova flavor-key my-baremetal-flavor set capabilities:has_ssd="true"</screen>
 nova boot --flavor ironic-test --image test-image instance-1</screen>
                     </listitem>
                   </itemizedlist>
-                  <section xml:id="dib-raid-support">
-                    <title>DIB support for Proliant Hardware Manager</title>
-                    <para>To create an agent ramdisk with <literal>Proliant Hardware Manager</literal>,
-                        use the <literal>proliant-tools</literal> element in DIB:</para>
-                    <screen>disk-image-create -o proliant-agent-ramdisk ironic-agent fedora proliant-tools</screen>
-                  </section>
                 </section>
                 <section xml:id="disk-erase-support">
                   <title>Disk Erase Support</title>
@@ -2728,11 +2706,6 @@ nova boot --flavor ironic-test --image test-image instance-1</screen>
                     This clean step is performed as part of automated cleaning and it is disabled
                     by default. See <xref linkend="inbandvsoutofbandcleaning"/> for more information on
                     enabling or disabling a clean step.</para>
-                  <para>To create an agent ramdisk with <literal>Proliant Hardware Manager</literal>, use the
-                    <literal>proliant-tools</literal> element in DIB:</para>
-                  <screen>disk-image-create -o proliant-agent-ramdisk ironic-agent fedora proliant-tools</screen>
-                  <para>See the <link xlink:href="https://docs.openstack.org/diskimage-builder/latest/elements/proliant-tools/README.html">proliant-tools</link> for more information on creating agent ramdisk with
-                    <literal>proliant-tools</literal> element in DIB.</para>
                 </section>
               </section>
             </section>


### PR DESCRIPTION
In general, the default ramdisk image that we provide as part of the
product should be sufficient and customers should not need to build
their own ramdisk, nor should they have to create a special boot ISO
image because automatic boot ISO creation should work on its own. This
change removes the instructions to create a special image for Proliant
support since our ramdisk image has that built in, and removes
references to the manual boot ISO creation. Additionally clean up other
unnecessary references to DIB.

In the future, we should come up with a cohesive story around allowing
users to customize their own images using either Kiwi or
diskimage-builder and a freely distributed base image in OBS.