### PR TITLE
Add references to DIB back to guide

### DIFF
--- a/xml/admin-ironic.xml
+++ b/xml/admin-ironic.xml
@@ -1941,7 +1941,14 @@ nova boot --flavor ironic-test-3 --image test-image instance-1</screen>
                             machine that matches with user specified flavors.</para>
                     </listitem>
                   </itemizedlist>
-                  <para>The automatic boot ISO creation for UEFI boot mode has been enabled in Kilo.</para>
+                  <para>The automatic boot ISO creation for UEFI boot mode has been enabled in Kilo.
+                    The manual creation of boot ISO for UEFI boot mode is also possible, but note that it is not officially supported.
+                    For the latter, the boot ISO for the deploy image needs to be built
+                    separately and the deploy image’s <literal>boot_iso</literal> property in glance should
+                    contain the glance UUID of the boot ISO. For building boot ISO, add the <literal>iso</literal>
+                    element to the <link xlink:href="https://pypi.python.org/pypi/diskimage-builder">diskimage-builder</link>
+                    command to build the image. For example:</para>
+￼                   <screen>disk-image-create ubuntu baremetal iso</screen>
                 </section>
                 <section xml:id="ilo-uefi-secure-boot-support">
                   <title>UEFI Secure Boot Support</title>
@@ -1973,6 +1980,14 @@ nova boot --flavor ironic-test-3 --image test-image instance-1</screen>
                     specified flavors but deployment would not use its secure boot capability.
                     Secure boot deploy would happen only when it is explicitly specified through
                     flavor.</para>
+                  <para>You may use element <literal>ubuntu-signed</literal> or <literal>fedora</literal> to build signed deploy iso and
+                    user images with <link xlink:href="https://pypi.python.org/pypi/diskimage-builder">diskimage-builder</link>, but note that custom images are not officially supported.
+                    Refer to <link xlink:href="https://docs.openstack.org/ironic/pike/install/deploy-ramdisk.html#deploy-ramdisk">Building or downloading a deploy ramdisk image</link>
+                    for more information on building deploy ramdisk.</para>
+￼                   <para>The below command creates files named <literal>cloud-image-boot.iso</literal>, <literal>cloud-image.initrd</literal>,
+￼                     <literal>cloud-image.vmlinuz</literal> and <literal>cloud-image.qcow2</literal> in the current working directory:</para>
+￼                   <screen>cd &lt;path-to-diskimage-builder&gt;
+￼ ./bin/disk-image-create -o cloud-image ubuntu-signed baremetal iso</screen>
                   <note>
                     <para>In UEFI secure boot, digitally signed bootloader should be able to validate
                         digital signatures of kernel during boot process. This requires that the
@@ -2706,6 +2721,11 @@ nova boot --flavor ironic-test --image test-image instance-1</screen>
                     This clean step is performed as part of automated cleaning and it is disabled
                     by default. See <xref linkend="inbandvsoutofbandcleaning"/> for more information on
                     enabling or disabling a clean step.</para>
+                  <para>To create an agent ramdisk with <literal>Proliant Hardware Manager</literal> with disk erase support, use the
+￼                   <literal>proliant-tools</literal> element in DIB:</para>
+￼                 <screen>disk-image-create -o proliant-agent-ramdisk ironic-agent fedora proliant-tools</screen>
+￼                 <para>See the <link xlink:href="https://docs.openstack.org/diskimage-builder/latest/elements/proliant-tools/README.html">proliant-tools</link> for more information on creating agent ramdisk with
+￼                   <literal>proliant-tools</literal> element in DIB.</para>
                 </section>
               </section>
             </section>


### PR DESCRIPTION
This partially reverts #761. It's not forbidden to mention
diskimage-builder or other freely licensed distros, so long as we call
out that special customizations to ramdisk images or boot ISOs can't be
supported. This also corrects an error that #761 had removed, which
called out 'suse' as a DIB element. 'suse' is not an element available
in DIB (it's 'opensuse'), and moreover the section called for a special
'-signed' element which is not available for opensuse, so we need to
reference the 'ubuntu-signed' element.