### PR TITLE
Migrating cloud admin and user guide to ops guide

### DIFF
--- a/xml/book.operations.xml
+++ b/xml/book.operations.xml
@@ -10,17 +10,12 @@
  <info>
   <abstract>
    <para>
-    This guide provides a list of useful procedures for managing your
-    &product; cloud. The audience is the admin-level operator of the
-    cloud.
+     At the time of the &productname; &productnumber; release, this guide
+     contains information pertaining to the operations,
+     administration, and user functions of &productname;.
+     The audience is the admin-level operator of the cloud.
    </para>
-   <important>
-     <para>
-       At the time of the &productname; &productnumber; release, this guide
-       contains information pertaining to the operations,
-       administration, and user functions of &productname;.
-     </para>
-   </important>
+
   </abstract>
  </info>
  <xi:include href="operations-operations_overview.xml"/>

--- a/xml/book.operations.xml
+++ b/xml/book.operations.xml
@@ -11,7 +11,7 @@
   <abstract>
    <para>
      At the time of the &productname; &productnumber; release, this guide
-     contains information pertaining to the operations,
+     contains information pertaining to the operation,
      administration, and user functions of &productname;.
      The audience is the admin-level operator of the cloud.
    </para>

--- a/xml/book.operations.xml
+++ b/xml/book.operations.xml
@@ -14,6 +14,13 @@
     &product; cloud. The audience is the admin-level operator of the
     cloud.
    </para>
+   <important>
+     <para>
+       At the time of the &productname; &productnumber; release, this guide
+       contains information pertaining to the operations,
+       administration, and user functions of &productname;.
+     </para>
+   </important>
   </abstract>
  </info>
  <xi:include href="operations-operations_overview.xml"/>
@@ -29,6 +36,7 @@
  <xi:include href="operations-managing_dashboards.xml"/>
  <xi:include href="operations-managing_orchestration.xml"/>
  <xi:include href="operations-managing_telemetry.xml"/>
+ <xi:include href="operations-managing_magnum.xml"/>
  <xi:include href="operations-maintenance-system_maintenance.xml"/>
  <xi:include href="operations-managing-ops-console.xml"/>
  <xi:include href="bura-bura_overview.xml"/>

--- a/xml/networking-create-ha-router.xml
+++ b/xml/networking-create-ha-router.xml
@@ -1,8 +1,11 @@
 <?xml version="1.0"?>
+<?xml-stylesheet href="urn:x-suse:xslt:profiling:docbook51-profile.xsl"
+ type="text/xml"
+ title="Profiling step"?>
 <!DOCTYPE section [
- <!ENTITY % entities SYSTEM "entities.ent"> %entities;
+ <!ENTITY % entities SYSTEM "entity-decl.ent"> %entities;
 ]>
-<!---->
+
 <section xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude"
   xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="CreateHARouter">
  <title>Creating a Highly Available Router</title>
@@ -11,7 +14,7 @@
   <para>
    CVR (Centralized Virtual Routing) and DVR (Distributed Virtual Routing) are
    two types of technologies which can be used to provide routing processes in
-   &kw-hos-phrase;. You can create Highly Available (HA) versions of CVR and
+   &productname; &productnumber;. You can create Highly Available (HA) versions of CVR and
    DVR routers by using the options in the table below when creating your
    router.
   </para>

--- a/xml/networking-create-ha-router.xml
+++ b/xml/networking-create-ha-router.xml
@@ -1,0 +1,157 @@
+<?xml version="1.0"?>
+<!DOCTYPE section [
+ <!ENTITY % entities SYSTEM "entities.ent"> %entities;
+]>
+<!---->
+<section xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude"
+  xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="CreateHARouter">
+ <title>Creating a Highly Available Router</title>
+ <section xml:id="CVRDVR">
+  <title>CVR and DVR High Available Routers</title>
+  <para>
+   CVR (Centralized Virtual Routing) and DVR (Distributed Virtual Routing) are
+   two types of technologies which can be used to provide routing processes in
+   &kw-hos-phrase;. You can create Highly Available (HA) versions of CVR and
+   DVR routers by using the options in the table below when creating your
+   router.
+  </para>
+  <para>
+   The neutron command for creating a router <literal>neutron router-create
+   router_name --distributed=True|False --ha=True|False</literal> requires
+   administrative permissions. See the example in the next section, Creating a
+   High Availability Router.
+  </para>
+  <informaltable colsep="1" rowsep="1">
+   <tgroup cols="4" align="center">
+    <colspec colname="c1" colnum="1" colwidth="1.28*"/>
+    <colspec colname="c2" colnum="2" colwidth="1*"/>
+    <colspec colname="c3" colnum="3" colwidth="1.45*"/>
+    <colspec colname="c4" colnum="4" colwidth="4.68*" align="left"/>
+    <thead>
+     <row>
+      <entry>--distributed</entry>
+      <entry>--ha</entry>
+      <entry>Router Type</entry>
+      <entry>Description</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>False</entry>
+      <entry>False</entry>
+      <entry>CVR</entry>
+      <entry>Centralized Virtual Router</entry>
+     </row>
+     <row>
+      <entry>False</entry>
+      <entry>True</entry>
+      <entry>CVRHA</entry>
+      <entry>Centralized Virtual Router with L3 High Availablity</entry>
+     </row>
+     <row>
+      <entry>True</entry>
+      <entry>False</entry>
+      <entry>DVR</entry>
+      <entry>Distributed Virtual Router without SNAT High Availability</entry>
+     </row>
+     <row>
+      <entry>True</entry>
+      <entry>True</entry>
+      <entry>DVRHA</entry>
+      <entry>Distributed Virtual Router with SNAT High Availability</entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
+ </section>
+ <section xml:id="CreateRouter">
+  <title>Creating a High Availability Router</title>
+  <para>
+   You can create a highly available router using the neutron command line
+   interface.
+  </para>
+  <orderedlist>
+   <listitem>
+    <para>
+     To create the HA router simply add <literal>--ha=True</literal> to the
+     neutron router-create command. If you want to also make the router
+     distributed, add <literal>--distributed=True</literal>. In this example, a
+     DVR SNAT HA router is created with the name <literal>routerHA</literal>.
+    </para>
+<screen>$ neutron router-create routerHA --distributed=True --ha=True</screen>
+   </listitem>
+   <listitem>
+    <para>
+     Set the gateway for the external network and add interface
+    </para>
+<screen>$ neutron router-gateway-set routerHA &lt;ext-net-id&gt;
+$ neutron router-interface-add routerHA &lt;private_subnet_id&gt;</screen>
+   </listitem>
+   <listitem>
+    <para>
+     Once the router is created, gateway set and interface attached, you now
+     have a router with high availability.
+    </para>
+   </listitem>
+  </orderedlist>
+ </section>
+ <section xml:id="TestRouter">
+  <title>Test Router for High Availability</title>
+  <para>
+   You can demonstrate that the router is HA by running a continuous ping from
+   a VM instance that is running on the private network to an external server
+   such as a public DNS. As the ping is running, list the l3 agents hosting the
+   router and identify the agent that is responsible for hosting the active
+   router. Induce the failover mechanism by creating a catastrophic event like
+   shutting down node hosting the l3 agent. Once the node is shut down, you
+   will see that the ping from the VM to the external network continues to run
+   as the backup l3 agent takes over. To verify the agent hosting the primary
+   router has changed, list the agents hosting the router. You will see a
+   different agent is now hosting the active router.
+  </para>
+  <orderedlist>
+   <listitem>
+    <para>
+     Boot an instance on the private network
+    </para>
+<screen>$ nova boot --image &lt;image_id&gt; --flavor &lt;flavor_id&gt; --nic net_id=&lt;private_net_id&gt; --key_name &lt;key&gt; VM1</screen>
+   </listitem>
+   <listitem>
+    <para>
+     Log into the VM using the ssh keys
+    </para>
+<screen>ssh -i &lt;key&gt; &lt;ipaddress of VM1&gt;</screen>
+   </listitem>
+   <listitem>
+    <para>
+     Start a ping to X.X.X.X. While pinging, make sure there is no packet loss
+     and leave the ping running.
+    </para>
+<screen>$ ping X.X.X.X</screen>
+   </listitem>
+   <listitem>
+    <para>
+     Check which agent is hosting the active router
+    </para>
+<screen>$ neutron l3-agent-list-hosting-router &lt;router_id&gt;</screen>
+   </listitem>
+   <listitem>
+    <para>
+     Shutdown the node hosting the agent.
+    </para>
+   </listitem>
+   <listitem>
+    <para>
+     Within 10 seconds, check again to see which L3 agent is hosting the active
+     router
+    </para>
+<screen>$ neutron l3-agent-list-hosting-router &lt;router_id&gt;</screen>
+   </listitem>
+   <listitem>
+    <para>
+     You will see a different agent.
+    </para>
+   </listitem>
+  </orderedlist>
+ </section>
+</section>

--- a/xml/operations-configure_firewall.xml
+++ b/xml/operations-configure_firewall.xml
@@ -5,6 +5,7 @@
 <!DOCTYPE section [
  <!ENTITY % entities SYSTEM "entity-decl.ent"> %entities;
 ]>
+
 <section xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="topic_gll_nsn_15">
  <title>Using Firewall as a Service (FWaaS)</title>
  <para>
@@ -30,7 +31,6 @@
   traffic</emphasis> and will only filter traffic from external networks, also
   known as <emphasis>north-south traffic</emphasis>.
  </para>
-</section>
 <section>
  <title>Overview of the &productname; Firewall configuration</title>
  <para>
@@ -66,8 +66,9 @@
    optional and is tenant-configured.
   </para>
  </important>
+</section>
  <section xml:id="idg-all-networking-fwaas-xml-9">
-  <title>&kw-hos-phrase; FWaaS Configuration</title>
+  <title>&productname; &productnumber; FWaaS Configuration</title>
   <para>
    <emphasis role="bold">Check for an enabled firewall.</emphasis>
   </para>
@@ -303,9 +304,6 @@ $ ./webserv.sh</screen>
 <screen>$ neutron firewall-update —router &lt;router-1-id&gt; —router &lt;router-2-id&gt; &lt;firewall-name&gt;</screen>
   </warning>
  </section>
-
-
-
  <section xml:id="idg-all-operations-configure_firewall-xml-7">
   <title>Making Changes to the Firewall Rules</title>
   <orderedlist>

--- a/xml/operations-configure_firewall.xml
+++ b/xml/operations-configure_firewall.xml
@@ -6,7 +6,33 @@
  <!ENTITY % entities SYSTEM "entity-decl.ent"> %entities;
 ]>
 <section xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="topic_gll_nsn_15">
- <title>Configuring the &productname; Firewall</title>
+ <title>Using Firewall as a Service (FWaaS)</title>
+ <para>
+  The Firewall as a Service (FWaaS) provides the ability to assign
+  network-level, port security for all traffic entering and existing a tenant
+  network. More information on this service can be found via the public
+  OpenStack documentation located at
+  <link xlink:href="http://specs.openstack.org/openstack/neutron-specs/specs/api/firewall_as_a_service__fwaas_.html"/>.
+  The following documentation provides command-line interface example
+  instructions for configuring and testing a firewall. The Firewall as a
+  Service can also be configured and managed by the Horizon web interface.
+ </para>
+ <para>
+  FWaaS is implemented directly in the L3 agent
+  (<emphasis>neutron-l3-agent</emphasis>), however if VPNaaS is enabled, FWaaS
+  is implemented in the VPNaaS agent (<emphasis>neutron-vpn-agent</emphasis>).
+  Because FWaaS does not use a separate agent process or start a specific
+  service, there currently are no Monasca alarms for it.
+ </para>
+ <para>
+  If DVR is enabled, the firewall service currently does not filter traffic
+  between OpenStack private networks, also known as <emphasis>east-west
+  traffic</emphasis> and will only filter traffic from external networks, also
+  known as <emphasis>north-south traffic</emphasis>.
+ </para>
+</section>
+<section>
+ <title>Overview of the &productname; Firewall configuration</title>
  <para>
   The following instructions provide information about how to identify and
   modify the overall &productname; firewall that is configured in front of the
@@ -40,6 +66,246 @@
    optional and is tenant-configured.
   </para>
  </important>
+ <section xml:id="idg-all-networking-fwaas-xml-9">
+  <title>&kw-hos-phrase; FWaaS Configuration</title>
+  <para>
+   <emphasis role="bold">Check for an enabled firewall.</emphasis>
+  </para>
+  <orderedlist>
+   <listitem>
+    <para>
+     You should check to determine if the firewall is enabled. The output of
+     the <emphasis>neutron ext-list</emphasis> should contain a firewall entry.
+    </para>
+<screen>neutron ext-list</screen>
+   </listitem>
+   <listitem>
+    <para>
+     Assuming the external network is already created by the admin, this
+     command will show the external network.
+    </para>
+<screen>neutron net-list</screen>
+   </listitem>
+  </orderedlist>
+  <para>
+   <emphasis role="bold">Create required assets.</emphasis>
+  </para>
+  <para>
+   Before creating firewalls, you will need to create a network, subnet,
+   router, security group rules, start an instance and assign it a floating IP
+   address.
+  </para>
+  <orderedlist>
+   <listitem>
+    <para>
+     Create the network, subnet and router.
+    </para>
+<screen>neutron net-create private
+neutron subnet-create --name sub private 10.0.0.0/24 --gateway 10.0.0.1
+neutron router-create router
+neutron router-interface-add router sub
+neutron router-gateway-set router ext-net</screen>
+   </listitem>
+   <listitem>
+    <para>
+     Create security group rules. Security group rules filter traffic at VM
+     level.
+    </para>
+<screen>neutron security-group-rule-create default --protocol icmp
+neutron security-group-rule-create default --protocol tcp --port-range-min 22 --port-range-max 22
+neutron security-group-rule-create default --protocol tcp --port-range-min 80 --port-range-max 80</screen>
+   </listitem>
+   <listitem>
+    <para>
+     Boot a VM.
+    </para>
+<screen>NET=$(neutron net-list | awk '/private/ {print $2}')
+nova boot --flavor 1 --image &lt;image&gt; --nic net-id=$NET vm1 --poll</screen>
+   </listitem>
+   <listitem>
+    <para>
+     Verify if the instance is ACTIVE and is assigned an IP address.
+    </para>
+<screen>nova list</screen>
+   </listitem>
+   <listitem>
+    <para>
+     Get the port id of the vm1 instance.
+    </para>
+<screen>fixedip=$(nova list | awk '/vm1/ {print $12}' | awk -F '=' '{print $2}' | awk -F ',' '{print $1}')
+vmportuuid=$(neutron port-list | grep $fixedip | awk '{print $2}')</screen>
+   </listitem>
+   <listitem>
+    <para>
+     Create and associate a floating IP address to the vm1 instance.
+    </para>
+<screen>neutron floatingip-create ext-net --port-id $vmportuuid</screen>
+   </listitem>
+   <listitem>
+    <para>
+     Verify if the floating IP is assigned to the instance. The following
+     command should show an assigned floating IP address from the external
+     network range.
+    </para>
+<screen>nova show vm1</screen>
+   </listitem>
+   <listitem>
+    <para>
+     Verify if the instance is reachable from the external network. SSH into
+     the instance from a node in (or has route to) the external network.
+    </para>
+<screen>ssh cirros@FIP-VM1
+password: &lt;password&gt;</screen>
+   </listitem>
+  </orderedlist>
+  <para>
+   <emphasis role="bold">Create and attach the firewall.</emphasis>
+  </para>
+  <note>
+   <para>
+    By default, an internal "drop all" rule is enabled in IP tables if none of
+    the defined rules match the real-time data packets.
+   </para>
+  </note>
+  <orderedlist>
+   <listitem>
+    <para>
+     Create new firewall rules using <literal>firewall-rule-create</literal>
+     command and providing the protocol, action (allow, deny, reject) and name
+     for the new rule.
+    </para>
+    <para>
+     Firewall actions provide rules in which data traffic can be handled. An
+     <emphasis role="bold">allow</emphasis> rule will allow traffic to pass
+     through the firewall,
+     <emphasis role="bold">deny</emphasis>
+     will stop and prevent data traffic from passing through the firewall and
+     <emphasis role="bold">reject</emphasis>
+     will reject the data traffic and return a
+     <emphasis>destination-unreachable</emphasis> response. Using
+     <emphasis role="bold">reject</emphasis> will speed up failure detection
+     time dramatically for legitimate users, since they will not be required to
+     wait for retransmission timeouts or submit retries. Some customers should
+     stick with <emphasis role="bold">deny</emphasis> where prevention of port
+     scanners and similar methods may be attempted by hostile attackers. Using
+     <emphasis role="bold">deny</emphasis>
+     will drop all of the packets, making it more difficult for malicious
+     intent. The firewall action, <emphasis role="bold">deny</emphasis> is the
+     default behavior.
+    </para>
+    <para>
+     The example below demonstrates how to allow icmp and ssh while denying
+     access to http. See the <literal>neutron</literal> command-line reference
+     at <link xlink:href="http://docs.openstack.org/cli-reference/content/neutronclient_commands.html"/>
+     on additional options such as source IP, destination IP, source port and
+     destination port.
+    </para>
+    <note>
+     <para>
+      You can create a firewall rule with an identical name and each instance
+      will have a unique id associated with the created rule, however for
+      clarity purposes this is not recommended.
+     </para>
+    </note>
+<screen>neutron firewall-rule-create --protocol icmp --action allow --name allow-icmp
+neutron firewall-rule-create --protocol tcp --destination-port 80 --action deny --name deny-http
+neutron firewall-rule-create --protocol tcp --destination-port 22 --action allow --name allow-ssh</screen>
+   </listitem>
+   <listitem>
+    <para>
+     Once the rules are created, create the firewall policy by using the
+     <literal>firewall-policy-create</literal> command with the
+     <literal>--firewall-rules</literal> option and rules to include in quotes,
+     followed by the name of the new policy. The order of the rules is
+     important.
+    </para>
+<screen>neutron firewall-policy-create --firewall-rules "allow-icmp deny-http allow-ssh" policy-fw</screen>
+   </listitem>
+   <listitem>
+    <para>
+     Finish the firewall creation by using the
+     <literal>firewall-create</literal> command, the policy name and the new
+     name you want to give to your new firewall.
+    </para>
+<screen>neutron firewall-create policy-fw --name user-fw</screen>
+   </listitem>
+   <listitem>
+    <para>
+     You can view the details of your new firewall by using the
+     <literal>firewall-show</literal> command and the name of your firewall.
+     This will verify that the status of the firewall is ACTIVE.
+    </para>
+<screen>neutron firewall-show user-fw</screen>
+   </listitem>
+  </orderedlist>
+  <para>
+   <emphasis role="bold">Verify the FWaaS is functional.</emphasis>
+  </para>
+  <orderedlist>
+   <listitem>
+    <para>
+     Since allow-icmp firewall rule is set you can ping the floating IP address
+     of the instance from the external network.
+    </para>
+<screen>ping &lt;FIP-VM1&gt;</screen>
+   </listitem>
+   <listitem>
+    <para>
+     Similarly, you can connect via ssh to the instance due to the allow-ssh
+     firewall rule.
+    </para>
+<screen>ssh cirros@&lt;FIP-VM1&gt;
+password: &lt;password&gt;</screen>
+   </listitem>
+   <listitem>
+    <para>
+     Run a web server on vm1 instance that listens over port 80, accepts
+     requests and sends a WELCOME response.
+    </para>
+<screen>$ vi webserv.sh
+
+#!/bin/bash
+
+MYIP=$(/sbin/ifconfig eth0|grep 'inet addr'|awk -F: '{print $2}'| awk '{print $1}');
+while true; do
+  echo -e "HTTP/1.0 200 OK
+
+Welcome to $MYIP" | sudo nc -l -p 80
+done
+
+# Give it Exec rights
+$ chmod 755 webserv.sh
+
+# Execute the script
+$ ./webserv.sh</screen>
+   </listitem>
+   <listitem>
+    <para>
+     You should expect to see curl fail over port 80 because of the deny-http
+     firewall rule. If curl succeeds, the firewall is not blocking incoming
+     http requests.
+    </para>
+<screen>curl -vvv &lt;FIP-VM1&gt;</screen>
+   </listitem>
+  </orderedlist>
+  <warning>
+   <para>
+    When using reference implementation, new networks, FIPs and routers created
+    after the Firewall creation will not be automatically updated with firewall
+    rules. Thus, execute the firewall-update command by passing the current and
+    new router Ids such that the rules are reconfigured across all the routers
+    (both current and new).
+   </para>
+   <para>
+    For example if router-1 is created before and router-2 is created after the
+    firewall creation
+   </para>
+<screen>$ neutron firewall-update —router &lt;router-1-id&gt; —router &lt;router-2-id&gt; &lt;firewall-name&gt;</screen>
+  </warning>
+ </section>
+
+
+
  <section xml:id="idg-all-operations-configure_firewall-xml-7">
   <title>Making Changes to the Firewall Rules</title>
   <orderedlist>
@@ -113,6 +379,43 @@
   <para>
    You can repeat these steps as needed to add, remove, or edit any of these
    firewall rules.
+  </para>
+ </section>
+ <section xml:id="sec.hp20fwaas.more">
+  <title>More Information</title>
+  <para>
+   Firewalls are based in IPtable settings.
+  </para>
+  <para>
+   Each firewall that is created is known as an instance.
+  </para>
+  <para>
+   A firewall instance can be deployed on selected project routers. If no
+   specific project router is selected, a firewall instance is automatically
+   applied to all project routers.
+  </para>
+  <para>
+   Only 1 firewall instance can be applied to a project router.
+  </para>
+  <para>
+   Only 1 firewall policy can be applied to a firewall instance.
+  </para>
+  <para>
+   Multiple firewall rules can be added and applied to a firewall policy.
+  </para>
+  <para>
+   Firewall rules can be shared across different projects via the Share API
+   flag.
+  </para>
+  <para>
+   Firewall rules supersede the Security Group rules that are applied at the
+   Instance level for all traffic entering or leaving a private, project
+   network.
+  </para>
+  <para>
+   For more information on the neutron command-line interface (CLI) and
+   firewalls, see the OpenStack networking command-line client reference:
+   <link xlink:href="http://docs.openstack.org/cli-reference/content/neutronclient_commands.html"/>
   </para>
  </section>
 </section>

--- a/xml/operations-lbaas-dashboard.xml
+++ b/xml/operations-lbaas-dashboard.xml
@@ -1,0 +1,191 @@
+<?xml version="1.0"?>
+<!DOCTYPE section [
+ <!ENTITY % entities SYSTEM "entities.ent"> %entities;
+]>
+<!---->
+<section xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude"
+ xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="lbaas_dashboard">
+ <title>Creating a Load Balancer with the Dashboard</title>
+ <para>
+  In &kw-hos-phrase; you can create a Load Balancer with the Load Balancer
+  Panel in the Dashboard.
+ </para>
+ <para>
+  Follow the steps below to create the load balancer, listener, pool, add
+  members to the pool and create the health monitor.
+ </para>
+ <note>
+  <para>
+   Optionally, you may add members to the load balancer pool after the load
+   balancer has been created.
+  </para>
+ </note>
+ <procedure>
+  <step>
+   <para>
+    <emphasis role="bold">Login to the Dashboard</emphasis>
+   </para>
+   <para>
+    Login into the Dashboard using your domain, user account and password.
+   </para>
+  </step>
+  <step>
+   <para>
+    <emphasis role="bold">Navigate and Create Load Balancer</emphasis>
+   </para>
+   <para>
+    Once logged into the Dashboard, navigate to the <guimenu>Load
+    Balancers</guimenu> panel by selecting
+    <menuchoice><guimenu>Project</guimenu><guimenu>Network</guimenu><guimenu>Load
+    Balancers</guimenu></menuchoice> in the navigation menu, then select
+    <guimenu>Create Load Balancer</guimenu> from the Load
+    Balancers page.
+   </para>
+  </step>
+  <step>
+   <para>
+    <emphasis role="bold">Create Load Balancer</emphasis>
+   </para>
+   <para>
+    Provide the Load Balancer details, Load Balancer Name, Description
+    (optional), IP Address and Subnet. When complete, select Next.
+   </para>
+   <informalfigure>
+    <mediaobject>
+     <imageobject role="fo">
+      <imagedata fileref="media-horizon-lbaas_panel-LoadBalancers2.png" width="75%"/>
+     </imageobject>
+     <imageobject role="html">
+      <imagedata fileref="media-horizon-lbaas_panel-LoadBalancers2.png"/>
+     </imageobject>
+    </mediaobject>
+   </informalfigure>
+  </step>
+  <step>
+   <para>
+    <emphasis role="bold">Create Listener</emphasis>
+   </para>
+   <para>
+    Provide a Name, Description, Protocol (HTTP, TCP, TERMINATED_HTTPS) and
+    Port for the Load Balancer Listener.
+   </para>
+   <informalfigure>
+    <mediaobject>
+     <imageobject role="fo">
+      <imagedata fileref="media-horizon-lbaas_panel-LoadBalancers3.png" width="75%"/>
+     </imageobject>
+     <imageobject role="html">
+      <imagedata fileref="media-horizon-lbaas_panel-LoadBalancers3.png"/>
+     </imageobject>
+    </mediaobject>
+   </informalfigure>
+  </step>
+  <step>
+   <para>
+    <emphasis role="bold">Create Pool</emphasis>
+   </para>
+   <para>
+    Provide the Name, Description and Method (LEAST_CONNECTIONS, ROUND_ROBIN,
+    SOURCE_IP) for the Load Balancer Pool.
+   </para>
+   <informalfigure>
+    <mediaobject>
+     <imageobject role="fo">
+      <imagedata fileref="media-horizon-lbaas_panel-LoadBalancers4.png" width="75%"/>
+     </imageobject>
+     <imageobject role="html">
+      <imagedata fileref="media-horizon-lbaas_panel-LoadBalancers4.png"/>
+     </imageobject>
+    </mediaobject>
+   </informalfigure>
+  </step>
+  <step>
+   <para>
+    <emphasis role="bold">Add Pool Members</emphasis>
+   </para>
+   <para>
+    Add members to the Load Balancer Pool.
+   </para>
+   <note>
+    <para>
+     Optionally, you may add members to the load balancer pool after the load
+     balancer has been created.
+    </para>
+   </note>
+   <informalfigure>
+    <mediaobject>
+     <imageobject role="fo">
+      <imagedata fileref="media-horizon-lbaas_panel-LoadBalancers5.png" width="75%"/>
+     </imageobject>
+     <imageobject role="html">
+      <imagedata fileref="media-horizon-lbaas_panel-LoadBalancers5.png"/>
+     </imageobject>
+    </mediaobject>
+   </informalfigure>
+  </step>
+  <step>
+   <para>
+    <emphasis role="bold">Create Health Monitor</emphasis>
+   </para>
+   <para>
+    Create Health Monitor by providing the Monitor type (HTTP, PING, TCP), the
+    Health check interval, Retry count, timeout, HTTP Method, Expected HTTP
+    status code and the URL path. Once all fields are filled, select
+    <emphasis role="bold">Create Load Balancer</emphasis>.
+   </para>
+   <informalfigure>
+    <mediaobject>
+     <imageobject role="fo">
+      <imagedata fileref="media-horizon-lbaas_panel-LoadBalancers6.png" width="75%"/>
+     </imageobject>
+     <imageobject role="html">
+      <imagedata fileref="media-horizon-lbaas_panel-LoadBalancers6.png"/>
+     </imageobject>
+    </mediaobject>
+   </informalfigure>
+  </step>
+  <step>
+   <para>
+    <emphasis role="bold">Load Balancer Provisioning Status</emphasis>
+   </para>
+   <para>
+    Clicking on the Load Balancers tab again will provide the status of the
+    Load Balancer. The Load Balancer will be in
+    <emphasis role="bold">Pending Create</emphasis> until the Load Balancer
+    is created, at which point the Load Balancer will change to an
+    <emphasis role="bold">Active</emphasis> state.
+   </para>
+   <informalfigure>
+    <mediaobject>
+     <imageobject role="fo">
+      <imagedata fileref="media-horizon-lbaas_panel-LoadBalancers8.png" width="75%"/>
+     </imageobject>
+     <imageobject role="html">
+      <imagedata fileref="media-horizon-lbaas_panel-LoadBalancers8.png"/>
+     </imageobject>
+    </mediaobject>
+   </informalfigure>
+  </step>
+  <step>
+   <para>
+    <emphasis role="bold">Load Balancer Overview</emphasis>
+   </para>
+   <para>
+    Once <emphasis role="bold">Load Balancer 1</emphasis> has been created, it
+    will appear in the Load Balancers list. Click the Load Balancer 1, it will show
+    the Overview. In this view, you can see the Load  Balancer Provider type,
+    the Admin State, Floating IP, Load Balancer, Subnet and Port ID's.
+   </para>
+   <informalfigure>
+    <mediaobject>
+     <imageobject role="fo">
+      <imagedata fileref="media-horizon-lbaas_panel-LoadBalancers7.png" width="75%"/>
+     </imageobject>
+     <imageobject role="html">
+      <imagedata fileref="media-horizon-lbaas_panel-LoadBalancers7.png"/>
+     </imageobject>
+    </mediaobject>
+   </informalfigure>
+  </step>
+ </procedure>
+</section>

--- a/xml/operations-lbaas-dashboard.xml
+++ b/xml/operations-lbaas-dashboard.xml
@@ -1,13 +1,16 @@
 <?xml version="1.0"?>
+<?xml-stylesheet href="urn:x-suse:xslt:profiling:docbook51-profile.xsl"
+ type="text/xml"
+ title="Profiling step"?>
 <!DOCTYPE section [
- <!ENTITY % entities SYSTEM "entities.ent"> %entities;
+ <!ENTITY % entities SYSTEM "entity-decl.ent"> %entities;
 ]>
-<!---->
+
 <section xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude"
  xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="lbaas_dashboard">
  <title>Creating a Load Balancer with the Dashboard</title>
  <para>
-  In &kw-hos-phrase; you can create a Load Balancer with the Load Balancer
+  In &productname; &productnumber; you can create a Load Balancer with the Load Balancer
   Panel in the Dashboard.
  </para>
  <para>

--- a/xml/operations-lbaas.xml
+++ b/xml/operations-lbaas.xml
@@ -1,0 +1,483 @@
+<?xml version="1.0"?>
+<!DOCTYPE section [
+ <!ENTITY % entities SYSTEM "entities.ent"> %entities;
+]>
+<!---->
+<section xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude"
+          xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="HP2.0LBaaS">
+ <title>Using Load Balancing as a Service (LBaaS)</title>
+ <para>
+  Load Balancing as a Service (LBaaS) is an advanced networking service that
+  allows load balancing of multi-node environments. It provides the ability to
+  spread requests across multiple servers thereby reducing the load on any
+  single server. The following examples depict usage of the various OpenStack
+  command-line interfaces. The Load Balancer v1 API is also accessible
+  via the Horizon web interface if the v1 API is enabled. The Load Balancer v2
+  API does not currently have a representative Horizon web interface. The v2
+  API is targeted to have a Horizon web interface in a future &kw-hos; release.
+  This document describes the configuration for LBaaS v1 and v2.
+ </para>
+ <para>
+  You can create TLS enabled Load Balancers in &kw-hos-phrase; by following the
+  steps labeled for TLS Load Balancers. You cannot enable TLS with v1 Load
+  Balancers, only v2 Load Balancers can be enabled with TLS.
+ </para>
+ <important>
+  <para>
+   When Barbican is not installed by default, you have to manually install
+   Barbican and redeploy neutron.
+  </para>
+ </important>
+ <para>
+  &kw-hos-phrase; can support either LBaaS v1 or LBaaS v2 to allow for wide
+  ranging customer requirements. Check with your administrator for the version
+  that is installed before starting your configuration.
+ </para>
+ <section xml:id="idg-all-userguide-lbaas-xml-6">
+  <title>Configuration</title>
+  <para>
+   &kw-hos-phrase; LBaaS Configuration
+  </para>
+  <para>
+   <emphasis role="bold">Create Private Network for LBaaS</emphasis>
+  </para>
+  <para>
+   You can create the new network and router by executing the following command
+   from the &lcm; or a shell with access to the API nodes.
+  </para>
+  <procedure>
+   <step>
+    <para>
+     As a cloud admin, run the following commands to create a private network
+     and a router.
+    </para>
+<screen>neutron net-create private
+neutron subnet-create --name sub private 10.1.0.0/24 --gateway 10.1.0.1
+neutron router-create --distributed false router
+neutron router-interface-add router sub
+neutron router-gateway-set router ext-net</screen>
+   </step>
+  </procedure>
+  <para>
+   <emphasis role="bold">Start Virtual Machines</emphasis>
+  </para>
+  <procedure>
+   <step>
+    <para>
+     Add security group rules.
+    </para>
+    <note>
+     <para>
+      In the example below the load balancer is tested on port 80. If you
+      need to test the load balancer on a different port you will need to
+      create a security group rule for your port number.
+     </para>
+    </note>
+<screen>neutron security-group-rule-create default --protocol icmp
+neutron security-group-rule-create default --protocol tcp --port-range-min 22 --port-range-max 22
+neutron security-group-rule-create default --protocol tcp --port-range-min 80 --port-range-max 80</screen>
+   </step>
+   <step>
+    <para>
+     Start two VMs on the private network.
+    </para>
+<screen>## Start vm1
+nova boot --flavor 1 --image &lt;image&gt; --nic net-id=$(neutron net-list | awk '/private/ {print $2}') vm1
+
+## start vm2
+nova boot --flavor 1 --image &lt;image&gt; --nic net-id=$(neutron net-list | awk '/private/ {print $2}') vm2</screen>
+   </step>
+   <step>
+    <para>
+     Check if the VMs are active.
+    </para>
+<screen>nova list</screen>
+   </step>
+  </procedure>
+  <para>
+   <emphasis role="bold">For TLS Load Balancers - Create Certificate Chain and
+   Key</emphasis>
+  </para>
+  <procedure>
+   <step>
+    <para>
+     From a computer with access to the Barbican and labs API, run the
+     following sequence of commands
+    </para>
+<screen>openssl genrsa -des3 -out ca.key 1024
+openssl req -new -x509 -days 3650 -key ca.key -out ca.crt
+openssl x509  -in  ca.crt -out ca.pem
+openssl genrsa -des3 -out ca-int_encrypted.key 1024
+openssl rsa -in ca-int_encrypted.key -out ca-int.key
+openssl req -new -key ca-int.key -out ca-int.csr -subj "/CN=ca-int@acme.com"
+openssl x509 -req -days 3650 -in ca-int.csr -CA ca.crt -CAkey ca.key -set_serial 01 -out ca-int.crt
+openssl genrsa -des3 -out server_encrypted.key 1024
+openssl rsa -in server_encrypted.key -out server.key
+openssl req -new -key server.key -out server.csr -subj "/CN=server@acme.com"
+openssl x509 -req -days 3650 -in server.csr -CA ca-int.crt -CAkey ca-int.key -set_serial 01 -out server.crt</screen>
+   </step>
+   <step>
+    <para>
+     For SNI, create another chain with a different CN
+    </para>
+<screen>openssl genrsa -des3 -out ca2.key 1024
+openssl req -new -x509 -days 3650 -key ca2.key -out ca2.crt
+openssl x509  -in  ca2.crt -out ca2.pem
+openssl genrsa -des3 -out ca-int_encrypted2.key 1024
+openssl rsa -in ca-int_encrypted2.key -out ca-int2.key
+openssl req -new -key ca-int2.key -out ca-int2.csr -subj "/CN=ca-int-test2@stacme.com"
+openssl x509 -req -days 3650 -in ca-int2.csr -CA ca2.crt -CAkey ca2.key -set_serial 01 -out ca-int2.crt
+openssl genrsa -des3 -out server_encrypted2.key 1024
+openssl rsa -in server_encrypted2.key -out server2.key
+openssl req -new -key server2.key -out server2.csr -subj "/CN=test2@stacme.com"
+openssl x509 -req -days 3650 -in server2.csr -CA ca-int2.crt -CAkey ca-int2.key -set_serial 01 -out server2.crt</screen>
+   </step>
+  </procedure>
+  <para>
+   <emphasis role="bold">For TLS Load Balancers - Barbican Secrets and
+   Containers</emphasis>
+  </para>
+  <procedure>
+   <step>
+    <para>
+     Source the <literal>barbican.osrc</literal> file from the lifecycle
+     manager node. If you need to perform this operation on a different
+     computer make sure that the OpenStack user account uploading the certs has
+     the keymanager-admin role and is in the admin tenant (see
+     <xref linkend="topic_qmz_fg3_btx"/>
+     for a list of roles and tenants). LBaaS will only be able to access
+     certificates stored in the admin tenant.
+    </para>
+<screen>barbican secret store --payload-content-type='text/plain' --name='certificate' --payload="$(cat server.crt)"
+barbican secret store --payload-content-type='text/plain' --name='private_key' --payload="$(cat server.key)"
+barbican secret container create --name='tls_container' --type='certificate' --secret="certificate=$(barbican secret list | awk '/ certificate / {print $2}')" --secret="private_key=$(barbican secret list | awk '/ private_key / {print $2}')"</screen>
+    <warning>
+     <para>
+      Do not delete the certificate container associated with your Load
+      Balancer listeners before deleting the Load Balancers themselves. If you
+      delete the certificate first, future operations on your Load Balancers
+      and failover will cease to function.
+     </para>
+    </warning>
+   </step>
+   <step>
+    <para>
+     Add the second certificate chain to test SNI
+    </para>
+<screen>barbican secret store --payload-content-type='text/plain' --name='certificate2' --payload="$(cat server2.crt)"
+barbican secret store --payload-content-type='text/plain' --name='private_key2' --payload="$(cat server2.key)"
+barbican secret container create --name='tls_container2' --type='certificate' --secret="certificate=$(barbican secret list | awk '/ certificate2 / {print $2}')" --secret="private_key=$(barbican secret list | awk '/ private_key2 / {print $2}')"</screen>
+   </step>
+   <step>
+    <para>
+     Find the Octavia user id. You will add the id as a barbican acl user for
+     the containers and keys.
+    </para>
+<screen>source keystone.osrc
+openstack user list</screen>
+   </step>
+   <step>
+    <para>
+     Get the container and secret hrefs.
+    </para>
+<screen>source barbican.osrc
+barbican secret list
+barbican secret container list</screen>
+   </step>
+   <step>
+    <para>
+     Add the acl user obtained in step 3 to the hrefs obtained in step 4 by
+     executing <literal>barbican acl user add --user &lt;user id of Octavia&gt;
+     &lt;href&gt;</literal>. In the example below, the Octavia user,
+     <literal>66649a0863b64275bc3bffb50e3d76c8</literal> is being added as the
+     Barbican acl user for the containers and keys:
+    </para>
+<screen>barbican acl user add --user 66649a0863b64275bc3bffb50e3d76c8 https://10.242.124.130:9311/v1/containers/7ebcd4fa-e96a-493d-b1ee-260914d3cbeb
+barbican acl user add --user 66649a0863b64275bc3bffb50e3d76c8 https://10.242.124.130:9311/v1/secrets/d3c9584c-a43c-4fc1-bfa9-ebcafee57059
+barbican acl user add --user 66649a0863b64275bc3bffb50e3d76c8 https://10.242.124.130:9311/v1/secrets/0b958aa8-49d2-40aa-82dd-5660e012b3a3</screen>
+   </step>
+  </procedure>
+  <para>
+   <emphasis role="bold">Create Load Balancer v2</emphasis>
+  </para>
+  <note>
+   <para>
+    The creation of the Load Balancer requires a tenant network and not an
+    external network.
+   </para>
+  </note>
+  <procedure>
+   <step>
+    <para>
+     Create the new load balancer using the
+     <literal>lbaas-loadbalancer-create</literal> command and giving the load
+     balancer a name and subnet.
+    </para>
+<screen>source barbican.osrc
+neutron lbaas-loadbalancer-create --name lb sub</screen>
+   </step>
+   <step>
+    <para>
+     Create a new listener. If you are enabling TLS, use the second example, if
+     you are enabling TLS and SNI, use the third example.
+    </para>
+    <note>
+     <para>
+      Use unique port numbers for each listener. This example uses 80, 443
+      and 444.
+     </para>
+    </note>
+    <substeps>
+     <step>
+      <para>
+       Create a new listener for the load balancer without TLS using the
+       <literal>lbaas-listener-create</literal> command and giving the listener
+       the name of the load balancer, the protocol, the protocol port and a
+       name for the listener.
+      </para>
+<screen>neutron lbaas-listener-create --loadbalancer lb --protocol HTTP --protocol-port 80 --name listener</screen>
+     </step>
+     <step>
+      <para>
+       Create a new listener for the load balancer with TLS and no SNI using
+       the <literal>lbaas-listener-create</literal> command and giving the
+       listener the name of the load balancer, the protocol, the protocol port,
+       the name for the listener and the default TLS container.
+      </para>
+<screen>neutron lbaas-listener-create --loadbalancer lb --protocol-port 443 --protocol TERMINATED_HTTPS --name tls_listener --default-tls-container-ref=$(barbican secret container list | awk '/ tls_container / {print $2}')</screen>
+     </step>
+     <step>
+      <para>
+       Create a new listener for the load balancer with TLS and SNI using the
+       <literal>lbaas-listener-create</literal> command and giving the listener
+       the name of the load balancer, the protocol, the protocol port, the name
+       for the listener, the default TLS container and the SNI container.
+      </para>
+<screen>neutron lbaas-listener-create --loadbalancer lb --protocol-port 444 --protocol TERMINATED_HTTPS --name sni_listener --default-tls-container-ref=$(barbican secret container list | awk '/ tls_container / {print $2}') --sni-container-refs $(barbican secret container list | awk '/ tls_container2 / {print $2}’</screen>
+     </step>
+     <step>
+      <para>
+       For each listener, create a new pool for the load balancer using the
+       <literal>lbaas-pool-create</literal> command. Creating a new pool
+       requires the load balancing algorithm, the name of the listener, the
+       protocol and a name for the pool. In the example below we show the
+       command for the listener named <literal>listener</literal>. You need to
+       repeat that for the tls_listener and sni_listener as well. Make sure to
+       specify different names for each pool.
+      </para>
+<screen>neutron lbaas-pool-create --lb-algorithm ROUND_ROBIN --listener listener --protocol HTTP --name &lt;pool name&gt;</screen>
+     </step>
+     <step>
+      <para>
+       You can add members to the load balancer pool by running the
+       <literal>lbaas-member-create</literal> command. The command requires the
+       subnet, IP address, protocol port and the name of the pool for each
+       virtual machine you would like to include into the load balancer pool. It is
+       important to note that this will need to be repeated for each pool
+       created above.
+      </para>
+<screen>neutron lbaas-member-create --subnet sub --address &lt;ip address vm1&gt; --protocol-port &lt;port&gt; &lt;pool name&gt;
+neutron lbaas-member-create --subnet sub --address &lt;ip address vm2&gt; --protocol-port &lt;port&gt; &lt;pool name&gt;</screen>
+     </step>
+     <step>
+      <para>
+       Display the current state of the load balancer and values with
+       <literal>lbaas-loadbalancer-show</literal>.
+      </para>
+<screen>neutron lbaas-loadbalancer-show lb</screen>
+     </step>
+     <step>
+      <para>
+       You need to assign the floating IP to lbaas VIP so it can be accessed
+       from the external network.
+      </para>
+<screen>fixedip_vip=$(neutron lbaas-loadbalancer-list | awk '/lb/ {print $6}')
+portuuid_vip=$(neutron port-list | grep $fixedip_vip | awk '{print $2}')</screen>
+     </step>
+     <step>
+      <para>
+       Create and associate the floating IP address to lbaas VIP address.
+      </para>
+<screen>neutron floatingip-create ext-net --port-id $portuuid_vip</screen>
+     </step>
+    </substeps>
+   </step>
+  </procedure>
+  <itemizedlist>
+   <listitem>
+    <para>
+     A complete list of the Load Balancer v2 API commands can be found at:
+     <link xlink:href="https://wiki.openstack.org/wiki/Neutron/LBaaS/API_2.0"/>
+    </para>
+   </listitem>
+   <listitem>
+    <para>
+     Additional Load Balancer v2 API examples can be found at:
+     <link xlink:href="http://docs.openstack.org/mitaka/networking-guide/adv-config-lbaas.html"/>
+    </para>
+<!-- Commented in DITA original: -->
+<!--<note>Examples of how to terminate SSL certificates on a Load Balancer
+are not currently available. These examples are being created and a reference
+URL will be added to this document when they become available.</note>-->
+   </listitem>
+   <listitem>
+    <para>
+     Instructions on how to terminate TLS certificates on a deployed Load
+     Balancer can be found at:
+     <link xlink:href="https://wiki.openstack.org/wiki/Neutron/LBaaS/API_2.0#Create_a_Listener"/>
+    </para>
+   </listitem>
+  </itemizedlist>
+  <para>
+   <emphasis role="bold">Create Load Balancer v1</emphasis>
+  </para>
+  <note>
+   <para>
+    v1 Load Balancers cannot be enabled with TLS.
+   </para>
+  </note>
+  <procedure>
+   <step>
+    <para>
+     Create the load balancer pool with <literal>lb-pool-create</literal>
+     giving it a method, name, protocol and subnet.
+    </para>
+<screen>neutron lb-pool-create --lb-method ROUND_ROBIN --name pool --protocol HTTP --subnet-id $(neutron subnet-list | awk '/sub/ {print $2}')</screen>
+   </step>
+   <step>
+    <para>
+     Create load balancing members with <literal>lb-member-create</literal>
+     providing the IP address, protocol and load balancing pool name to each
+     member.
+    </para>
+<screen>neutron lb-member-create --address &lt;ip address vm1&gt; --protocol-port &lt;port&gt; pool
+neutron lb-member-create --address &lt;ip address vm2&gt; --protocol-port &lt;port&gt; pool</screen>
+   </step>
+   <step>
+    <para>
+     Create the vip with <literal>lb-vip-create</literal> giving it a name,
+     protocol, protocol port and a subnet.
+    </para>
+<screen>neutron lb-vip-create --name vip --protocol-port &lt;port&gt; --protocol HTTP --subnet-id $(neutron subnet-list | awk '/sub/ {print $2}') pool</screen>
+   </step>
+   <step>
+    <para>
+     You can check to see if the load balancer is active with
+     <literal>lb-vip-show</literal>
+    </para>
+<screen>neutron lb-vip-show vip</screen>
+   </step>
+  </procedure>
+  <para>
+   <emphasis role="bold">Validate LBaaS Functionality</emphasis>
+  </para>
+  <note>
+   <para>
+    You should perform the following steps from a node that has a route to
+    the private network. Using the examples from above, 10.1.0.0/24 should be
+    reachable.
+   </para>
+  </note>
+  <procedure>
+   <step>
+    <para>
+     SSH into both vm1 and vm2 in two separate windows and make them listen on
+     your configured port.
+    </para>
+   </step>
+   <step>
+    <para>
+     From one window.
+    </para>
+<screen>ssh cirros@&lt;ip address vm1&gt;
+pass: &lt;password&gt;</screen>
+   </step>
+   <step>
+    <para>
+     From another window.
+    </para>
+<screen>ssh cirros@&lt;ip address vm2&gt;
+pass: &lt;password&gt;</screen>
+   </step>
+   <step>
+    <para>
+     Start running web servers on both of the virtual machines.
+    </para>
+   </step>
+   <step>
+    <para>
+     Create a webserv.sh script with below contents. Use the &lt;port&gt; from
+     the member creation step.
+    </para>
+<screen>$ vi webserv.sh
+
+#!/bin/bash
+
+MYIP=$(/sbin/ifconfig eth0|grep 'inet addr'|awk -F: '{print $2}'| awk '{print $1}');
+while true; do
+    echo -e "HTTP/1.0 200 OK
+
+Welcome to $MYIP" | sudo nc -l -p &lt;port&gt;
+done
+
+## Give it Exec rights
+$ chmod 755 webserv.sh
+
+## Start webserver
+$ ./webserv.sh</screen>
+   </step>
+   <step>
+    <para>
+     Open a separate window. From the respective source node in external
+     network (in case of accessing LBaaS VIP thorough its FIP) or in private
+     network (in case of no FIP), add the respective IP address to the no_proxy
+     env variable, if required. You can get the <emphasis>VIP</emphasis> from
+     the <literal>neutron lbaas-loadbalancer-list</literal> for LBaaS v2 and
+     <literal>neutron lb-vip-list</literal> for LBaaS v1.
+    </para>
+   </step>
+   <step>
+    <para>
+     Run the following commands to test load balancing. In this example, the
+     VIP IP address is 10.1.0.7 and when executing curl against the VIP, the
+     responses are returned from the load balanced services.
+    </para>
+<screen>$ export no_proxy=$no_proxy,10.1.0.7
+
+## Curl the VIP
+$ curl 10.1.0.7
+Welcome to 10.1.0.4
+
+$ curl 10.1.0.7
+Welcome to 10.1.0.5
+
+$ curl 10.1.0.7
+Welcome to 10.1.0.4</screen>
+   </step>
+  </procedure>
+  <para>
+   <emphasis role="bold">Verify SNI</emphasis>
+  </para>
+  <para>
+   You can verify SNI by running the following command from a node with access
+   to the private network. You can get the VIP from the neutron
+   <literal>lbaas-loadbalancer-list</literal> for LBaaS v2.
+  </para>
+<screen>openssl s_client -servername test2@stacme.com -connect &lt;vip of lb&gt;:444</screen>
+  <para>
+   Certificate information will print to the screen. You should verify that the
+   CN matches the CN you passed to <literal>-servername</literal>. In the
+   example below the CN matches the servername passed from above.
+  </para>
+<screen>subject=/CN=test2@stacme.com
+issuer=/CN=ca-int-test2@stacme.com</screen>
+ </section>
+ <section xml:id="idg-all-userguide-lbaas-xml-15">
+  <title>For More Information</title>
+  <para>
+   For more information on the neutron command-line interface (CLI) and load
+   balancing, see the OpenStack networking command-line client reference:
+   <link xlink:href="http://docs.openstack.org/cli-reference/content/neutronclient_commands.html"/>
+  </para>
+ </section>
+</section>

--- a/xml/operations-lbaas.xml
+++ b/xml/operations-lbaas.xml
@@ -1,10 +1,12 @@
 <?xml version="1.0"?>
+<?xml-stylesheet href="urn:x-suse:xslt:profiling:docbook51-profile.xsl"
+ type="text/xml"
+ title="Profiling step"?>
 <!DOCTYPE section [
- <!ENTITY % entities SYSTEM "entities.ent"> %entities;
+ <!ENTITY % entities SYSTEM "entity-decl.ent"> %entities;
 ]>
-<!---->
-<section xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude"
-          xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="HP2.0LBaaS">
+
+<section xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="HP2.0LBaaS">
  <title>Using Load Balancing as a Service (LBaaS)</title>
  <para>
   Load Balancing as a Service (LBaaS) is an advanced networking service that
@@ -14,11 +16,11 @@
   command-line interfaces. The Load Balancer v1 API is also accessible
   via the Horizon web interface if the v1 API is enabled. The Load Balancer v2
   API does not currently have a representative Horizon web interface. The v2
-  API is targeted to have a Horizon web interface in a future &kw-hos; release.
+  API is targeted to have a Horizon web interface in a future &productname; release.
   This document describes the configuration for LBaaS v1 and v2.
  </para>
  <para>
-  You can create TLS enabled Load Balancers in &kw-hos-phrase; by following the
+  You can create TLS enabled Load Balancers in &productname; &productnumber; by following the
   steps labeled for TLS Load Balancers. You cannot enable TLS with v1 Load
   Balancers, only v2 Load Balancers can be enabled with TLS.
  </para>
@@ -29,14 +31,14 @@
   </para>
  </important>
  <para>
-  &kw-hos-phrase; can support either LBaaS v1 or LBaaS v2 to allow for wide
+  &productname; &productnumber; can support either LBaaS v1 or LBaaS v2 to allow for wide
   ranging customer requirements. Check with your administrator for the version
   that is installed before starting your configuration.
  </para>
  <section xml:id="idg-all-userguide-lbaas-xml-6">
   <title>Configuration</title>
   <para>
-   &kw-hos-phrase; LBaaS Configuration
+   &productname; &productnumber; LBaaS Configuration
   </para>
   <para>
    <emphasis role="bold">Create Private Network for LBaaS</emphasis>

--- a/xml/operations-magnum-create_magnum_cluster_dashboard.xml
+++ b/xml/operations-magnum-create_magnum_cluster_dashboard.xml
@@ -1,0 +1,243 @@
+<?xml version="1.0"?>
+<?xml-stylesheet href="urn:x-suse:xslt:profiling:docbook51-profile.xsl"
+ type="text/xml"
+ title="Profiling step"?>
+<!DOCTYPE section [
+ <!ENTITY % entities SYSTEM "entity-decl.ent"> %entities;
+]>
+
+<section xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude"
+  xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="create_magnum_cluster">
+ <title>Creating a Magnum Cluster with the Dashboard</title>
+ <para>
+  You can alternatively create a cluster template and cluster with the Magnum
+  UI in Horizon. The example instructions below demonstrate how to deploy a
+  Kubernetes Cluster using the Fedora Atomic image. Other deployments such as
+  Kubernetes on CoreOS, Docker Swarm on Fedora, and Mesos on Ubuntu all follow
+  the same set of instructions mentioned below with slight variations to their
+  parameters. You can determine those parameters by looking at the previous
+  set of CLI instructions in the
+  <command>magnum cluster-template-create</command> and
+  <command>magnum cluster-create</command> commands.
+ </para>
+ <section xml:id="idg-all-userguide-container_service-create_magnum_cluster_dashboard-xml-7">
+  <title>Prerequisites</title>
+  <itemizedlist>
+   <listitem>
+    <para>
+     Magnum must be installed before proceeding. For more information, see
+     <xref linkend="MagnumInstall"/>.
+    </para>
+    <important>
+     <para>
+      Pay particular attention to <literal>external-name:</literal> in
+      <literal>data/network_groups.yml</literal>. This cannot be set to the
+      default <literal>myardana.test</literal> and must be a valid
+      DNS-resolvable FQDN. If you do not have a DNS-resolvable FQDN, remove or
+      comment out the <literal>external-name</literal> entry and the public
+      endpoint will use an IP address instead of a name.
+     </para>
+    </important>
+   </listitem>
+   <listitem>
+    <para>
+     The image for which you want to base your cluster on must already have
+     been uploaded into glance. See the previous CLI instructions regarding
+     deploying a cluster on how this is done.
+    </para>
+   </listitem>
+  </itemizedlist>
+ </section>
+ <section xml:id="cluster_template">
+  <title>Creating the Cluster Template</title>
+  <para>
+   You will need access to the Dashboard to create the cluster
+   template.<!-- If you have not accessed the Horizon Dashboard before or you are
+   unfamiliar with it, see <xref linkend="user_dashboard_overview"/>
+   and <xref linkend="cloudadmin_gui"/> for more
+   information.-->
+  </para>
+  <procedure>
+   <step>
+    <para>
+     Open a web browser that has both JavaScript and cookies enabled. In the
+     address bar, enter the host name or IP address for the dashboard.
+    </para>
+   </step>
+   <step>
+    <para>
+     On the <guimenu>Log In</guimenu> page, enter your user name
+     and password and then click <guimenu>Connect</guimenu>.
+    </para>
+   </step>
+   <step>
+    <para>
+     Make sure you are in the appropriate domain and project in the left pane.
+     Below is an example image of the drop-down box:
+    </para>
+    <informalfigure>
+     <mediaobject>
+      <imageobject role="fo">
+       <imagedata fileref="media-horizon-domain_selector.png" width="75%"/>
+      </imageobject>
+      <imageobject role="html">
+       <imagedata fileref="media-horizon-domain_selector.png"/>
+      </imageobject>
+     </mediaobject>
+    </informalfigure>
+   </step>
+   <step>
+    <para>
+     A key pair is required for cluster template creation. It is applied to VMs
+     created during the cluster creation process. This allows SSH access to your
+     cluster's VMs. If you would like to create a new key pair, do so by going
+     to <menuchoice><guimenu>Project</guimenu><guimenu>Compute</guimenu>
+     <guimenu>Access &amp; Security</guimenu><guimenu>Key Pairs</guimenu>
+     </menuchoice>.
+    </para>
+   </step>
+   <step>
+    <para>
+     Go to <menuchoice><guimenu>Project</guimenu>
+     <guimenu>Container Infra</guimenu><guimenu>Cluster Templates</guimenu></menuchoice>.
+     Insert
+     <replaceable>CLUSTER_NAME</replaceable> and click on
+     <guimenu>+ Create Cluster Template</guimenu> with the following options:
+    </para>
+    <informalfigure>
+     <mediaobject>
+      <imageobject role="fo">
+       <imagedata fileref="media-horizon-create_cluster_template.png" width="75%"/>
+      </imageobject>
+      <imageobject role="html">
+       <imagedata fileref="media-horizon-create_cluster_template.png"/>
+      </imageobject>
+     </mediaobject>
+    </informalfigure>
+    <itemizedlist>
+     <listitem>
+      <para>
+       <guimenu>Public</guimenu> - makes the template available
+       for others to use.
+      </para>
+     </listitem>
+     <listitem>
+      <para>
+       <guimenu>Enable Registry</guimenu> - creates and uses a
+       private docker registry backed by OpenStack Swift in addition to using
+       the public docker registry.
+      </para>
+     </listitem>
+     <listitem>
+      <para>
+       <guimenu>Disable TLS</guimenu> - turns off TLS encryption.
+       For Kubernetes clusters which use client certificate authentication,
+       disabling TLS also involves disabling authentication.
+      </para>
+     </listitem>
+    </itemizedlist>
+    <informalfigure>
+     <mediaobject>
+      <imageobject role="fo">
+       <imagedata fileref="media-horizon-create_cluster_template2.png" width="75%"/>
+      </imageobject>
+      <imageobject role="html">
+       <imagedata fileref="media-horizon-create_cluster_template2.png"/>
+      </imageobject>
+     </mediaobject>
+    </informalfigure>
+    <informalfigure>
+     <mediaobject>
+      <imageobject role="fo">
+       <imagedata fileref="media-horizon-create_cluster_template3.png" width="75%"/>
+      </imageobject>
+      <imageobject role="html">
+       <imagedata fileref="media-horizon-create_cluster_template3.png"/>
+      </imageobject>
+     </mediaobject>
+    </informalfigure>
+    <itemizedlist>
+     <listitem>
+      <para>
+       Proxies are only needed if the created VMs require a proxy to connect
+       externally.
+      </para>
+     </listitem>
+     <listitem>
+      <para>
+       <guimenu>Master LB</guimenu> – This should be turned on
+       if LbaaS v2 (Octavia) is configured in your environment. This option
+       will create load balancers in front of the cluster's master nodes and
+       distribute the requests to the Kubernetes API and etcd across the master
+       nodes.
+      </para>
+     </listitem>
+     <listitem>
+      <para>
+       <guimenu>Floating IP</guimenu> – This assigns floating
+       IPs to the cluster nodes when the cluster is being created. This should
+       be selected if you wish to ssh into the cluster nodes, perform
+       diagnostics and additional tuning to Kubernetes.
+      </para>
+     </listitem>
+    </itemizedlist>
+   </step>
+   <step>
+    <para>
+     Click the <guimenu>Submit</guimenu> button to create the cluster template
+     and you should see <emphasis>my-template</emphasis> in the list of
+     templates.
+    </para>
+   </step>
+  </procedure>
+ </section>
+ <section xml:id="creating_the_cluster">
+  <title>Creating the Cluster</title>
+  <procedure>
+   <step>
+    <para>
+     Click <guimenu>Create Cluster</guimenu> for
+     <emphasis>my-template</emphasis> or go to
+     <menuchoice><guimenu>Project</guimenu><guimenu>Container Infra</guimenu>
+     <guimenu>Clusters</guimenu></menuchoice> and click <guimenu>+ Create
+     Cluster</guimenu> with the following options.
+    </para>
+    <informalfigure>
+     <mediaobject>
+      <imageobject role="fo">
+       <imagedata fileref="media-horizon-create_cluster_img1.png" width="75%"/>
+      </imageobject>
+      <imageobject role="html">
+       <imagedata fileref="media-horizon-create_cluster_img1.png"/>
+      </imageobject>
+     </mediaobject>
+    </informalfigure>
+   </step>
+   <step>
+    <para>
+     Click <guimenu>Create</guimenu> to start the cluster
+     creation process.
+    </para>
+   </step>
+   <step>
+    <para>
+     Click <guimenu>Clusters</guimenu> in the left pane to see
+     the list of clusters. You will see
+     <emphasis>my-cluster</emphasis> in this list. If you select
+     <emphasis>my-cluster</emphasis>, you will see additional
+     information regarding your cluster.
+    </para>
+    <informalfigure>
+     <mediaobject>
+      <imageobject role="fo">
+       <imagedata fileref="media-horizon-create_cluster_img3.png" width="75%"/>
+      </imageobject>
+      <imageobject role="html">
+       <imagedata fileref="media-horizon-create_cluster_img3.png"/>
+      </imageobject>
+     </mediaobject>
+    </informalfigure>
+   </step>
+  </procedure>
+ </section>
+</section>

--- a/xml/operations-magnum-deploying_apache_mesos_ubuntu.xml
+++ b/xml/operations-magnum-deploying_apache_mesos_ubuntu.xml
@@ -1,0 +1,430 @@
+<?xml version="1.0"?>
+<?xml-stylesheet href="urn:x-suse:xslt:profiling:docbook51-profile.xsl"
+ type="text/xml"
+ title="Profiling step"?>
+<!DOCTYPE section [
+ <!ENTITY % entities SYSTEM "entity-decl.ent"> %entities;
+]>
+
+<section xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude"
+   xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="deploying_apache_mesos_ubuntu">
+ <title>Deploying an Apache Mesos Cluster on Ubuntu</title>
+ <section xml:id="idg-all-userguide-container_service-deploying_apache_mesos_ubuntu-xml-6">
+  <title>Prerequisites</title>
+  <para>
+   These steps assume the following have been completed:
+  </para>
+  <itemizedlist>
+   <listitem>
+    <para>
+     The Magnum service has been installed. For more information, see
+     <xref linkend="MagnumInstall"/>.
+    </para>
+   </listitem>
+   <listitem>
+    <para>
+     Deploying an Apache Mesos Cluster requires the Fedora Atomic image
+     that is compatible for the OpenStack release. You can download
+     the <emphasis role="bold">ubuntu-mesos-latest.qcow2</emphasis>
+     image from
+     <link xlink:href="https://fedorapeople.org/groups/magnum/"/>
+    </para>
+   </listitem>
+  </itemizedlist>
+ </section>
+ <section xml:id="idg-all-userguide-container_service-deploying_apache_mesos_ubuntu-xml-7">
+  <title>Creating the Cluster</title>
+  <para>
+   The following example is created using Kubernetes Container Orchestration
+   Engine (COE) running on Fedora Atomic guest OS on &productname; VMs.
+  </para>
+  <procedure>
+   <step>
+    <para>
+     As <emphasis role="bold">stack</emphasis> user, login to the lifecycle
+     manager.
+    </para>
+   </step>
+   <step>
+    <para>
+     Source openstack admin credentials.
+    </para>
+<screen>$ source service.osrc</screen>
+   </step>
+   <step>
+    <para>
+     If you haven't already, download Fedora Atomic image that is compatible for the
+     OpenStack release.
+    </para>
+    <note>
+     <para>
+      The <literal>https_proxy</literal> is only needed if your environment
+      requires a proxy.
+     </para>
+    </note>
+<screen>$ https_proxy=http://proxy.yourcompany.net:8080 wget https://fedorapeople.org/groups/magnum/ubuntu-mesos-latest.qcow2</screen>
+   </step>
+   <step>
+    <para>
+     Create a Glance image.
+    </para>
+<screen>
+$ glance image-create --name ubuntu-mesos-latest --visibility public --disk-format qcow2 --os-distro ubuntu --container-format bare --file ubuntu-mesos-latest.qcow2 --progress
+[=============================&gt;] 100%
++------------------+--------------------------------------+
+| Property         | Value                                |
++------------------+--------------------------------------+
+| checksum         | 97cc1fdb9ca80bf80dbd6842aab7dab5     |
+| container_format | bare                                 |
+| created_at       | 2017-04-21T19:40:20Z                 |
+| disk_format      | qcow2                                |
+| id               | d6a4e6f9-9e34-4816-99fe-227e0131244f |
+| min_disk         | 0                                    |
+| min_ram          | 0                                    |
+| name             | ubuntu-mesos-latest                  |
+| os_distro        | ubuntu                               |
+| owner            | 2f5b83ab49d54aaea4b39f5082301d09     |
+| protected        | False                                |
+| size             | 753616384                            |
+| status           | active                               |
+| tags             | []                                   |
+| updated_at       | 2017-04-21T19:40:32Z                 |
+| virtual_size     | None                                 |
+| visibility       | public                               |
++------------------+--------------------------------------+</screen>
+   </step>
+   <step>
+    <para>
+     Create a Nova keypair.
+    </para>
+<screen>$ test -f ~/.ssh/id_rsa.pub || ssh-keygen -t rsa -N "" -f ~/.ssh/id_rsa
+$ nova keypair-add --pub-key ~/.ssh/id_rsa.pub testkey</screen>
+   </step>
+   <step>
+    <para>
+     Create a Magnum cluster template.
+    </para>
+<screen>$ magnum cluster-template-create --name my-mesos-template \
+  --image-id d6a4e6f9-9e34-4816-99fe-227e0131244f \
+  --keypair-id testkey \
+  --external-network-id ext-net \
+  --dns-nameserver 8.8.8.8 \
+  --flavor-id m1.small \
+  --docker-volume-size 5 \
+  --network-driver docker \
+  --coe mesos \
+  --http-proxy http://proxy.yourcompany.net:8080/ \
+  --https-proxy http://proxy.yourcompany.net:8080/</screen>
+    <note>
+     <orderedlist>
+      <listitem>
+       <para>
+        Use the <emphasis>image_id</emphasis> from <literal>glance
+        image-create</literal> command output in the previous step.
+       </para>
+      </listitem>
+      <listitem>
+       <para>
+        Use your organization's DNS server. If the &productname; public endpoint is
+        configured with the hostname, this server should provide resolution for
+        this hostname.
+       </para>
+      </listitem>
+      <listitem>
+       <para>
+        The proxy is only needed if public internet (for example,
+        <literal>https://discovery.etcd.io/</literal> or
+        <literal>https://gcr.io/</literal>) is not accessible
+        without proxy.
+       </para>
+      </listitem>
+     </orderedlist>
+    </note>
+   </step>
+   <step>
+    <para>
+     Create cluster. The command below will create a minimalistic cluster
+     consisting of a single Kubernetes Master (kubemaster) and single
+     Kubernetes Node (worker, kubeminion).
+    </para>
+<screen>$ magnum cluster-create --name my-mesos-cluster --cluster-template my-mesos-template --node-count 1 --master-count 1</screen>
+   </step>
+   <step>
+    <para>
+     Immediately after issuing <literal>cluster-create</literal> command,
+     cluster status should turn to
+     <emphasis role="bold">CREATE_IN_PROGRESS</emphasis> and stack_id assigned.
+    </para>
+<screen>$ magnum cluster-show my-mesos-cluster
++---------------------+--------------------------------------+
+| Property            | Value                                |
++---------------------+--------------------------------------+
+| status              | CREATE_IN_PROGRESS                   |
+| cluster_template_id | be354919-fa6c-4db8-9fd1-69792040f095 |
+| uuid                | b1493402-8571-4683-b81e-ddc129ff8937 |
+| stack_id            | 50aa20a6-bf29-4663-9181-cf7ba3070a25 |
+| status_reason       | -                                    |
+| created_at          | 2017-04-21T19:50:34+00:00            |
+| name                | my-mesos-cluster                     |
+| updated_at          | -                                    |
+| discovery_url       | -                                    |
+| api_address         | -                                    |
+| coe_version         | -                                    |
+| master_addresses    | []                                   |
+| create_timeout      | 60                                   |
+| node_addresses      | []                                   |
+| master_count        | 1                                    |
+| container_version   | -                                    |
+| node_count          | 1                                    |
++---------------------+--------------------------------------+</screen>
+   </step>
+   <step>
+    <para>
+     You can monitor cluster creation progress by listing the resources of the
+     Heat stack. Use the <literal>stack_id</literal> value from the
+     <literal>magnum cluster-status</literal> output above in the following
+     command:
+    </para>
+<screen>$ heat resource-list -n2 50aa20a6-bf29-4663-9181-cf7ba3070a25
+WARNING (shell) "heat resource-list" is deprecated, please use "openstack stack resource list" instead
++------------------------------+--------------------------------------+-----------------------------------+-----------------+----------------------+-------------------------------+
+| resource_name                | physical_resource_id                 | resource_type                     | resource_status | updated_time         | stack_name                    |
++------------------------------+--------------------------------------+-----------------------------------+-----------------+----------------------+-------------------------------+
+| add_proxy_master             | 10394a74-1503-44b4-969a-44258c9a7be1 | OS::Heat::SoftwareConfig          | CREATE_COMPLETE | 2017-04-21T19:50:33Z | my-mesos-cluster-w2trq7m46qus |
+| add_proxy_master_deployment  |                                      | OS::Heat::SoftwareDeploymentGroup | INIT_COMPLETE   | 2017-04-21T19:50:33Z | my-mesos-cluster-w2trq7m46qus |
+...</screen>
+   </step>
+   <step>
+    <para>
+     The cluster is complete when all resources show
+     <emphasis role="bold">CREATE_COMPLETE</emphasis>.
+    </para>
+<screen>$ magnum cluster-show my-mesos-cluster
++---------------------+--------------------------------------+
+| Property            | Value                                |
++---------------------+--------------------------------------+
+| status              | CREATE_COMPLETE                      |
+| cluster_template_id | 9e942bfa-2c78-4837-82f5-6bea88ba1bf9 |
+| uuid                | 9d7bb502-8865-4cbd-96fa-3cd75f0f6945 |
+| stack_id            | 339a72b4-a131-47c6-8d10-365e6f6a18cf |
+| status_reason       | Stack CREATE completed successfully  |
+| created_at          | 2017-04-24T20:54:31+00:00            |
+| name                | my-mesos-cluster                     |
+| updated_at          | 2017-04-24T20:59:18+00:00            |
+| discovery_url       | -                                    |
+| api_address         | 172.31.0.10                          |
+| coe_version         | -                                    |
+| master_addresses    | ['172.31.0.10']                      |
+| create_timeout      | 60                                   |
+| node_addresses      | ['172.31.0.5']                       |
+| master_count        | 1                                    |
+| container_version   | 1.9.1                                |
+| node_count          | 1                                    |
++---------------------+--------------------------------------+</screen>
+   </step>
+   <step>
+    <para>
+     Verify that
+     <link xlink:href="https://mesosphere.github.io/marathon/">Marathon</link>
+     web console is available at http://${MASTER_IP}:8080/, and
+     <link xlink:href="http://mesos.apache.org/documentation/latest/">Mesos</link>
+     UI is available at http://${MASTER_IP}:5050/
+    </para>
+<screen>$ https_proxy=http://proxy.yourcompany.net:8080 curl -LO \
+  https://storage.googleapis.com/kubernetes-release/release/v1.2.0/bin/linux/amd64/kubectl
+$ chmod +x ./kubectl
+$ sudo mv ./kubectl /usr/local/bin/kubectl</screen>
+   </step>
+   <step>
+    <para>
+     Create an example Mesos application.
+    </para>
+<screen>$ mkdir my_mesos_cluster
+$ cd my_mesos_cluster/
+$ cat &gt; sample.json &lt;&lt;-EOFc
+{
+  "id": "sample",
+  "cmd": "python3 -m http.server 8080",
+  "cpus": 0.5,
+  "mem": 32.0,
+  "container": {
+    "type": "DOCKER",
+    "docker": {
+      "image": "python:3",
+      "network": "BRIDGE",
+      "portMappings": [
+        { "containerPort": 8080, "hostPort": 0 }
+      ]
+    }
+  }
+}
+EOF
+</screen>
+<screen>$ curl -s -X POST -H "Content-Type: application/json" \
+  http://172.31.0.10:8080/v2/apps -d@sample.json | json_pp
+{
+   "dependencies" : [],
+   "healthChecks" : [],
+   "user" : null,
+   "mem" : 32,
+   "requirePorts" : false,
+   "tasks" : [],
+   "cpus" : 0.5,
+   "upgradeStrategy" : {
+      "minimumHealthCapacity" : 1,
+      "maximumOverCapacity" : 1
+   },
+   "maxLaunchDelaySeconds" : 3600,
+   "disk" : 0,
+   "constraints" : [],
+   "executor" : "",
+   "cmd" : "python3 -m http.server 8080",
+   "id" : "/sample",
+   "labels" : {},
+   "ports" : [
+      0
+   ],
+   "storeUrls" : [],
+   "instances" : 1,
+   "tasksRunning" : 0,
+   "tasksHealthy" : 0,
+   "acceptedResourceRoles" : null,
+   "env" : {},
+   "tasksStaged" : 0,
+   "tasksUnhealthy" : 0,
+   "backoffFactor" : 1.15,
+   "version" : "2017-04-25T16:37:40.657Z",
+   "uris" : [],
+   "args" : null,
+   "container" : {
+      "volumes" : [],
+      "docker" : {
+         "portMappings" : [
+            {
+               "containerPort" : 8080,
+               "hostPort" : 0,
+               "servicePort" : 0,
+               "protocol" : "tcp"
+            }
+         ],
+         "parameters" : [],
+         "image" : "python:3",
+         "forcePullImage" : false,
+         "network" : "BRIDGE",
+         "privileged" : false
+      },
+      "type" : "DOCKER"
+   },
+   "deployments" : [
+      {
+         "id" : "6fbe48f0-6a3c-44b7-922e-b172bcae1be8"
+      }
+   ],
+   "backoffSeconds" : 1
+}</screen>
+   </step>
+   <step>
+    <para>
+     Wait for sample application to start. Use REST API or Marathon web console
+     to monitor status:
+    </para>
+<screen>$ curl -s http://172.31.0.10:8080/v2/apps/sample | json_pp
+{
+   "app" : {
+      "deployments" : [],
+      "instances" : 1,
+      "tasks" : [
+         {
+            "id" : "sample.7fdd1ee4-29d5-11e7-9ee0-02427da4ced1",
+            "stagedAt" : "2017-04-25T16:37:40.807Z",
+            "version" : "2017-04-25T16:37:40.657Z",
+            "ports" : [
+               31827
+            ],
+            "appId" : "/sample",
+            "slaveId" : "21444bc5-3eb8-49cd-b020-77041e0c88d0-S0",
+            "host" : "10.0.0.9",
+            "startedAt" : "2017-04-25T16:37:42.003Z"
+         }
+      ],
+      "upgradeStrategy" : {
+         "maximumOverCapacity" : 1,
+         "minimumHealthCapacity" : 1
+      },
+      "storeUrls" : [],
+      "requirePorts" : false,
+      "user" : null,
+      "id" : "/sample",
+      "acceptedResourceRoles" : null,
+      "tasksRunning" : 1,
+      "cpus" : 0.5,
+      "executor" : "",
+      "dependencies" : [],
+      "args" : null,
+      "backoffFactor" : 1.15,
+      "ports" : [
+         10000
+      ],
+      "version" : "2017-04-25T16:37:40.657Z",
+      "container" : {
+         "volumes" : [],
+         "docker" : {
+            "portMappings" : [
+               {
+                  "servicePort" : 10000,
+                  "protocol" : "tcp",
+                  "hostPort" : 0,
+                  "containerPort" : 8080
+               }
+            ],
+            "forcePullImage" : false,
+            "parameters" : [],
+            "image" : "python:3",
+            "privileged" : false,
+            "network" : "BRIDGE"
+         },
+         "type" : "DOCKER"
+      },
+      "constraints" : [],
+      "tasksStaged" : 0,
+      "env" : {},
+      "mem" : 32,
+      "disk" : 0,
+      "labels" : {},
+      "tasksHealthy" : 0,
+      "healthChecks" : [],
+      "cmd" : "python3 -m http.server 8080",
+      "backoffSeconds" : 1,
+      "maxLaunchDelaySeconds" : 3600,
+      "versionInfo" : {
+         "lastConfigChangeAt" : "2017-04-25T16:37:40.657Z",
+         "lastScalingAt" : "2017-04-25T16:37:40.657Z"
+      },
+      "uris" : [],
+      "tasksUnhealthy" : 0
+   }
+}</screen>
+   </step>
+   <step>
+    <para>
+     Verify that deployed application is responding on automatically assigned
+     port on floating IP address of worker node.
+    </para>
+<screen>$ curl http://172.31.0.5:31827
+&lt;!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd"&gt;
+&lt;html&gt;
+&lt;head&gt;
+&lt;meta http-equiv="Content-Type" content="text/html; charset=utf-8"&gt;
+&lt;title&gt;Directory listing for /&lt;/title&gt;
+...</screen>
+   </step>
+   <step>
+    <para>
+     If LBaaS v2 is enabled in &productname; environment, a new load balancer can be
+     created to perform request rotation between several masters. For more
+     information about LBaaS v2 support, see <xref linkend="OctaviaInstall"/>.
+    </para>
+   </step>
+  </procedure>
+ </section>
+</section>

--- a/xml/operations-magnum-deploying_docker_fedora_atomic.xml
+++ b/xml/operations-magnum-deploying_docker_fedora_atomic.xml
@@ -1,0 +1,308 @@
+<?xml version="1.0"?>
+<?xml-stylesheet href="urn:x-suse:xslt:profiling:docbook51-profile.xsl"
+ type="text/xml"
+ title="Profiling step"?>
+<!DOCTYPE section [
+ <!ENTITY % entities SYSTEM "entity-decl.ent"> %entities;
+]>
+
+<section xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude"
+          xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="deploying_docker_fedora_atomic">
+ <title>Deploying a Docker Swarm Cluster on Fedora Atomic</title>
+ <section xml:id="idg-all-userguide-container_service-deploying_docker_fedora_atomic-xml-6">
+  <title>Prerequisites</title>
+  <para>
+   These steps assume the following have been completed:
+  </para>
+  <itemizedlist>
+   <listitem>
+    <para>
+     The Magnum service has been installed. For more information, see
+     <xref linkend="MagnumInstall"/>.
+    </para>
+   </listitem>
+   <listitem>
+    <para>
+     Deploying a Docker Swarm Cluster on Fedora Atomic requires the Fedora
+     Atomic image
+     <emphasis role="bold">fedora-atomic-26-20170723.0.x86_64.qcow2</emphasis>
+     prepared specifically for the OpenStack Pike release. You can download
+     the <emphasis role="bold">fedora-atomic-26-20170723.0.x86_64.qcow2</emphasis>
+     image from
+     <link xlink:href="https://download.fedoraproject.org/pub/alt/atomic/stable/Fedora-Atomic-26-20170723.0/CloudImages/x86_64/"/>
+    </para>
+   </listitem>
+  </itemizedlist>
+ </section>
+ <section xml:id="idg-all-userguide-container_service-deploying_docker_fedora_atomic-xml-7">
+  <title>Creating the Cluster</title>
+  <para>
+   The following example is created using Kubernetes Container Orchestration
+   Engine (COE) running on Fedora Atomic guest OS on &productname; VMs.
+  </para>
+  <orderedlist>
+   <listitem>
+    <para>
+     As <emphasis role="bold">stack</emphasis> user, login to the lifecycle
+     manager.
+    </para>
+   </listitem>
+   <listitem>
+    <para>
+     Source openstack admin credentials.
+    </para>
+<screen>$ source service.osrc</screen>
+   </listitem>
+   <listitem>
+    <para>
+     If you haven't already, download Fedora Atomic image, prepared for
+     Openstack Pike release.
+    </para>
+<screen>$ wget https://download.fedoraproject.org/pub/alt/atomic/stable/Fedora-Atomic-26-20170723.0/CloudImages/x86_64/images/Fedora-Atomic-26-20170723.0.x86_64.qcow2</screen>
+   </listitem>
+   <listitem>
+    <para>
+     Create a Glance image.
+    </para>
+<screen>$ glance image-create --name fedora-atomic-26-20170723.0.x86_64 --visibility public \
+  --disk-format qcow2 --os-distro fedora-atomic --container-format bare \
+  --file Fedora-Atomic-26-20170723.0.x86_64.qcow2 --progress
+[=============================&gt;] 100%
++------------------+--------------------------------------+
+| Property         | Value                                |
++------------------+--------------------------------------+
+| checksum         | 9d233b8e7fbb7ea93f20cc839beb09ab     |
+| container_format | bare                                 |
+| created_at       | 2017-04-10T21:13:48Z                 |
+| disk_format      | qcow2                                |
+| id               | 4277115a-f254-46c0-9fb0-fffc45d2fd38 |
+| min_disk         | 0                                    |
+| min_ram          | 0                                    |
+| name             | fedora-atomic-26-20170723.0.x86_64   |
+| os_distro        | fedora-atomic                        |
+| owner            | 2f5b83ab49d54aaea4b39f5082301d09     |
+| protected        | False                                |
+| size             | 515112960                            |
+| status           | active                               |
+| tags             | []                                   |
+| updated_at       | 2017-04-10T21:13:56Z                 |
+| virtual_size     | None                                 |
+| visibility       | public                               |
++------------------+--------------------------------------+</screen>
+   </listitem>
+   <listitem>
+    <para>
+     Create a Nova keypair.
+    </para>
+<screen>$ test -f ~/.ssh/id_rsa.pub || ssh-keygen -t rsa -N "" -f ~/.ssh/id_rsa
+$ nova keypair-add --pub-key ~/.ssh/id_rsa.pub testkey</screen>
+   </listitem>
+   <listitem>
+    <para>
+     Create a Magnum cluster template.
+    </para>
+    <note>
+     <para>
+      The <literal>--tls-disabled</literal> flag is not specified in the
+      included template. Authentication via client certificate will be turned
+      on in clusters created from this template.
+     </para>
+    </note>
+<screen>$  magnum cluster-template-create --name my-swarm-template \
+  --image-id 4277115a-f254-46c0-9fb0-fffc45d2fd38 \
+  --keypair-id testkey \
+  --external-network-id ext-net \
+  --dns-nameserver 8.8.8.8 \
+  --flavor-id m1.small \
+  --docker-volume-size 5 \
+  --network-driver docker \
+  --coe swarm \
+  --http-proxy http://proxy.yourcompany.net:8080/ \
+  --https-proxy http://proxy.yourcompany.net:8080/</screen>
+    <note>
+     <orderedlist>
+      <listitem>
+       <para>
+        Use the <literal>image_id</literal> from
+        <literal>glance image-create</literal> command output in the previous
+        step.
+       </para>
+      </listitem>
+      <listitem>
+       <para>
+        Use your organization's DNS server. If the &productname; public endpoint
+        is configured with the hostname, this server should provide
+        resolution for this hostname.
+       </para>
+      </listitem>
+      <listitem>
+       <para>
+        The proxy is only needed if public internet (for example,
+        <literal>https://discovery.etcd.io/</literal> or
+        <literal>https://gcr.io/</literal>) is not accessible without proxy.
+       </para>
+      </listitem>
+     </orderedlist>
+    </note>
+   </listitem>
+   <listitem>
+    <para>
+     Create cluster. The command below will create a minimalistic cluster
+     consisting of a single Kubernetes Master (kubemaster) and single
+     Kubernetes Node (worker, kubeminion).
+    </para>
+<screen>$ magnum cluster-create --name my-swarm-cluster --cluster-template my-swarm-template \
+  --node-count 1 --master-count 1</screen>
+   </listitem>
+   <listitem>
+    <para>
+     Immediately after issuing <literal>cluster-create</literal> command,
+     cluster status should turn to
+     <emphasis role="bold">CREATE_IN_PROGRESS</emphasis>
+     and <literal>stack_id</literal> assigned.
+    </para>
+<screen>$ magnum cluster-show my-swarm-cluster
++---------------------+------------------------------------------------------------+
+| Property            | Value                                                      |
++---------------------+------------------------------------------------------------+
+| status              | CREATE_IN_PROGRESS                                         |
+| cluster_template_id | 17df266e-f8e1-4056-bdee-71cf3b1483e3                       |
+| uuid                | c3e13e5b-85c7-44f4-839f-43878fe5f1f8                       |
+| stack_id            | 3265d843-3677-4fed-bbb7-e0f56c27905a                       |
+| status_reason       | -                                                          |
+| created_at          | 2017-04-21T17:13:08+00:00                                  |
+| name                | my-swarm-cluster                                           |
+| updated_at          | -                                                          |
+| discovery_url       | https://discovery.etcd.io/54e83ea168313b0c2109d0f66cd0aa6f |
+| api_address         | -                                                          |
+| coe_version         | -                                                          |
+| master_addresses    | []                                                         |
+| create_timeout      | 60                                                         |
+| node_addresses      | []                                                         |
+| master_count        | 1                                                          |
+| container_version   | -                                                          |
+| node_count          | 1                                                          |
++---------------------+------------------------------------------------------------+</screen>
+   </listitem>
+   <listitem>
+    <para>
+     You can monitor cluster creation progress by listing the resources of the
+     Heat stack. Use the <literal>stack_id</literal> value from the
+     <literal>magnum cluster-status</literal> output above in the following
+     command:
+    </para>
+<screen>$ heat resource-list -n2 3265d843-3677-4fed-bbb7-e0f56c27905a
+WARNING (shell) "heat resource-list" is deprecated, please use "openstack stack resource list" instead
++--------------------+--------------------------------------+--------------------------------------------+-----------------+----------------------+-------------------------------+
+| resource_name      | physical_resource_id                 | resource_type                              | resource_status | updated_time         | stack_name                    |
+|--------------------+--------------------------------------+--------------------------------------------+-----------------+----------------------+-------------------------------+
+| api_address_switch | 430f82f2-03e3-4085-8c07-b4a6b6d7e261 | Magnum::ApiGatewaySwitcher                 | CREATE_COMPLETE | 2017-04-21T17:13:07Z | my-swarm-cluster-j7gbjcxaremy |
+| api_listener       | a306fd54-e569-4673-8fd3-7ae5ebdf53c3 | Magnum::Optional::Neutron::LBaaS::Listener | CREATE_COMPLETE | 2017-04-21T17:13:07Z | my-swarm-cluster-j7gbjcxaremy |
+. . .</screen>
+   </listitem>
+   <listitem>
+    <para>
+     The cluster is complete when all resources show
+     <emphasis role="bold">CREATE_COMPLETE</emphasis>. You can also obtain the
+     floating IP address once the cluster has been created.
+    </para>
+<screen>$ magnum cluster-show my-swarm-cluster
++---------------------+------------------------------------------------------------+
+| Property            | Value                                                      |
++---------------------+------------------------------------------------------------+
+| status              | CREATE_COMPLETE                                            |
+| cluster_template_id | 17df266e-f8e1-4056-bdee-71cf3b1483e3                       |
+| uuid                | c3e13e5b-85c7-44f4-839f-43878fe5f1f8                       |
+| stack_id            | 3265d843-3677-4fed-bbb7-e0f56c27905a                       |
+| status_reason       | Stack CREATE completed successfully                        |
+| created_at          | 2017-04-21T17:13:08+00:00                                  |
+| name                | my-swarm-cluster                                           |
+| updated_at          | 2017-04-21T17:18:26+00:00                                  |
+| discovery_url       | https://discovery.etcd.io/54e83ea168313b0c2109d0f66cd0aa6f |
+| api_address         | tcp://172.31.0.7:2376                                      |
+| coe_version         | 1.0.0                                                      |
+| master_addresses    | ['172.31.0.7']                                             |
+| create_timeout      | 60                                                         |
+| node_addresses      | ['172.31.0.5']                                             |
+| master_count        | 1                                                          |
+| container_version   | 1.9.1                                                      |
+| node_count          | 1                                                          |
++---------------------+------------------------------------------------------------+</screen>
+   </listitem>
+   <listitem>
+    <para>
+     Generate and sign client certificate using <literal>magnum
+     cluster-config</literal> command.
+    </para>
+<screen>$ mkdir my_swarm_cluster
+$ cd my_swarm_cluster/
+~/my_swarm_cluster $ magnum cluster-config my-swarm-cluster
+{'tls': True, 'cfg_dir': '.', 'docker_host': u'tcp://172.31.0.7:2376'}
+~/my_swarm_cluster $ ls
+ca.pem  cert.pem  key.pem</screen>
+   </listitem>
+   <listitem>
+    <para>
+     Copy generated certificates and key to ~/.docker folder on first cluster
+     master node.
+    </para>
+<screen>$ scp -r ~/my_swarm_cluster fedora@172.31.0.7:.docker
+ca.pem                                             100% 1066     1.0KB/s   00:00
+key.pem                                            100% 1679     1.6KB/s   00:00
+cert.pem                                           100% 1005     1.0KB/s   00:00</screen>
+   </listitem>
+   <listitem>
+    <para>
+     Login to first master node and set up cluster access environment
+     variables.
+    </para>
+<screen>$ ssh fedora@172.31.0.7
+[fedora@my-6zxz5ukdu-0-bvqbsn2z2uwo-swarm-master-n6wfplu7jcwo ~]$ export DOCKER_TLS_VERIFY=1
+[fedora@my-6zxz5ukdu-0-bvqbsn2z2uwo-swarm-master-n6wfplu7jcwo ~]$ export DOCKER_HOST=tcp://172.31.0.7:2376</screen>
+   </listitem>
+   <listitem>
+    <para>
+     Verfy that the swarm container is up and running.
+    </para>
+<screen>[fedora@my-6zxz5ukdu-0-bvqbsn2z2uwo-swarm-master-n6wfplu7jcwo ~]$ docker ps -a
+CONTAINER ID        IMAGE               COMMAND                  CREATED             STATUS              PORTS               NAMES
+fcbfab53148c        swarm:1.0.0         "/swarm join --addr 1"   24 minutes ago      Up 24 minutes       2375/tcp            my-xggjts5zbgr-0-d4qhxhdujh4q-swarm-node-vieanhwdonon.novalocal/swarm-agent</screen>
+   </listitem>
+   <listitem>
+    <para>
+     Deploy a sample docker application (nginx) and verify that Nginx is
+     serving requests at port 8080 on worker node(s), on both floating and
+     private IPs:
+    </para>
+<screen>[fedora@my-6zxz5ukdu-0-bvqbsn2z2uwo-swarm-master-n6wfplu7jcwo ~]$ docker run -itd -p 8080:80 nginx
+192030325fef0450b7b917af38da986edd48ac5a6d9ecb1e077b017883d18802
+
+[fedora@my-6zxz5ukdu-0-bvqbsn2z2uwo-swarm-master-n6wfplu7jcwo ~]$ docker port 192030325fef
+80/tcp -&gt; 10.0.0.11:8080
+
+[fedora@my-6zxz5ukdu-0-bvqbsn2z2uwo-swarm-master-n6wfplu7jcwo ~]$ curl http://10.0.0.11:8080
+&lt;!DOCTYPE html&gt;
+&lt;html&gt;
+&lt;head&gt;
+&lt;title&gt;Welcome to nginx!&lt;/title&gt;
+&lt;style&gt;
+...
+[fedora@my-6zxz5ukdu-0-bvqbsn2z2uwo-swarm-master-n6wfplu7jcwo ~]$ curl http://172.31.0.5:8080
+&lt;!DOCTYPE html&gt;
+&lt;html&gt;
+&lt;head&gt;
+&lt;title&gt;Welcome to nginx!&lt;/title&gt;
+&lt;style&gt;
+...</screen>
+   </listitem>
+   <listitem>
+    <para>
+     If LBaaS v2 is enabled in your &productname; environment, a new load balancer
+     can be created to perform request rotation between several masters. For
+     more information about LBaaS v2 support, see
+     <xref linkend="OctaviaInstall"/>.
+    </para>
+   </listitem>
+  </orderedlist>
+ </section>
+</section>

--- a/xml/operations-magnum-deploying_kubernetes_coreos.xml
+++ b/xml/operations-magnum-deploying_kubernetes_coreos.xml
@@ -1,0 +1,316 @@
+<?xml version="1.0"?>
+<?xml-stylesheet href="urn:x-suse:xslt:profiling:docbook51-profile.xsl"
+ type="text/xml"
+ title="Profiling step"?>
+<!DOCTYPE section [
+ <!ENTITY % entities SYSTEM "entity-decl.ent"> %entities;
+]>
+
+<section xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="deploying_kubernetes_coreos">
+ <title>Deploying a Kubernetes Cluster on CoreOS</title>
+ <section xml:id="idg-all-userguide-container_service-deploying_kubernetes_coreos-xml-6">
+  <title>Prerequisites</title>
+  <para>
+   These steps assume the following have been completed:
+  </para>
+  <itemizedlist>
+   <listitem>
+    <para>
+     The Magnum service has been installed. For more information, see
+     <xref linkend="MagnumInstall"/>.
+    </para>
+   </listitem>
+   <listitem>
+    <para>
+     Creating the Magnum cluster requires the CoreOS image for OpenStack. You
+     can download compressed image file
+     <emphasis role="bold">coreos_production_openstack_image.img.bz2</emphasis>
+     from
+     <link xlink:href="http://stable.release.core-os.net/amd64-usr/current/"/>.
+    </para>
+   </listitem>
+  </itemizedlist>
+ </section>
+ <section xml:id="idg-all-userguide-container_service-deploying_kubernetes_coreos-xml-7">
+  <title>Creating the Cluster</title>
+  <para>
+   The following example is created using Kubernetes Container Orchestration
+   Engine (COE) running on CoreOS guest OS on &productname; VMs.
+  </para>
+  <orderedlist>
+   <listitem>
+    <para>
+     Login to the &lcm;.
+    </para>
+   </listitem>
+   <listitem>
+    <para>
+     Source openstack admin credentials.
+    </para>
+<screen>$ source service.osrc</screen>
+   </listitem>
+   <listitem>
+    <para>
+     If you haven't already, download CoreOS image that is compatible for the OpenStack
+     release.
+    </para>
+    <note>
+     <para>
+      The https_proxy is only needed if your environment requires a proxy.
+     </para>
+    </note>
+<screen>$ export https_proxy=http://proxy.yourcompany.net:8080
+$ wget https://stable.release.core-os.net/amd64-usr/current/coreos_production_openstack_image.img.bz2
+$ bunzip2 coreos_production_openstack_image.img.bz2</screen>
+   </listitem>
+   <listitem>
+    <para>
+     Create a Glance image.
+    </para>
+<screen>$ glance image-create --name coreos-magnum --visibility public \
+  --disk-format raw --os-distro coreos --container-format bare \
+  --file coreos_production_openstack_image.img --progress
+[=============================&gt;] 100%
++------------------+--------------------------------------+
+| Property         | Value                                |
++------------------+--------------------------------------+
+| checksum         | 4110469bb15af72ec0cf78c2da4268fa     |
+| container_format | bare                                 |
+| created_at       | 2017-04-25T18:10:52Z                 |
+| disk_format      | raw                                  |
+| id               | c25fc719-2171-437f-9542-fcb8a534fbd1 |
+| min_disk         | 0                                    |
+| min_ram          | 0                                    |
+| name             | coreos-magnum                        |
+| os_distro        | coreos                               |
+| owner            | 2f5b83ab49d54aaea4b39f5082301d09     |
+| protected        | False                                |
+| size             | 806551552                            |
+| status           | active                               |
+| tags             | []                                   |
+| updated_at       | 2017-04-25T18:11:07Z                 |
+| virtual_size     | None                                 |
+| visibility       | public                               |
++------------------+--------------------------------------+</screen>
+   </listitem>
+   <listitem>
+    <para>
+     Create a Nova keypair.
+    </para>
+<screen>$ test -f ~/.ssh/id_rsa.pub || ssh-keygen -t rsa -N "" -f ~/.ssh/id_rsa
+$ nova keypair-add --pub-key ~/.ssh/id_rsa.pub testkey</screen>
+   </listitem>
+   <listitem>
+    <para>
+     Create a Magnum cluster template.
+    </para>
+<screen>$ magnum cluster-template-create --name my-coreos-template \
+  --image-id c25fc719-2171-437f-9542-fcb8a534fbd1 \
+  --keypair-id testkey \
+  --external-network-id ext-net \
+  --dns-nameserver 8.8.8.8 \
+  --flavor-id m1.small \
+  --docker-volume-size 5 \
+  --network-driver flannel \
+  --coe kubernetes \
+  --http-proxy http://proxy.yourcompany.net:8080/ \
+  --https-proxy http://proxy.yourcompany.net:8080/</screen>
+    <note>
+     <orderedlist>
+       <listitem>
+        <para>
+         Use the <emphasis>image_id</emphasis> from
+         <literal>glance image-create</literal> command output in the
+         previous step.
+        </para>
+       </listitem>
+       <listitem>
+        <para>
+         Use your organization's DNS server. If the &productname; public endpoint
+         is configured with the hostname, this server should provide
+         resolution for this hostname.
+        </para>
+       </listitem>
+       <listitem>
+        <para>
+         The proxy is only needed if public internet (for example,
+         <literal>https://discovery.etcd.io/</literal> or
+         <literal>https://gcr.io/</literal>) is not accessible without proxy.
+        </para>
+       </listitem>
+      </orderedlist>
+     </note>
+   </listitem>
+   <listitem>
+    <para>
+     Create cluster. The command below will create a minimalistic cluster
+     consisting of a single Kubernetes Master (kubemaster) and single
+     Kubernetes Node (worker, kubeminion).
+    </para>
+<screen>$ magnum cluster-create --name my-coreos-cluster --cluster-template my-coreos-template --node-count 1 --master-count 1</screen>
+   </listitem>
+   <listitem>
+    <para>
+     Almost immediately after issuing <literal>cluster-create</literal>
+     command, cluster status should turn to
+     <emphasis role="bold">CREATE_IN_PROGRESS</emphasis> and stack_id assigned.
+    </para>
+<screen>$ magnum cluster-show my-coreos-cluster
++---------------------+------------------------------------------------------------+
+| Property            | Value                                                      |
++---------------------+------------------------------------------------------------+
+| status              | CREATE_IN_PROGRESS                                         |
+| cluster_template_id | c48fa7c0-8dd9-4da4-b599-9e62dc942ca5                       |
+| uuid                | 6b85e013-f7c3-4fd3-81ea-4ea34201fd45                       |
+| stack_id            | c93f873a-d563-4721-9bd9-3bae2340750a                       |
+| status_reason       | -                                                          |
+| created_at          | 2017-04-25T22:38:43+00:00                                  |
+| name                | my-coreos-cluster                                          |
+| updated_at          | -                                                          |
+| discovery_url       | https://discovery.etcd.io/6e4c0e5ff5e5b9872173d06880886a0c |
+| api_address         | -                                                          |
+| coe_version         | -                                                          |
+| master_addresses    | []                                                         |
+| create_timeout      | 60                                                         |
+| node_addresses      | []                                                         |
+| master_count        | 1                                                          |
+| container_version   | -                                                          |
+| node_count          | 1                                                          |
++---------------------+------------------------------------------------------------+</screen>
+   </listitem>
+   <listitem>
+    <para>
+     You can monitor cluster creation progress by listing the resources of the
+     Heat stack. Use the <literal>stack_id</literal> value from the
+     <literal>magnum cluster-status</literal> output above in the following
+     command:
+    </para>
+<screen>$ heat resource-list -n2 c93f873a-d563-4721-9bd9-3bae2340750a
+WARNING (shell) "heat resource-list" is deprecated, please use "openstack stack resource list" instead
++--------------------------------+-------------------------------------------------------------------------------------+-------------------------------------------------------------------
+----------------------------------------------------------------+--------------------+----------------------+-------------------------------------------------------------------------+
+| resource_name                  | physical_resource_id                                                                | resource_type
+                                                                | resource_status    | updated_time         | stack_name                                                              |
++--------------------------------+-------------------------------------------------------------------------------------+-------------------------------------------------------------------
+----------------------------------------------------------------+--------------------+----------------------+-------------------------------------------------------------------------+
+| api_address_switch             |                                                                                     | Magnum::ApiGatewaySwitcher
+                                                                | INIT_COMPLETE      | 2017-04-25T22:38:42Z | my-coreos-cluster-mscybll54eoj                                          |
+| api_listener                   | 1dc1c599-b552-4f03-94e9-936fbb889741                                                | Magnum::Optional::Neutron::LBaaS::Listener
+                                                                | CREATE_COMPLETE    | 2017-04-25T22:38:42Z | my-coreos-cluster-mscybll54eoj                                          |
+| api_loadbalancer               | bf1d8c64-a75f-4eec-8f2f-373d49aee581                                                | Magnum::Optional::Neutron::LBaaS::LoadBalancer
+                                                                | CREATE_COMPLETE    | 2017-04-25T22:38:42Z | my-coreos-cluster-mscybll54eoj                                          |
+. . .
+</screen>
+   </listitem>
+   <listitem>
+    <para>
+     The cluster is complete when all resources show
+     <emphasis role="bold">CREATE_COMPLETE</emphasis>.
+    </para>
+   </listitem>
+   <listitem>
+    <para>
+     Install kubectl onto your &lcm;.
+    </para>
+<screen>$ export https_proxy=http://proxy.yourcompany.net:8080
+$ wget https://storage.googleapis.com/kubernetes-release/release/v1.2.0/bin/linux/amd64/kubectl
+$ chmod +x ./kubectl
+$ sudo mv ./kubectl /usr/local/bin/kubectl</screen>
+   </listitem>
+   <listitem>
+    <para>
+     Generate the cluster configuration using
+     <command>magnum cluster-config</command>. If the CLI option
+     <option>--tls-disabled</option> was not
+     specified during cluster template creation, authentication in the cluster
+     will be turned on. In this case, <command>magnum cluster-config</command>
+     command will generate client authentication certificate
+     (<filename>cert.pem</filename>) and key (<filename>key.pem</filename>).
+     Copy and paste <command>magnum cluster-config</command> output
+     to your command line input to finalize configuration (that is, export
+     KUBECONFIG environment variable).
+    </para>
+<screen>$ mkdir my_cluster
+$ cd my_cluster
+/my_cluster $ ls
+/my_cluster $ magnum cluster-config my-cluster
+export KUBECONFIG=./config
+/my_cluster $ ls
+ca.pem cert.pem config key.pem
+/my_cluster $ export KUBECONFIG=./config
+/my_cluster $ kubectl version
+Client Version: version.Info{Major:"1", Minor:"2", GitVersion:"v1.2.0", GitCommit:"5cb86ee022267586db386f62781338b0483733b3", GitTreeState:"clean"}
+Server Version: version.Info{Major:"1", Minor:"2", GitVersion:"v1.2.0", GitCommit:"cffae0523cfa80ddf917aba69f08508b91f603d5", GitTreeState:"clean"}</screen>
+   </listitem>
+   <listitem>
+    <para>
+     Create a simple Nginx replication controller, exposed as a service of type
+     NodePort.
+    </para>
+<screen>$ cat &gt;nginx.yml &lt;&lt;-EOF
+apiVersion: v1
+kind: ReplicationController
+metadata:
+  name: nginx-controller
+spec:
+  replicas: 1
+  selector:
+    app: nginx
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      containers:
+        - name: nginx
+          image: nginx
+          ports:
+            - containerPort: 80
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: nginx-service
+spec:
+  type: NodePort
+  ports:
+  - port: 80
+    nodePort: 30080
+  selector:
+    app: nginx
+EOF
+
+$ kubectl create -f nginx.yml</screen>
+   </listitem>
+   <listitem>
+    <para>
+     Check pod status until it turns from
+     <emphasis role="bold">Pending</emphasis> to
+     <emphasis role="bold">Running</emphasis>.
+    </para>
+<screen>$ kubectl get pods
+NAME                      READY    STATUS     RESTARTS    AGE
+nginx-controller-5cmev    1/1      Running    0           2m</screen>
+   </listitem>
+   <listitem>
+    <para>
+     Ensure that the Nginx welcome page is displayed at port 30080 using the
+     kubemaster floating IP.
+    </para>
+<screen>$ http_proxy= curl http://172.31.0.6:30080
+&lt;!DOCTYPE html&gt;
+&lt;html&gt;
+&lt;head&gt;
+&lt;title&gt;Welcome to nginx!&lt;/title&gt;</screen>
+   </listitem>
+   <listitem>
+    <para>
+     If LBaaS v2 is enabled in &productname; environment, and your cluster was
+     created with more than one kubemaster, a new load balancer can be created
+     to perform request rotation between several masters. For more
+     information about LBaaS v2 support, see <xref linkend="OctaviaInstall"/>.
+    </para>
+   </listitem>
+  </orderedlist>
+ </section>
+</section>

--- a/xml/operations-magnum-deploying_kubernetes_fedora_atomic.xml
+++ b/xml/operations-magnum-deploying_kubernetes_fedora_atomic.xml
@@ -1,0 +1,303 @@
+<?xml version="1.0"?>
+<?xml-stylesheet href="urn:x-suse:xslt:profiling:docbook51-profile.xsl"
+ type="text/xml"
+ title="Profiling step"?>
+<!DOCTYPE section [
+ <!ENTITY % entities SYSTEM "entity-decl.ent"> %entities;
+]>
+
+<section xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude"
+  xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="deploying_kubernetes_fedora_atomic">
+ <title>Deploying a Kubernetes Cluster on Fedora Atomic</title>
+ <section xml:id="idg-all-userguide-container_service-deploying_kubernetes_fedora_atomic-xml-6">
+  <title>Prerequisites</title>
+  <para>
+   These steps assume the following have been completed:
+  </para>
+  <itemizedlist>
+   <listitem>
+    <para>
+     The Magnum service has been installed. For more information, see
+     <xref linkend="MagnumInstall"/>.
+    </para>
+   </listitem>
+   <listitem>
+    <para>
+     Deploying a Kubernetes Cluster on Fedora Atomic requires the Fedora Atomic
+     image <emphasis role="bold">fedora-atomic-26-20170723.0.x86_64.qcow2</emphasis> prepared
+     specifically for the OpenStack release. You can download the
+     <emphasis role="bold">fedora-atomic-26-20170723.0.x86_64.qcow2</emphasis>
+     image from
+     <link xlink:href="https://fedorapeople.org/groups/magnum/"/>
+    </para>
+   </listitem>
+  </itemizedlist>
+ </section>
+ <section xml:id="idg-all-userguide-container_service-deploying_kubernetes_fedora_atomic-xml-7">
+  <title>Creating the Cluster</title>
+  <para>
+   The following example is created using Kubernetes Container Orchestration
+   Engine (COE) running on Fedora Atomic guest OS on &productname; VMs.
+  </para>
+  <orderedlist>
+   <listitem>
+    <para>
+     As <emphasis role="bold">stack</emphasis> user, login to the lifecycle
+     manager.
+    </para>
+   </listitem>
+   <listitem>
+    <para>
+     Source openstack admin credentials.
+    </para>
+<screen>$ source service.osrc</screen>
+   </listitem>
+   <listitem>
+    <para>
+     If you haven't already, download Fedora Atomic image, prepared for the
+     Openstack Pike release.
+    </para>
+<screen>$ wget https://download.fedoraproject.org/pub/alt/atomic/stable/Fedora-Atomic-26-20170723.0/CloudImages/x86_64/images/Fedora-Atomic-26-20170723.0.x86_64.qcow2</screen>
+   </listitem>
+   <listitem>
+    <para>
+     Create a Glance image.
+    </para>
+<screen>$ glance image-create --name fedora-atomic-26-20170723.0.x86_64 --visibility public \
+  --disk-format qcow2 --os-distro fedora-atomic --container-format bare \
+  --file Fedora-Atomic-26-20170723.0.x86_64.qcow2 --progress
+[=============================&gt;] 100%
++------------------+--------------------------------------+
+| Property         | Value                                |
++------------------+--------------------------------------+
+| checksum         | 9d233b8e7fbb7ea93f20cc839beb09ab     |
+| container_format | bare                                 |
+| created_at       | 2017-04-10T21:13:48Z                 |
+| disk_format      | qcow2                                |
+| id               | 4277115a-f254-46c0-9fb0-fffc45d2fd38 |
+| min_disk         | 0                                    |
+| min_ram          | 0                                    |
+| name             | fedora-atomic-26-20170723.0.x86_64   |
+| os_distro        | fedora-atomic                        |
+| owner            | 2f5b83ab49d54aaea4b39f5082301d09     |
+| protected        | False                                |
+| size             | 515112960                            |
+| status           | active                               |
+| tags             | []                                   |
+| updated_at       | 2017-04-10T21:13:56Z                 |
+| virtual_size     | None                                 |
+| visibility       | public                               |
++------------------+--------------------------------------+</screen>
+   </listitem>
+   <listitem>
+    <para>
+     Create a Nova keypair.
+    </para>
+<screen>$ test -f ~/.ssh/id_rsa.pub || ssh-keygen -t rsa -N "" -f ~/.ssh/id_rsa
+$ nova keypair-add --pub-key ~/.ssh/id_rsa.pub testkey</screen>
+   </listitem>
+   <listitem>
+    <para>
+     Create a Magnum cluster template.
+    </para>
+<screen>$ magnum cluster-template-create --name my-template \
+  --image-id 4277115a-f254-46c0-9fb0-fffc45d2fd38 \
+  --keypair-id testkey \
+  --external-network-id ext-net \
+  --dns-nameserver 8.8.8.8 \
+  --flavor-id m1.small \
+  --docker-volume-size 5 \
+  --network-driver flannel \
+  --coe kubernetes \
+  --http-proxy http://proxy.yourcompany.net:8080/ \
+  --https-proxy http://proxy.yourcompany.net:8080/</screen>
+    <note>
+     <orderedlist>
+      <listitem>
+       <para>
+        Use the <emphasis>image_id</emphasis> from <literal>glance
+        image-create</literal> command output in the previous step.
+       </para>
+      </listitem>
+      <listitem>
+       <para>
+        Use your organization's DNS server. If the &productname; public endpoint is
+        configured with the hostname, this server should provide resolution for
+        this hostname.
+       </para>
+      </listitem>
+      <listitem>
+       <para>
+        The proxy is only needed if public internet (for example,
+        <literal>https://discovery.etcd.io/</literal> or
+        <literal>https://gcr.io/</literal>) is not accessible without proxy.
+       </para>
+      </listitem>
+     </orderedlist>
+    </note>
+   </listitem>
+   <listitem>
+    <para>
+     Create cluster. The command below will create a minimalistic cluster
+     consisting of a single Kubernetes Master (kubemaster) and single
+     Kubernetes Node (worker, kubeminion).
+    </para>
+<screen>$ magnum cluster-create --name my-cluster --cluster-template my-template --node-count 1 --master-count 1</screen>
+   </listitem>
+   <listitem>
+    <para>
+     Immediately after issuing <literal>cluster-create</literal> command,
+     cluster status should turn to
+     <emphasis role="bold">CREATE_IN_PROGRESS</emphasis> and stack_id assigned.
+    </para>
+<screen>$ magnum cluster-show my-cluster
++---------------------+------------------------------------------------------------+
+| Property            | Value                                                      |
++---------------------+------------------------------------------------------------+
+| status              | CREATE_IN_PROGRESS                                         |
+| cluster_template_id | 245c6bf8-c609-4ea5-855a-4e672996cbbc                       |
+| uuid                | 0b78a205-8543-4589-8344-48b8cfc24709                       |
+| stack_id            | 22385a42-9e15-49d9-a382-f28acef36810                       |
+| status_reason       | -                                                          |
+| created_at          | 2017-04-10T21:25:11+00:00                                  |
+| name                | my-cluster                                                 |
+| updated_at          | -                                                          |
+| discovery_url       | https://discovery.etcd.io/193d122f869c497c2638021eae1ab0f7 |
+| api_address         | -                                                          |
+| coe_version         | -                                                          |
+| master_addresses    | []                                                         |
+| create_timeout      | 60                                                         |
+| node_addresses      | []                                                         |
+| master_count        | 1                                                          |
+| container_version   | -                                                          |
+| node_count          | 1                                                          |
++---------------------+------------------------------------------------------------+</screen>
+   </listitem>
+   <listitem>
+    <para>
+     You can monitor cluster creation progress by listing the resources of the
+     Heat stack. Use the <literal>stack_id</literal> value from the
+     <literal>magnum cluster-status</literal> output above in the following
+     command:
+    </para>
+<screen>$ heat resource-list -n2 22385a42-9e15-49d9-a382-f28acef36810
+WARNING (shell) "heat resource-list" is deprecated, please use "openstack stack resource list" instead
++-------------------------------+--------------------------------------+-----------------------------------+--------------------+----------------------+-------------------------+
+| resource_name                 | physical_resource_id                 | resource_type                     | resource_status    | updated_time         | stack_name              |
++-------------------------------+--------------------------------------+-----------------------------------+--------------------+----------------------+-------------------------+
+| api_address_floating_switch   | 06b2cc0d-77f9-4633-8d96-f51e2db1faf3 | Magnum::FloatingIPAddressSwitcher | CREATE_COMPLETE    | 2017-04-10T21:25:10Z | my-cluster-z4aquda2mgpv |
+| api_address_lb_switch         | 965124ca-5f62-4545-bbae-8d9cda7aff2e | Magnum::ApiGatewaySwitcher        | CREATE_COMPLETE    | 2017-04-10T21:25:10Z | my-cluster-z4aquda2mgpv |
+. . .</screen>
+   </listitem>
+   <listitem>
+    <para>
+     The cluster is complete when all resources show
+     <emphasis role="bold">CREATE_COMPLETE</emphasis>.
+    </para>
+   </listitem>
+   <listitem>
+    <para>
+     Install kubectl onto your &lcm;.
+    </para>
+<screen>$ export https_proxy=http://proxy.yourcompany.net:8080
+$ wget https://storage.googleapis.com/kubernetes-release/release/v1.2.0/bin/linux/amd64/kubectl
+$ chmod +x ./kubectl
+$ sudo mv ./kubectl /usr/local/bin/kubectl</screen>
+   </listitem>
+   <listitem>
+    <para>
+     Generate the cluster configuration using
+     <command>magnum cluster-config</command>. If the CLI option
+     <option>--tls-disabled</option> was not
+     specified during cluster template creation, authentication in the cluster
+     will be turned on. In this case, <command>magnum cluster-config</command>
+     command will generate client authentication certificate
+     (<filename>cert.pem</filename>) and key (<filename>key.pem</filename>).
+     Copy and paste <command>magnum cluster-config</command> output
+     to your command line input to finalize configuration (that is, export
+     KUBECONFIG environment variable).
+    </para>
+<screen>$ mkdir my_cluster
+$ cd my_cluster
+/my_cluster $ ls
+/my_cluster $ magnum cluster-config my-cluster
+export KUBECONFIG=./config
+/my_cluster $ ls
+ca.pem cert.pem config key.pem
+/my_cluster $ export KUBECONFIG=./config
+/my_cluster $ kubectl version
+Client Version: version.Info{Major:"1", Minor:"2", GitVersion:"v1.2.0", GitCommit:"5cb86ee022267586db386f62781338b0483733b3", GitTreeState:"clean"}
+Server Version: version.Info{Major:"1", Minor:"2", GitVersion:"v1.2.0", GitCommit:"cffae0523cfa80ddf917aba69f08508b91f603d5", GitTreeState:"clean"}</screen>
+   </listitem>
+   <listitem>
+    <para>
+     Create a simple Nginx replication controller, exposed as a service of type
+     NodePort.
+    </para>
+<screen>$ cat &gt;nginx.yml &lt;&lt;-EOF
+apiVersion: v1
+kind: ReplicationController
+metadata:
+  name: nginx-controller
+spec:
+  replicas: 1
+  selector:
+    app: nginx
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      containers:
+        - name: nginx
+          image: nginx
+          ports:
+            - containerPort: 80
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: nginx-service
+spec:
+  type: NodePort
+  ports:
+  - port: 80
+    nodePort: 30080
+  selector:
+    app: nginx
+EOF
+
+$ kubectl create -f nginx.yml</screen>
+   </listitem>
+   <listitem>
+    <para>
+     Check pod status until it turns from
+     <emphasis role="bold">Pending</emphasis> to
+     <emphasis role="bold">Running</emphasis>.
+    </para>
+<screen>$ kubectl get pods
+NAME                      READY    STATUS     RESTARTS    AGE
+nginx-controller-5cmev    1/1      Running    0           2m</screen>
+   </listitem>
+   <listitem>
+    <para>
+     Ensure that the Nginx welcome page is displayed at port 30080 using the
+     kubemaster floating IP.
+    </para>
+<screen>$ http_proxy= curl http://172.31.0.6:30080
+&lt;!DOCTYPE html&gt;
+&lt;html&gt;
+&lt;head&gt;
+&lt;title&gt;Welcome to nginx!&lt;/title&gt;</screen>
+   </listitem>
+   <listitem>
+    <para>
+     If LBaaS v2 is enabled in &productname; environment, and your cluster was
+     created with more than one kubemaster, a new load balancer can be created
+     to perform request rotation between several masters. For more
+     information about LBaaS v2 support, see <xref linkend="OctaviaInstall"/>.
+    </para>
+   </listitem>
+  </orderedlist>
+ </section>
+</section>

--- a/xml/operations-managing_dashboards.xml
+++ b/xml/operations-managing_dashboards.xml
@@ -12,4 +12,5 @@
  </para>
  <xi:include href="operations-configuring-configure_dashboard.xml"/>
  <xi:include href="operations-configuring-change_horizon_timeout.xml"/>
+ <xi:include href="operations-lbaas-dashboard.xml"/>
 </chapter>

--- a/xml/operations-managing_magnum.xml
+++ b/xml/operations-managing_magnum.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0"?>
+<?xml-stylesheet href="urn:x-suse:xslt:profiling:docbook51-profile.xsl"
+ type="text/xml"
+ title="Profiling step"?>
+<!DOCTYPE chapter [
+ <!ENTITY % entities SYSTEM "entity-decl.ent"> %entities;
+]>
+<chapter xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude"
+ xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="using_container_as_a_service_overview">
+ <title>Managing Container as a Service (Magnum)</title>
+
+ <para>
+  The &productname; Magnum Service provides container orchestration engines such as
+  Docker Swarm, Kubernetes, and Apache Mesos available as first class
+  resources. &productname; Magnum uses Heat to orchestrate an OS image which
+  contains Docker and Kubernetes and runs that image in either virtual machines
+  or bare metal in a cluster configuration.
+ </para>
+
+ <xi:include href="operations-magnum-deploying_kubernetes_fedora_atomic.xml"/>
+ <xi:include href="operations-magnum-deploying_kubernetes_coreos.xml"/>
+ <xi:include href="operations-magnum-deploying_docker_fedora_atomic.xml"/>
+ <xi:include href="operations-magnum-deploying_apache_mesos_ubuntu.xml"/>
+ <xi:include href="operations-magnum-create_magnum_cluster_dashboard.xml"/>
+</chapter>

--- a/xml/operations-managing_networking.xml
+++ b/xml/operations-managing_networking.xml
@@ -13,4 +13,5 @@
  <xi:include href="operations-configure_firewall.xml"/>
  <xi:include href="operations-dns-designate_overview.xml"/>
  <xi:include href="networking-networking_overview.xml"/>
+ <xi:include href="networking-create-ha-router.xml"/>
 </chapter>

--- a/xml/operations-managing_networking.xml
+++ b/xml/operations-managing_networking.xml
@@ -11,6 +11,8 @@
   Information about managing and configuring the Networking service.
  </para>
  <xi:include href="operations-configure_firewall.xml"/>
+ <xi:include href="operations-networking-vpnaas.xml"/>
+ <xi:include href="operations-lbaas.xml"/>
  <xi:include href="operations-dns-designate_overview.xml"/>
  <xi:include href="networking-networking_overview.xml"/>
  <xi:include href="networking-create-ha-router.xml"/>

--- a/xml/operations-managing_orchestration.xml
+++ b/xml/operations-managing_orchestration.xml
@@ -13,4 +13,5 @@
  </para>
  <xi:include href="operations-orchestration-configure_orchestration.xml"/>
  <xi:include href="operations-orchestration-autoscaling.xml"/>
+ <xi:include href="operations-orchestration-lbaas.xml"/>
 </chapter>

--- a/xml/operations-networking-vpnaas.xml
+++ b/xml/operations-networking-vpnaas.xml
@@ -1,0 +1,328 @@
+<?xml version="1.0"?>
+<!DOCTYPE section [
+ <!ENTITY % entities SYSTEM "entities.ent"> %entities;
+]>
+<!---->
+<section xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude"
+          xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="UsingVPNaaS">
+ <title>Using VPN as a Service (VPNaaS)</title>
+ <para>
+  <emphasis role="bold">&kw-hos-phrase; VPNaaS Configuration</emphasis>
+ </para>
+ <para>
+  This document describes the configuration process and requirements for the
+  &kw-hos-phrase; Virtual Private Network (VPN) as a Service module.
+ </para>
+ <section xml:id="idg-all-networking-vpnaas-xml-7">
+  <title>Prerequisites</title>
+  <orderedlist>
+   <listitem>
+    <para>
+     &kw-hos; must be installed.
+    </para>
+   </listitem>
+   <listitem>
+    <para>
+     Before setting up VPNaaS, you will need to have created an external
+     network and a subnet with access to the internet. Information on how to
+     create the external network and subnet can be found in
+     <xref linkend="sec.vpnaas.more"/>.
+    </para>
+   </listitem>
+   <listitem>
+    <para>
+     You should assume 172.16.0.0/16 as the ext-net CIDR in this document.
+    </para>
+   </listitem>
+  </orderedlist>
+ </section>
+ <section xml:id="Considerations">
+  <title>Considerations</title>
+  <para>
+   Using the Neutron plugin-based VPNaaS causes additional processes to be run
+   on the Network Service Nodes. One of these processes, the ipsec charon
+   process from StrongSwan, runs as root and listens on an external network. A
+   vulnerability in that process can lead to remote root compromise of the
+   Network Service Nodes. If this is a concern customers should consider using
+   a VPN solution other than the Neutron plugin-based VPNaaS and/or deploying
+   additional protection mechanisms.
+  </para>
+ </section>
+ <section xml:id="idg-all-networking-vpnaas-xml-9">
+  <title>Configuration</title>
+  <para>
+   <emphasis role="bold">Setup Networks</emphasis> You can setup VPN as a
+   Service (VPNaaS) by first creating networks, subnets and routers using the
+   <literal>neutron</literal> command line. The VPNaaS module enables the
+   ability to extend access between private networks across two different
+   &kw-hos; clouds or between a &kw-hos; cloud and a non-cloud network. VPNaaS
+   is based on the open source software application called StrongSwan.
+   StrongSwan (more information available
+   at <link xlink:href="http://www.strongswan.org/"/>)
+   is an IPsec implementation and provides basic VPN gateway functionality.
+  </para>
+  <note>
+   <para>
+    You can execute the included commands from any shell with access to the
+    service APIs. In the included examples, the commands are executed from the
+    lifecycle manager, however you could execute the commands from the
+    controller node or any other shell with aforementioned service API access.
+   </para>
+  </note>
+  <note>
+   <para>
+    The use of floating IP's is not possible with the current version of
+    VPNaaS when DVR is enabled. Ensure that no floating IP is associated to
+    instances that will be using VPNaaS when using a DVR router. Floating IP
+    associated to instances are ok when using CVR router.
+   </para>
+  </note>
+  <procedure>
+   <step>
+    <para>
+     From the &lcm;, create first private network, subnet and
+     router assuming that <emphasis>ext-net</emphasis> is created by admin.
+    </para>
+<screen>neutron net-create privateA
+neutron subnet-create --name subA privateA 10.1.0.0/24 --gateway 10.1.0.1
+neutron router-create router1
+neutron router-interface-add router1 subA
+neutron router-gateway-set router1 ext-net</screen>
+   </step>
+   <step>
+    <para>
+     Create second private network, subnet and router.
+    </para>
+<screen>neutron net-create privateB
+neutron subnet-create --name subB privateB 10.2.0.0/24 --gateway 10.2.0.1
+neutron router-create router2
+neutron router-interface-add router2 subB
+neutron router-gateway-set router2 ext-net</screen>
+   </step>
+  </procedure>
+  <procedure xml:id="pro.vpnaas.start">
+   <title>Starting Virtual Machines</title>
+   <step>
+    <para>
+     From the &lcm; run the following to start the virtual
+     machines. Begin with adding secgroup rules for SSH and ICMP.
+    </para>
+<screen>neutron security-group-rule-create default --protocol icmp
+neutron security-group-rule-create default --protocol tcp --port-range-min 22 --port-range-max 22</screen>
+   </step>
+   <step>
+    <para>
+     Start the virtual machine in the privateA subnet. Using <emphasis>nova
+     images-list</emphasis>, use the image id to boot image instead of the
+     image name. After executing this step, it is recommended that you wait
+     approximately 10 seconds to allow the virtual machine to become active.
+    </para>
+<screen>NETA=$(neutron net-list | awk '/privateA/ {print $2}')
+nova boot --flavor 1 --image &lt;id&gt; --nic net-id=$NETA vm1</screen>
+   </step>
+   <step>
+    <para>
+     Start the virtual machine in the privateB subnet.
+    </para>
+<screen>NETB=$(neutron net-list | awk '/privateB/ {print $2}')
+nova boot --flavor 1 --image &lt;id&gt; --nic net-id=$NETB vm2</screen>
+   </step>
+   <step xml:id="st.vpnaas.obtain-ip">
+    <para>
+     Verify private IP's are allocated to the respective vms. Take note of IP's
+     for later use.
+    </para>
+<screen>nova show vm1
+nova show vm2</screen>
+   </step>
+  </procedure>
+  <procedure>
+   <title>Create VPN</title>
+   <step>
+    <para>
+     You can set up the VPN by executing the below commands from the lifecycle
+     manager or any shell with access to the service APIs. Begin with creating
+     the policies with <literal>vpn-ikepolicy-create</literal> and
+     <literal>vpn-ipsecpolicy-create </literal>.
+    </para>
+<screen>neutron vpn-ikepolicy-create ikepolicy
+neutron vpn-ipsecpolicy-create ipsecpolicy</screen>
+   </step>
+   <step>
+    <para>
+     Create the VPN service at router1.
+    </para>
+<screen>neutron vpn-service-create --name myvpnA --description "My vpn service" router1 subA</screen>
+   </step>
+   <step>
+    <para>
+     Wait at least 5 seconds and then run
+     <literal>ipsec-site-connection-create</literal> to create a ipsec-site
+     connection. Note that <literal>--peer-address</literal> is the assign
+     ext-net IP from router2 and <literal>--peer-cidr</literal> is subB cidr.
+    </para>
+<screen>neutron ipsec-site-connection-create --name vpnconnection1 --vpnservice-id myvpnA \
+--ikepolicy-id ikepolicy --ipsecpolicy-id ipsecpolicy --peer-address 172.16.0.3 \
+--peer-id 172.16.0.3 --peer-cidr 10.2.0.0/24 --psk secret</screen>
+   </step>
+   <step>
+    <para>
+     Create the VPN service at router2.
+    </para>
+<screen>neutron vpn-service-create --name myvpnB --description "My vpn serviceB" router2 subB </screen>
+   </step>
+   <step>
+    <para>
+     Wait at least 5 seconds and then run
+     <literal>ipsec-site-connection-create</literal> to create a ipsec-site
+     connection. Note that <literal>--peer-address</literal> is the assigned
+     ext-net IP from router1 and <literal>--peer-cidr</literal> is subA cidr.
+    </para>
+<screen>neutron ipsec-site-connection-create --name vpnconnection2 --vpnservice-id myvpnB \
+--ikepolicy-id ikepolicy --ipsecpolicy-id ipsecpolicy --peer-address 172.16.0.2 \
+--peer-id 172.16.0.2 --peer-cidr 10.1.0.0/24 --psk secret</screen>
+   </step>
+   <step>
+    <para>
+     On the &lcm;, run the
+     <literal>ipsec-site-connection-list</literal> command to see the active
+     connections. Be sure to check that the vpn_services are ACTIVE. You can
+     check this by running <literal>vpn-service-list</literal> and then
+     checking ipsec-site-connections status. You should expect that the time
+     for both vpn-services and ipsec-site-connections to become ACTIVE could
+     take as long as 1 to 3 minutes.
+    </para>
+<screen>neutron ipsec-site-connection-list
++--------------------------------------+----------------+--------------+---------------+------------+-----------+--------+
+| id                                   | name           | peer_address | peer_cidrs    | route_mode | auth_mode | status |
++--------------------------------------+----------------+--------------+---------------+------------+-----------+--------+
+| 1e8763e3-fc6a-444c-a00e-426a4e5b737c | vpnconnection2 | 172.16.0.2   | "10.1.0.0/24" | static     | psk       | ACTIVE |
+| 4a97118e-6d1d-4d8c-b449-b63b41e1eb23 | vpnconnection1 | 172.16.0.3   | "10.2.0.0/24" | static     | psk       | ACTIVE |
++--------------------------------------+----------------+--------------+---------------+------------+-----------+--------+</screen>
+   </step>
+  </procedure>
+  <para>
+   <emphasis role="bold">Verify VPN</emphasis> In the case of non-admin users,
+   you can verify the VPN connection by pinging the virtual machines.
+  </para>
+  <procedure>
+   <step>
+    <para>
+     Check the VPN connections.
+    </para>
+    <note>
+     <para>
+      vm1-ip and vm2-ip denotes private IP's for vm1 and vm2 respectively.
+      The private IPs are obtained, as described in of
+      <xref linkend="st.vpnaas.obtain-ip"/>. If you are unable to SSH to the
+      private network due to a lack
+      of direct access, the VM console can be accessed through Horizon.
+     </para>
+    </note>
+<screen>ssh cirros@vm1-ip
+password: &lt;password&gt;
+
+# ping the private IP address of vm2
+ping ###.###.###.###</screen>
+   </step>
+   <step>
+    <para>
+     In another terminal.
+    </para>
+<screen>ssh cirros@vm2-ip
+password: &lt;password&gt;
+
+# ping the private IP address of vm1
+ping ###.###.###.###</screen>
+   </step>
+   <step>
+    <para>
+     You should see ping responses from both virtual machines.
+    </para>
+   </step>
+  </procedure>
+  <para>
+   As the admin user, you should check to make sure that a route exists between
+   the router gateways. Once the gateways have been checked, packet encryption
+   can be verified by using traffic analyzer (tcpdump) by tapping on the
+   respective namespace (qrouter-* in case of non-DVR and snat-* in case of
+   DVR) and tapping the right interface (qg-***).
+  </para>
+  <note>
+   <para>
+    When using DVR namespaces, all the occurrences of qrouter-xxxxxx in the
+    following commands should be replaced with respective snat-xxxxxx.
+   </para>
+  </note>
+  <procedure>
+   <step>
+    <para>
+     Check the if the route exists between two router gateways. You can get the
+     right qrouter namespace id by executing <emphasis>sudo ip
+     netns</emphasis>. Once you have the qrouter namespace id, you can get the
+     interface by executing <emphasis>sudo ip netns qrouter-xxxxxxxx ip
+     addr</emphasis> and from the result the interface can be found.
+    </para>
+<screen>sudo ip netns
+sudo ip netns exec qrouter-&lt;router1 UUID&gt; ping &lt;router2 gateway&gt;
+sudo ip netns exec qrouter-&lt;router2 UUID&gt; ping &lt;router1 gateway&gt;</screen>
+   </step>
+   <step>
+    <para>
+     Initiate a tcpdump on the interface.
+    </para>
+<screen>sudo ip netns exec qrouter-xxxxxxxx tcpdump -i qg-xxxxxx</screen>
+   </step>
+   <step>
+    <para>
+     Check the VPN connection.
+    </para>
+<screen>ssh cirros@vm1-ip
+password: &lt;password&gt;
+
+# ping the private IP address of vm2
+ping ###.###.###.###</screen>
+   </step>
+   <step>
+    <para>
+     Repeat for other namespace and right tap interface.
+    </para>
+<screen>sudo ip netns exec qrouter-xxxxxxxx tcpdump -i qg-xxxxxx</screen>
+   </step>
+   <step>
+    <para>
+     In another terminal.
+    </para>
+<screen>ssh cirros@vm2-ip
+password: &lt;password&gt;
+
+# ping the private IP address of vm1
+ping ###.###.###.###</screen>
+   </step>
+   <step>
+    <para>
+     You will find encrypted packets containing ‘ESP’ in the tcpdump trace.
+    </para>
+   </step>
+  </procedure>
+ </section>
+ <section xml:id="sec.vpnaas.more">
+  <title>More Information</title>
+  <para>
+   VPNaaS currently only supports Pre-shared Keys (PSK) security between VPN
+   gateways. A different VPN gateway solution should be considered if stronger,
+   certificate-based security is required.
+  </para>
+  <para>
+   For more information on the neutron command-line interface (CLI) and VPN as
+   a Service (VPNaaS), see the OpenStack networking command-line client
+   reference:
+   <link xlink:href="http://docs.openstack.org/cli-reference/content/neutronclient_commands.html"/>
+  </para>
+  <para>
+   For information on how to create an external network and subnet, see the
+   OpenStack manual:
+   <link xlink:href="http://docs.openstack.org/user-guide/dashboard_create_networks.html"/>
+  </para>
+ </section>
+</section>

--- a/xml/operations-networking-vpnaas.xml
+++ b/xml/operations-networking-vpnaas.xml
@@ -1,24 +1,27 @@
 <?xml version="1.0"?>
+<?xml-stylesheet href="urn:x-suse:xslt:profiling:docbook51-profile.xsl"
+ type="text/xml"
+ title="Profiling step"?>
 <!DOCTYPE section [
- <!ENTITY % entities SYSTEM "entities.ent"> %entities;
+ <!ENTITY % entities SYSTEM "entity-decl.ent"> %entities;
 ]>
-<!---->
+
 <section xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude"
           xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="UsingVPNaaS">
  <title>Using VPN as a Service (VPNaaS)</title>
  <para>
-  <emphasis role="bold">&kw-hos-phrase; VPNaaS Configuration</emphasis>
+  <emphasis role="bold">&productname; &productnumber; VPNaaS Configuration</emphasis>
  </para>
  <para>
   This document describes the configuration process and requirements for the
-  &kw-hos-phrase; Virtual Private Network (VPN) as a Service module.
+  &productname; &productnumber; Virtual Private Network (VPN) as a Service module.
  </para>
  <section xml:id="idg-all-networking-vpnaas-xml-7">
   <title>Prerequisites</title>
   <orderedlist>
    <listitem>
     <para>
-     &kw-hos; must be installed.
+     &productname; must be installed.
     </para>
    </listitem>
    <listitem>
@@ -55,7 +58,7 @@
    Service (VPNaaS) by first creating networks, subnets and routers using the
    <literal>neutron</literal> command line. The VPNaaS module enables the
    ability to extend access between private networks across two different
-   &kw-hos; clouds or between a &kw-hos; cloud and a non-cloud network. VPNaaS
+   &productname; clouds or between a &productname; cloud and a non-cloud network. VPNaaS
    is based on the open source software application called StrongSwan.
    StrongSwan (more information available
    at <link xlink:href="http://www.strongswan.org/"/>)

--- a/xml/operations-orchestration-lbaas.xml
+++ b/xml/operations-orchestration-lbaas.xml
@@ -1,13 +1,16 @@
 <?xml version="1.0"?>
+<?xml-stylesheet href="urn:x-suse:xslt:profiling:docbook51-profile.xsl"
+ type="text/xml"
+ title="Profiling step"?>
 <!DOCTYPE section [
- <!ENTITY % entities SYSTEM "entities.ent"> %entities;
+ <!ENTITY % entities SYSTEM "entity-decl.ent"> %entities;
 ]>
-<!---->
-<sectionxmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude"
+
+<section xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude"
  xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="LBaaSHeat">
   <title>Orchestration Service support for LBaaS v2</title>
   <para>
-   In &kw-hos;, the Orchestration Service provides support for LBaaS
+   In &productname;, the Orchestration Service provides support for LBaaS
    v2, which means users can create LBaaS v2 resources using Orchestration.
   </para>
   <para>
@@ -46,7 +49,6 @@
     </para>
    </listitem>
   </itemizedlist>
- </section>
  <section xml:id="loadbalancer.limitations">
   <title>Limitations</title>
   <para>
@@ -59,7 +61,7 @@
  <section xml:id="idg-all-userguide-lbaas_heat-xml-8">
   <title>More Information</title>
   <para>
-   For more information on configuring and using the &kw-hos; Load Balancing as
+   For more information on configuring and using the &productname; Load Balancing as
    a Service, see: <xref linkend="HP2.0LBaaSAdmin"/> and
    <xref linkend="HP2.0LBaaS"/>.
   </para>

--- a/xml/operations-orchestration-lbaas.xml
+++ b/xml/operations-orchestration-lbaas.xml
@@ -1,0 +1,76 @@
+<?xml version="1.0"?>
+<!DOCTYPE section [
+ <!ENTITY % entities SYSTEM "entities.ent"> %entities;
+]>
+<!---->
+<sectionxmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude"
+ xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="LBaaSHeat">
+  <title>Orchestration Service support for LBaaS v2</title>
+  <para>
+   In &kw-hos;, the Orchestration Service provides support for LBaaS
+   v2, which means users can create LBaaS v2 resources using Orchestration.
+  </para>
+  <para>
+   The OpenStack documentation for LBaaSv2 resource plugins is available at
+   following locations.
+  </para>
+  <itemizedlist>
+   <listitem>
+    <para>
+     Neutron LBaaS v2 LoadBalancer:
+     <link xlink:href="http://docs.openstack.org/developer/heat/template_guide/openstack.html#OS::Neutron::LBaaS::LoadBalancer"/>
+    </para>
+   </listitem>
+   <listitem>
+    <para>
+     Neutron LBaaS v2 Listener:
+     <link xlink:href="http://docs.openstack.org/developer/heat/template_guide/openstack.html#OS::Neutron::LBaaS::Listener"/>
+    </para>
+   </listitem>
+   <listitem>
+    <para>
+     Neutron LBaaS v2 Pool:
+     <link xlink:href="http://docs.openstack.org/developer/heat/template_guide/openstack.html#OS::Neutron::LBaaS::Pool"/>
+    </para>
+   </listitem>
+   <listitem>
+    <para>
+     Neutron LBaaS v2 Pool Member:
+     <link xlink:href="http://docs.openstack.org/developer/heat/template_guide/openstack.html#OS::Neutron::LBaaS::PoolMember"/>
+    </para>
+   </listitem>
+   <listitem>
+    <para>
+     Neutron LBaaS v2 Health Monitor:
+     <link xlink:href="http://docs.openstack.org/developer/heat/template_guide/openstack.html#OS::Neutron::LBaaS::HealthMonitor"/>
+    </para>
+   </listitem>
+  </itemizedlist>
+ </section>
+ <section xml:id="loadbalancer.limitations">
+  <title>Limitations</title>
+  <para>
+   In order to avoid stack-create timeouts when using load balancers, it is
+   recommended that no more than 100 load balancers be created at a time using
+   stack-create loops. Larger numbers of load balancers could reach quotas
+   and/or exhaust resources resulting in the stack create-timeout.
+  </para>
+ </section>
+ <section xml:id="idg-all-userguide-lbaas_heat-xml-8">
+  <title>More Information</title>
+  <para>
+   For more information on configuring and using the &kw-hos; Load Balancing as
+   a Service, see: <xref linkend="HP2.0LBaaSAdmin"/> and
+   <xref linkend="HP2.0LBaaS"/>.
+  </para>
+  <para>
+   For more information on the neutron command-line interface (CLI) and load
+   balancing, see the OpenStack networking command-line client reference:
+   <link xlink:href="http://docs.openstack.org/cli-reference/content/neutronclient_commands.html"/>
+  </para>
+  <para>
+   For more information on Heat see:
+   <link xlink:href="http://docs.openstack.org/developer/heat"/>
+  </para>
+ </section>
+</section>

--- a/xml/operations-tutorials-installing_cli.xml
+++ b/xml/operations-tutorials-installing_cli.xml
@@ -1,0 +1,159 @@
+<?xml version="1.0"?>
+<!DOCTYPE section [
+ <!ENTITY % entities SYSTEM "entities.ent"> %entities;
+]>
+<!---->
+<section xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude"
+        xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="install_cli">
+ <title>Installing the Command-Line Clients</title>
+ <para>
+  During the installation, by default, the suite of OpenStack command-line
+  tools are installed on the &lcm; and the control plane in your
+  environment. This includes the OpenStack Command-Line Interface as well as
+  the clients for the individual services such as the NovaClient, CinderClient,
+  and SwiftClient. You can learn more about these in the OpenStack
+  documentation here:
+  <link xlink:href="http://docs.openstack.org/cli-reference/">OpenStack
+  Command-Line Interface Reference</link>.
+ </para>
+ <para>
+  If you wish to install the command-line interfaces on other nodes in your
+  environment, there are two methods you can use to do so that we describe
+  below.
+ </para>
+ <section xml:id="idg-all-userguide-installing_cli-xml-5">
+  <title>Installing the CLI tools using the input model</title>
+  <para>
+   During the initial install phase of your cloud you can edit your input model
+   to request that the command-line clients be installed on any of the node
+   clusters in your environment. To do so, follow these steps:
+  </para>
+  <procedure>
+   <step>
+    <para>
+     Log in to the &lcm;.
+    </para>
+   </step>
+   <step>
+    <para>
+     Edit your <literal>control_plane.yml</literal> file. Full path:
+    </para>
+<screen>~/openstack/my_cloud/definition/data/control_plane.yml</screen>
+   </step>
+   <step>
+    <para>
+     In this file you will see a list of <literal>service-components</literal>
+     to be installed on each of your clusters. These clusters will be divided
+     per role, with your controller node cluster likely coming at the
+     beginning. Here you will see a list of each of the clients that can be
+     installed. These include:
+    </para>
+<screen>keystone-client
+glance-client
+cinder-client
+nova-client
+neutron-client
+swift-client
+heat-client
+openstack-client
+ceilometer-client
+monasca-client
+barbican-client
+designate-client</screen>
+   </step>
+   <step>
+    <para>
+     For each client you want to install, specify the name under the
+     <literal>service-components</literal> section for the cluster you want to
+     install it on.
+    </para>
+    <para>
+     So, for example, if you would like to install the Nova and Neutron clients on
+     your Compute node cluster, you can do so by adding the
+     <literal>nova-client</literal> and <literal>neutron-client</literal>
+     services, like this:
+    </para>
+<screen>      resources:
+        - name: compute
+          resource-prefix: comp
+          server-role: COMPUTE-ROLE
+          allocation-policy: any
+          min-count: 0
+          service-components:
+            - ntp-client
+            - nova-compute
+            - nova-compute-kvm
+            - neutron-l3-agent
+            - neutron-metadata-agent
+            - neutron-openvswitch-agent
+            - neutron-lbaasv2-agent
+            <emphasis role="bold">- nova-client
+            - neutron-client</emphasis></screen>
+    <note>
+     <para>
+      This example uses the <literal>entry-scale-kvm</literal> sample
+      file. Your model may be different so use this as a guide but do not
+      copy and paste the contents of this example into your input model.
+     </para>
+    </note>
+   </step>
+   <step>
+    <para>
+     Commit your configuration to the local git repo, as follows:
+    </para>
+<screen>cd ~/openstack/ardana/ansible
+git add -A
+git commit -m "My config or other commit message"</screen>
+   </step>
+   <step>
+    <para>
+     Continue with the rest of your installation.
+    </para>
+   </step>
+  </procedure>
+ </section>
+ <section xml:id="idg-all-userguide-installing_cli-xml-6">
+  <title>Installing the CLI tools using Ansible</title>
+  <para>
+   At any point after your initial installation you can install the
+   command-line clients on any of the nodes in your environment. To do so,
+   follow these steps:
+  </para>
+  <orderedlist>
+   <listitem>
+    <para>
+     Log in to the &lcm;.
+    </para>
+   </listitem>
+   <listitem>
+    <para>
+     Obtain the hostname for the nodes you want to install the clients on by
+     looking in your hosts file:
+    </para>
+<screen>cat /etc/hosts</screen>
+   </listitem>
+   <listitem>
+    <para>
+     Install the clients using this playbook, specifying your hostnames using
+     commas:
+    </para>
+<screen>cd ~/scratch/ansible/next/ardana/ansible
+ansible-playbook -i hosts/verb_hosts -e "install_package=&lt;client_name&gt;" client-deploy.yml -e "install_hosts=&lt;hostname&gt;"</screen>
+    <para>
+     So, for example, if you would like to install the NovaClient on two of your
+     Compute nodes with hostnames <literal>ardana-cp1-comp0001-mgmt</literal>
+     and <literal>ardana-cp1-comp0002-mgmt</literal> you can use this syntax:
+    </para>
+<screen>cd ~/scratch/ansible/next/ardana/ansible
+ansible-playbook -i hosts/verb_hosts -e "install_package=novaclient" client-deploy.yml -e "install_hosts=ardana-cp1-comp0001-mgmt,ardana-cp1-comp0002-mgmt"</screen>
+   </listitem>
+   <listitem>
+    <para>
+     Once the playbook completes successfully, you should be able to SSH to
+     those nodes and, using the proper credentials, authenticate and use the
+     command-line interfaces you have installed.
+    </para>
+   </listitem>
+  </orderedlist>
+ </section>
+</section>

--- a/xml/operations-tutorials-installing_cli.xml
+++ b/xml/operations-tutorials-installing_cli.xml
@@ -1,8 +1,11 @@
 <?xml version="1.0"?>
+<?xml-stylesheet href="urn:x-suse:xslt:profiling:docbook51-profile.xsl"
+ type="text/xml"
+ title="Profiling step"?>
 <!DOCTYPE section [
- <!ENTITY % entities SYSTEM "entities.ent"> %entities;
+ <!ENTITY % entities SYSTEM "entity-decl.ent"> %entities;
 ]>
-<!---->
+
 <section xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude"
         xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="install_cli">
  <title>Installing the Command-Line Clients</title>

--- a/xml/operations-tutorials-using_cli.xml
+++ b/xml/operations-tutorials-using_cli.xml
@@ -1,8 +1,11 @@
 <?xml version="1.0"?>
+<?xml-stylesheet href="urn:x-suse:xslt:profiling:docbook51-profile.xsl"
+ type="text/xml"
+ title="Profiling step"?>
 <!DOCTYPE section [
- <!ENTITY % entities SYSTEM "entities.ent"> %entities;
+ <!ENTITY % entities SYSTEM "entity-decl.ent"> %entities;
 ]>
-<!---->
+
 <section xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude"
  xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="CreateCloudAdmin">
  <title>Cloud Admin Actions with the Command Line</title>

--- a/xml/operations-tutorials-using_cli.xml
+++ b/xml/operations-tutorials-using_cli.xml
@@ -1,0 +1,596 @@
+<?xml version="1.0"?>
+<!DOCTYPE section [
+ <!ENTITY % entities SYSTEM "entities.ent"> %entities;
+]>
+<!---->
+<section xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude"
+ xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="CreateCloudAdmin">
+ <title>Cloud Admin Actions with the Command Line</title>
+ <para>
+  Cloud admins can use the command line tools to perform domain admin tasks
+  such as user and project administration.
+ </para>
+ <para>
+  Cloud admins can use the command line tools to perform domain admin tasks
+  such as user and project administration.
+ </para>
+ <section xml:id="idg-all-operations-cloudadmin_cli-xml-4">
+  <title>Creating Additional Cloud Admins</title>
+  <para>
+   You can create additional Cloud Admins to help with the administration of
+   your cloud.
+  </para>
+  <para>
+   &o_ident; identity service query and administration tasks can be performed
+   using the &ostack; command line utility. The utility is installed by the
+   &lcm; onto the &lcm;.
+  </para>
+  <note>
+   <para>
+    &o_ident; administration tasks should be performed by an
+    <emphasis>admin</emphasis> user with a token scoped to the
+    <emphasis>default</emphasis> domain via the &o_ident; v3 identity API.
+    These settings are preconfigured in the file
+    <filename>~/keystone.osrc</filename>. By default,
+    <filename>keystone.osrc</filename> is configured with the admin endpoint of
+    &o_ident;. If the admin endpoint is not accessible from your network, change
+    <literal>OS_AUTH_URL</literal> to point to the public endpoint.
+   </para>
+  </note>
+ </section>
+ <section xml:id="idg-all-operations-cloudadmin_cli-xml-5">
+  <title>Command Line Examples</title>
+  <para>
+   For a full list of commands, see
+   <link xlink:href="http://docs.openstack.org/developer/python-openstackclient/command-list.html">OpenStackClient
+   Command List</link>.
+  </para>
+  <para>
+   <emphasis role="bold">Sourcing the &o_ident; Administration
+   Credentials</emphasis>
+  </para>
+  <para>
+   You can set the environment variables needed for identity administration by
+   sourcing the <literal>keystone.osrc</literal> file created by the lifecycle
+   manager:
+  </para>
+<screen>source ~/keystone.osrc</screen>
+  <para>
+   <emphasis role="bold">List users in the default domain</emphasis>
+  </para>
+  <para>
+   These users are created by the &lcm; in the MySQL back end:
+  </para>
+<screen>openstack user list</screen>
+  <para>
+   Example output:
+  </para>
+<screen>$ openstack user list
++----------------------------------+------------------+
+| ID                               | Name             |
++----------------------------------+------------------+
+| 155b68eda9634725a1d32c5025b91919 | heat             |
+| 303375d5e44d48f298685db7e6a4efce | octavia          |
+| 40099e245a394e7f8bb2aa91243168ee | logging          |
+| 452596adbf4d49a28cb3768d20a56e38 | admin            |
+| 76971c3ad2274820ad5347d46d7560ec | designate        |
+| 7b2dc0b5bb8e4ffb92fc338f3fa02bf3 | hlm_backup       |
+| 86d345c960e34c9189519548fe13a594 | barbican         |
+| 8e7027ab438c4920b5853d52f1e08a22 | nova_monasca     |
+| 9c57dfff57e2400190ab04955e7d82a0 | barbican_service |
+| a3f99bcc71b242a1bf79dbc9024eec77 | nova             |
+| aeeb56fc4c4f40e0a6a938761f7b154a | glance-check     |
+| af1ef292a8bb46d9a1167db4da48ac65 | cinder           |
+| af3000158c6d4d3d9257462c9cc68dda | demo             |
+| b41a7d0cb1264d949614dc66f6449870 | swift            |
+| b78a2b17336b43368fb15fea5ed089e9 | cinderinternal   |
+| bae1718dee2d47e6a75cd6196fb940bd | monasca          |
+| d4b9b32f660943668c9f5963f1ff43f9 | ceilometer       |
+| d7bef811fb7e4d8282f19fb3ee5089e9 | swift-monitor    |
+| df58b381ca8a4c9bb42e371f2a78ef4f | freezer          |
+| e22bbb2be91342fd9afa20baad4cd490 | neutron          |
+| ec0ad2418a644e6b995d8af3eb5ff195 | glance           |
+| ef16c37ec7a648338eaf53c029d6e904 | swift-dispersion |
+| ef1a6daccb6f4694a27a1c41cc5e7a31 | glance-swift     |
+| fed3a599b0864f5b80420c9e387b4901 | monasca-agent    |
++----------------------------------+------------------+
+</screen>
+  <para>
+   <emphasis role="bold">List domains created by the installation
+   process</emphasis>:
+  </para>
+<screen>openstack domain list</screen>
+  <para>
+   Example output:
+  </para>
+<screen>$ openstack domain list
++----------------------------------+---------+---------+----------------------------------------------------------------------+
+| ID                               | Name    | Enabled | Description                                                          |
++----------------------------------+---------+---------+----------------------------------------------------------------------+
+| 6740dbf7465a4108a36d6476fc967dbd | heat    | True    | Owns users and projects created by heat                              |
+| default                          | Default | True    | Owns users and tenants (i.e. projects) available on Identity API v2. |
++----------------------------------+---------+---------+----------------------------------------------------------------------+</screen>
+  <para>
+   <emphasis role="bold">List the roles</emphasis>:
+  </para>
+<screen>openstack role list</screen>
+  <para>
+   Example output:
+  </para>
+<screen>$ openstack role list
++----------------------------------+---------------------------+
+| ID                               | Name                      |
++----------------------------------+---------------------------+
+| 0be3da26cd3f4cd38d490b4f1a8b0c03 | designate_admin           |
+| 13ce16e4e714473285824df8188ee7c0 | monasca-agent             |
+| 160f25204add485890bc95a6065b9954 | key-manager:service-admin |
+| 27755430b38c411c9ef07f1b78b5ebd7 | monitor                   |
+| 2b8eb0a261344fbb8b6b3d5934745fe1 | key-manager:observer      |
+| 345f1ec5ab3b4206a7bffdeb5318bd32 | admin                     |
+| 49ba3b42696841cea5da8398d0a5d68e | nova_admin                |
+| 5129400d4f934d4fbfc2c3dd608b41d9 | ResellerAdmin             |
+| 60bc2c44f8c7460a9786232a444b56a5 | neutron_admin             |
+| 654bf409c3c94aab8f929e9e82048612 | cinder_admin              |
+| 854e542baa144240bfc761cdb5fe0c07 | monitoring-delegate       |
+| 8946dbdfa3d346b2aa36fa5941b43643 | key-manager:auditor       |
+| 901453d9a4934610ad0d56434d9276b4 | key-manager:admin         |
+| 9bc90d1121544e60a39adbfe624a46bc | monasca-user              |
+| 9fe2a84a3e7443ae868d1009d6ab4521 | service                   |
+| 9fe2ff9ee4384b1894a90878d3e92bab | _member_                  |
+| a24d4e0a5de14bffbe166bfd68b36e6a | swiftoperator             |
+| ae088fcbf579425580ee4593bfa680e5 | heat_stack_user           |
+| bfba56b2562942e5a2e09b7ed939f01b | KeystoneAdmin             |
+| c05f54cf4bb34c7cb3a4b2b46c2a448b | glance_admin              |
+| cd61735400ca4fa19e80cebe9970d9a7 | Member                    |
+| fe010be5c57240db8f559e0114a380c1 | key-manager:creator       |
++----------------------------------+---------------------------+</screen>
+  <para>
+   <emphasis role="bold">List admin user role assignment within default
+   domain</emphasis>:
+  </para>
+<screen>openstack role assignment list --user admin --domain default</screen>
+  <para>
+   Example output:
+  </para>
+<screen># This indicates that the admin user is assigned the admin role within the default domain
+&prompt.ardana; openstack role assignment list --user admin --domain default
++----------------------------------+----------------------------------+-------+---------+---------+
+| Role                             | User                             | Group | Project | Domain  |
++----------------------------------+----------------------------------+-------+---------+---------+
+| b398322103504546a070d607d02618ad | fed1c038d9e64392890b6b44c38f5bbb |       |         | default |
++----------------------------------+----------------------------------+-------+---------+---------+</screen>
+  <para>
+   <emphasis role="bold">Create a new user in default domain</emphasis>:
+  </para>
+<screen>openstack user create --domain default --password-prompt --email &lt;email_address&gt; --description &lt;description&gt; --enable &lt;username&gt;</screen>
+  <para>
+   Example output showing the creation of a user named
+   <literal>testuser</literal> with email address
+   <literal>test@example.com</literal> and a description of <literal>Test
+   User</literal>:
+  </para>
+<screen>&prompt.ardana; openstack user create --domain default --password-prompt --email test@example.com --description "Test User" --enable testuser
+User Password:
+Repeat User Password:
++-------------+----------------------------------+
+| Field       | Value                            |
++-------------+----------------------------------+
+| description | Test User                        |
+| domain_id   | default                          |
+| email       | test@example.com                 |
+| enabled     | True                             |
+| id          | 8aad69acacf0457e9690abf8c557754b |
+| name        | testuser                         |
++-------------+----------------------------------+</screen>
+  <para>
+   <emphasis role="bold">Assign admin role for testuser within the default
+   domain</emphasis>:
+  </para>
+<screen>openstack role add admin --user &lt;username&gt; --domain default
+openstack role assignment list --user &lt;username&gt; --domain default</screen>
+  <para>
+   Example output:
+  </para>
+<screen># Just for demonstration purposes - do not do this in a production environment!
+&prompt.ardana; openstack role add admin --user testuser --domain default
+&prompt.ardana; openstack role assignment list --user testuser --domain default
++----------------------------------+----------------------------------+-------+---------+---------+
+| Role                             | User                             | Group | Project | Domain  |
++----------------------------------+----------------------------------+-------+---------+---------+
+| b398322103504546a070d607d02618ad | 8aad69acacf0457e9690abf8c557754b |       |         | default |
++----------------------------------+----------------------------------+-------+---------+---------+</screen>
+ </section>
+ <section xml:id="default.service.admin.roles">
+  <title>Assigning the default service admin roles</title>
+  <para>
+   The following examples illustrate how you can assign each of the new service
+   admin roles to a user.
+  </para>
+  <para>
+   <emphasis role="bold">Assigning the glance_admin role</emphasis>
+  </para>
+  <para>
+   A user must have the role of admin in order to assign the glance_admin role.
+   To assign the role, you will set the environment variables needed for the
+   identity service administrator.
+  </para>
+  <orderedlist>
+   <listitem>
+    <para>
+     First, source the identity service credentials:
+    </para>
+<screen>source ~/keystone.osrc</screen>
+   </listitem>
+   <listitem>
+    <para>
+     You can add the glance_admin role to a user on a project with this
+     command:
+    </para>
+<screen>openstack role add --user &lt;username&gt; --project &lt;project_name&gt; glance_admin</screen>
+    <para>
+     Example, showing a user named <literal>testuser</literal> being granted
+     the <literal>glance_admin</literal> role in the
+     <literal>test_project</literal> project:
+    </para>
+<screen>openstack role add --user testuser --project test_project glance_admin</screen>
+   </listitem>
+   <listitem>
+    <para>
+     You can confirm the role assignment by listing out the roles:
+    </para>
+<screen>openstack role assignment list --user &lt;username&gt;</screen>
+    <para>
+     Example output:
+    </para>
+<screen>&prompt.ardana; openstack role assignment list --user testuser
++----------------------------------+----------------------------------+-------+----------------------------------+--------+-----------+
+| Role                             | User                             | Group | Project                          | Domain | Inherited |
++----------------------------------+----------------------------------+-------+----------------------------------+--------+-----------+
+| 46ba80078bc64853b051c964db918816 | 8bcfe10101964e0c8ebc4de391f3e345 |       | 0ebbf7640d7948d2a17ac08bbbf0ca5b |        | False     |
++----------------------------------+----------------------------------+-------+----------------------------------+--------+-----------+</screen>
+   </listitem>
+   <listitem>
+    <para>
+     Note that only the role ID is displayed. To get the role name, execute the
+     following:
+    </para>
+<screen>openstack role show &lt;role_id&gt;</screen>
+    <para>
+     Example output:
+    </para>
+<screen>&prompt.ardana; openstack role show 46ba80078bc64853b051c964db918816
++-------+----------------------------------+
+| Field | Value                            |
++-------+----------------------------------+
+| id    | 46ba80078bc64853b051c964db918816 |
+| name  | glance_admin                     |
++-------+----------------------------------+</screen>
+   </listitem>
+   <listitem>
+    <para>
+     To demonstrate that the user has Glance admin privileges, authenticate
+     with those user creds and then upload and publish an image. Only a user
+     with an admin role or glance_admin can publish an image.
+    </para>
+    <orderedlist>
+     <listitem>
+      <para>
+       The easiest way to do this will be to make a copy of the
+       <literal>service.osrc</literal> file and edit it with your user
+       credentials. You can do that with this command:
+      </para>
+<screen>cp ~/service.osrc ~/user.osrc</screen>
+     </listitem>
+     <listitem>
+      <para>
+       Using your preferred editor, edit the <literal>user.osrc</literal> file
+       and replace the values for the following entries to match your user
+       credentials:
+      </para>
+<screen>export OS_USERNAME=&lt;username&gt;
+export OS_PASSWORD=&lt;password&gt;</screen>
+     </listitem>
+     <listitem>
+      <para>
+       You will also need to edit the following lines for your environment:
+      </para>
+<screen>## Change these values from 'unset' to 'export'
+export OS_PROJECT_NAME=&lt;project_name&gt;
+export OS_PROJECT_DOMAIN_NAME=Default</screen>
+      <para>
+       Here is an example output:
+      </para>
+<screen>unset OS_DOMAIN_NAME
+export OS_IDENTITY_API_VERSION=3
+export OS_AUTH_VERSION=3
+export OS_PROJECT_NAME=test_project
+export OS_PROJECT_DOMAIN_NAME=Default
+export OS_USERNAME=testuser
+export OS_USER_DOMAIN_NAME=Default
+export OS_PASSWORD=testuser
+export OS_AUTH_URL=http://192.168.245.9:35357/v3
+export OS_ENDPOINT_TYPE=internalURL
+# OpenstackClient uses OS_INTERFACE instead of OS_ENDPOINT
+export OS_INTERFACE=internal
+export OS_CACERT=/etc/ssl/certs/ca-certificates.crt</screen>
+     </listitem>
+    </orderedlist>
+   </listitem>
+   <listitem>
+    <para>
+     Source the environment variables for your user:
+    </para>
+<screen>source ~/user.osrc</screen>
+   </listitem>
+   <listitem>
+    <para>
+     Upload an image and publicize it:
+    </para>
+<screen>glance image-create --name "upload me" --visibility public --container-format bare --disk-format qcow2 --file uploadme.txt</screen>
+    <para>
+     Example output:
+    </para>
+<screen>+------------------+--------------------------------------+
+| Property         | Value                                |
++------------------+--------------------------------------+
+| checksum         | dd75c3b840a16570088ef12f6415dd15     |
+| container_format | bare                                 |
+| created_at       | 2016-01-06T23:31:27Z                 |
+| disk_format      | qcow2                                |
+| id               | cf1490f4-1eb1-477c-92e8-15ebbe91da03 |
+| min_disk         | 0                                    |
+| min_ram          | 0                                    |
+| name             | upload me                            |
+| owner            | bd24897932074780a20b780c4dde34c7     |
+| protected        | False                                |
+| size             | 10                                   |
+| status           | active                               |
+| tags             | []                                   |
+| updated_at       | 2016-01-06T23:31:31Z                 |
+| virtual_size     | None                                 |
+| visibility       | public                               |
++------------------+--------------------------------------+</screen>
+    <note>
+     <para>
+      You can use the command <command>glance help image-create</command> to
+      get the full syntax for this command.
+     </para>
+    </note>
+   </listitem>
+  </orderedlist>
+  <para>
+   <emphasis role="bold">Assigning the nova_admin role</emphasis>
+  </para>
+  <para>
+   A user must have the role of admin in order to assign the nova_admin role.
+   To assign the role, you will set the environment variables needed for the
+   identity service administrator.
+  </para>
+  <orderedlist>
+   <listitem>
+    <para>
+     First, source the identity service credentials:
+    </para>
+<screen>source ~/keystone.osrc</screen>
+   </listitem>
+   <listitem>
+    <para>
+     You can add the glance_admin role to a user on a project with this
+     command:
+    </para>
+<screen>openstack role add --user &lt;username&gt; --project &lt;project_name&gt; nova_admin</screen>
+    <para>
+     Example, showing a user named <literal>testuser</literal> being granted
+     the <literal>glance_admin</literal> role in the
+     <literal>test_project</literal> project:
+    </para>
+<screen>openstack role add --user testuser --project test_project nova_admin</screen>
+   </listitem>
+   <listitem>
+    <para>
+     You can confirm the role assignment by listing out the roles:
+    </para>
+<screen>openstack role assignment list --user &lt;username&gt;</screen>
+    <para>
+     Example output:
+    </para>
+<screen>&prompt.ardana; openstack role assignment list --user testuser
++----------------------------------+----------------------------------+-------+----------------------------------+--------+-----------+
+| Role                             | User                             | Group | Project                          | Domain | Inherited |
++----------------------------------+----------------------------------+-------+----------------------------------+--------+-----------+
+| 8cdb02bab38347f3b65753099f3ab73c | 8bcfe10101964e0c8ebc4de391f3e345 |       | 0ebbf7640d7948d2a17ac08bbbf0ca5b |        | False     |
++----------------------------------+----------------------------------+-------+----------------------------------+--------+-----------+</screen>
+   </listitem>
+   <listitem>
+    <para>
+     Note that only the role ID is displayed. To get the role name, execute the
+     following:
+    </para>
+<screen>openstack role show &lt;role_id&gt;</screen>
+    <para>
+     Example output:
+    </para>
+<screen>&prompt.ardana; openstack role show 8cdb02bab38347f3b65753099f3ab73c
++-------+----------------------------------+
+| Field | Value                            |
++-------+----------------------------------+
+| id    | 8cdb02bab38347f3b65753099f3ab73c |
+| name  | nova_admin                       |
++-------+----------------------------------+</screen>
+   </listitem>
+   <listitem>
+    <para>
+     To demonstrate that the user has &o_comp; admin privileges, authenticate with
+     those user creds and then upload and publish an image. Only a user with an
+     admin role or glance_admin can publish an image.
+    </para>
+    <orderedlist>
+     <listitem>
+      <para>
+       The easiest way to do this will be to make a copy of the
+       <literal>service.osrc</literal> file and edit it with your user
+       credentials. You can do that with this command:
+      </para>
+<screen>cp ~/service.osrc ~/user.osrc</screen>
+     </listitem>
+     <listitem>
+      <para>
+       Using your preferred editor, edit the <literal>user.osrc</literal> file
+       and replace the values for the following entries to match your user
+       credentials:
+      </para>
+<screen>export OS_USERNAME=&lt;username&gt;
+export OS_PASSWORD=&lt;password&gt;</screen>
+     </listitem>
+     <listitem>
+      <para>
+       You will also need to edit the following lines for your environment:
+      </para>
+<screen>## Change these values from 'unset' to 'export'
+export OS_PROJECT_NAME=&lt;project_name&gt;
+export OS_PROJECT_DOMAIN_NAME=Default</screen>
+      <para>
+       Here is an example output:
+      </para>
+<screen>unset OS_DOMAIN_NAME
+export OS_IDENTITY_API_VERSION=3
+export OS_AUTH_VERSION=3
+export OS_PROJECT_NAME=test_project
+export OS_PROJECT_DOMAIN_NAME=Default
+export OS_USERNAME=testuser
+export OS_USER_DOMAIN_NAME=Default
+export OS_PASSWORD=testuser
+export OS_AUTH_URL=http://192.168.245.9:35357/v3
+export OS_ENDPOINT_TYPE=internalURL
+# OpenstackClient uses OS_INTERFACE instead of OS_ENDPOINT
+export OS_INTERFACE=internal
+export OS_CACERT=/etc/ssl/certs/ca-certificates.crt</screen>
+     </listitem>
+    </orderedlist>
+   </listitem>
+   <listitem>
+    <para>
+     Source the environment variables for your user:
+    </para>
+<screen>source ~/user.osrc</screen>
+   </listitem>
+   <listitem>
+    <para>
+     List all of the virtual machines in the project specified in user.osrc:
+    </para>
+<screen>openstack server list</screen>
+    <para>
+     Example output showing no virtual machines, because there are no virtual
+     machines created on the project specified in the user.osrc file:
+    </para>
+<screen>+--------------------------------------+-------------------------------------------------------+--------+-----------------------------------------------------------------+
+| ID                                   | Name                                                  | Status | Networks                                                        |
++--------------------------------------+-------------------------------------------------------+--------+-----------------------------------------------------------------+
++--------------------------------------+-------------------------------------------------------+--------+-----------------------------------------------------------------+</screen>
+   </listitem>
+   <listitem>
+    <para>
+     For this demonstration, we do have a virtual machine associated with a
+     different project and because your user has nova_admin permissions, you
+     can view those virtual machines using a slightly different command:
+    </para>
+<screen>openstack server list --all-projects</screen>
+    <para>
+     Example output, now showing a virtual machine:
+    </para>
+<screen>&prompt.ardana; openstack server list --all-projects
++--------------------------------------+-------------------------------------------------------+--------+-----------------------------------------------------------------+
+| ID                                   | Name                                                  | Status | Networks                                                        |
++--------------------------------------+-------------------------------------------------------+--------+-----------------------------------------------------------------+
+| da4f46e2-4432-411b-82f7-71ab546f91f3 | testvml                                               | ACTIVE |                                                                 |
++--------------------------------------+-------------------------------------------------------+--------+-----------------------------------------------------------------+</screen>
+   </listitem>
+   <listitem>
+    <para>
+     You can also now delete virtual machines in other projects by using the
+     <literal>--all-tenants</literal> switch:
+    </para>
+<screen>openstack server delete --all-projects &lt;instance_id&gt;</screen>
+    <para>
+     Example, showing us deleting the instance in the previous step:
+    </para>
+<screen>openstack server delete --all-projects da4f46e2-4432-411b-82f7-71ab546f91f3</screen>
+   </listitem>
+   <listitem>
+    <para>
+     You can get a full list of available commands by using this:
+    </para>
+<screen>openstack -h</screen>
+   </listitem>
+  </orderedlist>
+  <para>
+   You can perform the same steps as above for the Neutron and Cinder service
+   admin roles:
+  </para>
+<screen>neutron_admin
+cinder_admin</screen>
+ </section>
+ <section xml:id="customize.policy">
+  <title>Customize policy.json on the &lcm;</title>
+  <para>
+   One way to deploy <filename>policy.json</filename> for a service is by going to each of the
+   target nodes and making changes there. This is not necessary anymore. This
+   process has been streamlined and policy.json files can be edited on the
+   &lcm; and then deployed to nodes. Please exercise caution when modifying
+   policy.json files. It is best to validate the changes in a non-production
+   environment before rolling out policy.json changes into production. It is
+   not recommended that you make policy.json changes without a way to validate
+   the desired policy behavior. Updated policy.json files can be deployed using
+   the appropriate <literal>&lt;service_name&gt;-reconfigure.yml</literal>
+   playbook.
+  </para>
+ </section>
+ <section xml:id="service.roles">
+  <title>Roles</title>
+  <para>
+   Service roles represent the functionality used to implement the &ostack;
+   role based access control (RBAC) model. This is used to manage access to
+   each &ostack; service. Roles are named and assigned per user or group for
+   each project by the identity service. Role definition and policy enforcement
+   are defined outside of the identity service independently by each &ostack;
+   service.
+  </para>
+  <para>
+   The token generated by the identity service for each user authentication
+   contains the role(s) assigned to that user for a particular project. When a
+   user attempts to access a specific &ostack; service, the role is parsed by
+   the service, compared to the service-specific policy file, and then granted
+   the resource access defined for that role by the service policy file.
+  </para>
+  <para>
+   Each service has its own service policy file with the
+   <literal>/etc/[SERVICE_CODENAME]/policy.json</literal> file name format
+   where <literal>[SERVICE_CODENAME]</literal> represents a specific &ostack;
+   service name. For example, the &ostack; &o_comp; service would have a policy
+   file called <literal>/etc/nova/policy.json</literal>.
+  </para>
+  <para>
+   Service policy files can be modified and deployed to control nodes from the
+   &lcm;. Administrators are advised to validate policy changes before checking
+   in the changes to the site branch of the local git repository before rolling
+   the changes into production. Do not make changes to policy files without
+   having a way to validate them.
+  </para>
+  <para>
+   The policy files are located at the following site branch directory on the
+   &lcm;.
+  </para>
+<screen>~/openstack/ardana/ansible/roles/</screen>
+  <para>
+   For test and validation, policy files can be modified in a non-production
+   environment from the <literal>~/scratch/</literal> directory. For a specific
+   policy file, run a search for <literal>policy.json</literal>. To deploy
+   policy changes for a service, run the service specific reconfiguration
+   playbook (for example, <literal>nova-reconfigure.yml</literal>). For a
+   complete list of reconfiguration playbooks, change directories to
+   <literal>~/scratch/ansible/next/ardana/ansible</literal> and run this
+   command:
+  </para>
+<screen>ls –l | grep reconfigure</screen>
+ </section>
+</section>

--- a/xml/operations-tutorials.xml
+++ b/xml/operations-tutorials.xml
@@ -12,6 +12,8 @@
   cloud.
  </para>
  <xi:include href="operations-tutorials-quickstart_guide.xml"/>
+ <xi:include href="operations-tutorials-installing_cli.xml"/>
+ <xi:include href="operations-tutorials-using_cli.xml"/>
  <xi:include href="operations-tutorials-manage_logs.xml"/>
  <xi:include href="operations-tutorials-integrating_logstash_splunk.xml"/>
  <xi:include href="operations-tutorials-keystone_ldap_integration.xml"/>


### PR DESCRIPTION
This PR adds administration and user content from the previously titled User Guide for CLM into the Operations Guide for CLM.

This content is being migrated as the new SOC9 structure favors the usage of the upstream Administration and User Guides. Migrating the content to the CLM Operations Guide ensures that we do not lose CLM-specific user and admin content. 

The User Guide was previously deleted in this PR: https://github.com/SUSE-Cloud/doc-cloud/pull/708