### PR TITLE
Adding XML ID to fix package failures

### DIFF
--- a/xml/bk_openstack-admin-guide.xml
+++ b/xml/bk_openstack-admin-guide.xml
@@ -9,7 +9,7 @@
   %entities;
 ]>
 
-<book xml:lang="en" xmlns="http://docbook.org/ns/docbook"
+<book xml:id="book.upstream-admin" xml:lang="en" xmlns="http://docbook.org/ns/docbook"
       xmlns:xi="http://www.w3.org/2001/XInclude" version="5.1">
  <title>&ostack; Administrator Guide</title>
  <info>


### PR DESCRIPTION
The _documentation-suse-openstack-cloud_ package is currently failing as the upstream-admin guide did not have an ID correctly assigned to the build. This fixes that issue.