### PR TITLE
Fixing broken ref

### DIFF
--- a/xml/operations-troubleshooting-recover_rabbit.xml
+++ b/xml/operations-troubleshooting-recover_rabbit.xml
@@ -8,7 +8,7 @@
  <para>
   &rabbit; is the message queue service that runs on each of your controller
   nodes and brokers communication between multiple services in your
-  &product; cloud environment. It is important for cloud operators to
+  &productname; cloud environment. It is important for cloud operators to
   understand how different troubleshooting scenarios affect &rabbit; so they
   can minimize downtime in their environments. We are going to discuss multiple
   scenarios and how it affects &rabbit;. We will also explain how you can


### PR DESCRIPTION
The package build was broken due to the wrong ref being implemented. This PR changes that.

See error logs: https://ci.suse.de/view/Cloud/view/Meta/job/cloud-trackupstream/component=documentation-suse-openstack-cloud,label=openstack-trackupstream,project=Devel%3ACloud%3A8%3AStaging/1826/console