### PR TITLE
Use &clm; instead of &lcm; for C*loud Lifec*ycle Manager [SOC 9]

### DIFF
--- a/xml/architecture-third_party-third_party_service_integration.xml
+++ b/xml/architecture-third_party-third_party_service_integration.xml
@@ -59,7 +59,7 @@
     <para>
      <emphasis role="bold">Packages:</emphasis> Addition of 3rd-party packages
      not available in &productname; repos onto a separate repo on the
-     &lcm; node. After import, these packages are automatically available for
+     &clm; node. After import, these packages are automatically available for
      installation on any target cloud node.
     </para>
    </listitem>
@@ -105,7 +105,7 @@
     <para>
      <emphasis role="bold">Ansible:</emphasis> Addition of third-party playbook
      and roles for the deployment and configuration of third-party components.
-     These playbooks can be integrated with all of the standard &lcm;
+     These playbooks can be integrated with all of the standard &clm;
      lifecycle operations, such as deployment, upgrade and
      reconfiguration.
     </para>
@@ -116,9 +116,9 @@
      third-party service integration may require additional content to be
      deployed to a node, where that content is not packaged as a deb/rpm, or
      the content is not a python plugin to be patched in an existing &productname;
-     service venv or python code for a new venv. &lcm;
+     service venv or python code for a new venv. &clm;
      provides a generic mechanism for packaging such content and delivering it
-     to target nodes (coupled with the use of &lcm; Ansible
+     to target nodes (coupled with the use of &clm; Ansible
      modules in the 3rd-party Ansible playbooks). For example, this mechanism
      can be used to deliver a Java-based application to target cloud
      nodes.</phrase><emphasis role="bold"> </emphasis>
@@ -154,17 +154,17 @@
  <section xml:id="d1e112">
   <title>Using the 3rd-party Import mechanism</title>
   <para>
-   The &lcm; 3rd-party import mechanism allows the import of
+   The &clm; 3rd-party import mechanism allows the import of
    various types of content into the &productname; platform in advance of a
    deployment. In the general use case, the 3rd-party content is imported after
-   the &lcm; has been initialised (i.e. after
+   the &clm; has been initialised (i.e. after
    <filename>hos-init.bash</filename> has been executed). The general procedure
    for importing 3rd-party content is as follows:
   </para>
   <orderedlist>
    <listitem>
     <para>
-     Ensure that the &lcm; has been initialised:
+     Ensure that the &clm; has been initialised:
     </para>
 <screen>~/hos-4.0.0/hos-init.bash</screen>
    </listitem>
@@ -175,7 +175,7 @@
     <orderedlist>
      <listitem>
       <para>
-       Create a top-level directory on the &lcm; under
+       Create a top-level directory on the &clm; under
        <filename>~/third-party</filename> and create sub-directories under that,
        according to the different third-party content being imported, e.g.:
       </para>
@@ -477,7 +477,7 @@ ansible-playbook -i hosts/verb_hosts site.yml</screen>
   <section xml:id="d1e439">
    <title>Service Definitions</title>
    <para>
-    To deploy a cloud with &lcm;, the cloud operator must
+    To deploy a cloud with &clm;, the cloud operator must
     prepare an input model that describes the cloud configuration in terms of
     which services (OpenStack and supporting) run on which server nodes, how
     sets of server nodes are configured in terms of network configuration and
@@ -492,13 +492,13 @@ ansible-playbook -i hosts/verb_hosts site.yml</screen>
    <para>
     A service may comprise of just one service-component, such as rabbitmq or
     mysql. A service-component represents the smallest unit of deployment for
-    &lcm;. A cloud operator describes the desired cloud
+    &clm;. A cloud operator describes the desired cloud
     deployment in terms of the selection layout of service components across
     groups, known as <literal>clusters</literal>. A service and its constituent
     service components are typically defined in separate yaml files (Note: the
     convention is to use separate files for general readability and
     organization, but this is not strictly required); the full set of &productname;
-    services and service components can be viewed on the &lcm; under the
+    services and service components can be viewed on the &clm; under the
     <filename>~/openstack/ardana/services</filename> directory. For example, the
     list of yaml files defining the nova service and its constituent
     service-components (in &product;) is as follows:
@@ -563,7 +563,7 @@ Date:   Wed Jul 13 09:46:19 2016 +0000
   <section xml:id="d1e519">
    <title>Ansible Playbooks and Roles</title>
    <para>
-    &lcm; supports the import of third-party Ansible
+    &clm; supports the import of third-party Ansible
     playbooks roles, as illustrated in the following diagram:
    </para>
    <informalfigure>
@@ -591,7 +591,7 @@ Date:   Wed Jul 13 09:46:19 2016 +0000
     <listitem>
      <para>
       <phrase>Add <literal>hooks</literal> for the integration third-party
-      playbooks with &lcm; lifecycle operations.</phrase>
+      playbooks with &clm; lifecycle operations.</phrase>
      </para>
     </listitem>
     <listitem>
@@ -655,7 +655,7 @@ Date:   Wed Jul 13 09:46:19 2016 +0000
    <para>
     <phrase>When the third-party-import playbook has completed, the above set
     of playbooks, roles and hooks are added to
-    <filename>~/openstack/ardana/ansible</filename> on the &lcm; and
+    <filename>~/openstack/ardana/ansible</filename> on the &clm; and
     committed to git (on the site branch).</phrase> Here is a sample git log
     entry representing the import of some third-party Ansible content:
    </para>
@@ -665,26 +665,26 @@ Date:   Wed Jul 13 09:46:21 2016 +0000
     Third-party Ansible import</screen>
    <para>
     For details on the implementation of ansible playbooks and roles for
-    &lcm;, please refer to <xref linkend="third_party_integrations"/>.
+    &clm;, please refer to <xref linkend="third_party_integrations"/>.
    </para>
    <para>
     In addition to adding the set of third-party Ansible playbooks and roles,
     the third-party top-level playbooks must be integrated with top-level
-    &lcm; playbooks for all supported lifecycle operations,
+    &clm; playbooks for all supported lifecycle operations,
     such as deploy, upgrade and so on. The next section details how that is
     achieved. The final section on Ansible details how to set up symlinks for
     third-party configuration templates.
    </para>
    <section xml:id="d1e608">
-    <title>&lcm; Ansible Hook Mechanism</title>
+    <title>&clm; Ansible Hook Mechanism</title>
     <para>
      To fully integrate your third-party playbooks, you must use the
-     &lcm; mechanism for <literal>hooking</literal> third-party
-     playbooks into the major &lcm; lifecycle operations so
+     &clm; mechanism for <literal>hooking</literal> third-party
+     playbooks into the major &clm; lifecycle operations so
      that, for example, when a deployment is run, it includes your playbooks
-     for deploying a third-party service. &lcm; supports the
+     for deploying a third-party service. &clm; supports the
      integration of third-party level playbooks with the following
-     &lcm; lifecycle operations:
+     &clm; lifecycle operations:
     </para>
     <itemizedlist>
      <listitem>
@@ -719,7 +719,7 @@ Date:   Wed Jul 13 09:46:21 2016 +0000
      </listitem>
     </itemizedlist>
     <para>
-     To hook into &lcm; lifecycle operations, you must
+     To hook into &clm; lifecycle operations, you must
      define a set of hook playbooks under the hooks.d directory within your
      Ansible content, where those playbooks follow a specific naming
      convention:
@@ -744,14 +744,14 @@ hooks.d/&lt;custom&gt;/post-&lt;action&gt;.yml</screen>
      <listitem>
       <para>
        <emphasis role="bold">action: </emphasis>Refers to the top-level
-       operation that &lcm; is executing, e.g. deploy or
+       operation that &clm; is executing, e.g. deploy or
        reconfigure.
       </para>
      </listitem>
      <listitem>
       <para>
        <emphasis role="bold">service: </emphasis>Refers to the name of a
-       &productname; service as per its naming in the &lcm;
+       &productname; service as per its naming in the &clm;
        top-level playbooks (ardana-deploy.yml, ardana-reconfigure.yml, etc.), e.g
        nova, glance, swift, etc.
       </para>
@@ -778,10 +778,10 @@ hooks.d/&lt;custom&gt;/post-&lt;action&gt;.yml</screen>
     <para>
      When the third-party-import playbook has completed, the full contents of
      the Ansible directory will be merged with the existing
-     <filename>~/openstack/ardana/ansible</filename> area on the &lcm;. The
+     <filename>~/openstack/ardana/ansible</filename> area on the &clm;. The
      Ansible hooks are not processed until the ready-deployment playbook has
      been run, after which the inclusion of the hooks will be apparent in the
-     &lcm; playbooks in the scratch area, i.e. under
+     &clm; playbooks in the scratch area, i.e. under
      <filename>/scratch/ansible/next/openstack/ardana</filename>. For example, from the
      above hooks specification, <filename>ardana-deploy.yml</filename> is rendered
      as follows:
@@ -798,7 +798,7 @@ hooks.d/&lt;custom&gt;/post-&lt;action&gt;.yml</screen>
 # License for the specific language governing permissions and limitations
 # under the License.
 #
-# Top-level &lcm; deploy playbook
+# Top-level &clm; deploy playbook
 #
 # Automatically managed by Ansible and will be overwritten on each
 # deploy ready.
@@ -875,7 +875,7 @@ hooks.d/&lt;custom&gt;/post-&lt;action&gt;.yml</screen>
     <para>
      In deploying &productname;, customers may want to modify some of the
      configuration files supplied by &productname;. To facilitate this, the
-     <filename>~/openstack/my_cloud/config</filename> area on the &lcm;
+     <filename>~/openstack/my_cloud/config</filename> area on the &clm;
      contains a set of symlinks to configuration file templates for the various
      services in &productname;. To customise, the customer edits these files
      directly and commits to git (see <xref linkend="using_git"/>) and those
@@ -927,11 +927,11 @@ symlinks:
     It is not uncommon for a third-party service integration to require
     additional content to be deployed to a node, where that content is not
     packaged as a deb/rpm or is a python application that could be deployed
-    into a venv. &lcm; provides a generic mechanism for
+    into a venv. &clm; provides a generic mechanism for
     packaging such content and delivering it to target nodes (coupled with the
-    use of &lcm; Ansible modules in the 3rd-party Ansible
+    use of &clm; Ansible modules in the 3rd-party Ansible
     playbooks). For example, this mechanism can be used to deliver a Java-based
-    application to target Cloud nodes. &lcm; packages this
+    application to target Cloud nodes. &clm; packages this
     content and makes it available in the same repo used for serving out python
     venvs, as shown in the diagram below:
    </para>
@@ -975,7 +975,7 @@ symlinks:
    <para>
     When the third-party-import playbook has been completed, the above content
     is bundled into a single package and made available on the venv repo of the
-    &lcm; node. An example playbook task for delivering this
+    &clm; node. An example playbook task for delivering this
     bundled package to a target cloud node is as follows:
    </para>
 <screen>- name: serviceA-server | install | Install myserviceA package
@@ -1058,7 +1058,7 @@ symlinks:
    <orderedlist>
     <listitem>
      <para>
-      Update the &lcm;:
+      Update the &clm;:
      </para>
 <screen>~/hos-4.x.y/hos-init.bash</screen>
     </listitem>

--- a/xml/bura-bura_overview.xml
+++ b/xml/bura-bura_overview.xml
@@ -275,13 +275,13 @@
      <row>
       <entry>Scheduler</entry>
       <entry>Daemon that stores and retrieves backup/restore jobs and executes them</entry>
-      <entry>Nodes needing backup/restore (controllers, &lcm;)</entry>
+      <entry>Nodes needing backup/restore (controllers, &clm;)</entry>
      </row>
      <row>
       <entry>Agent</entry>
       <entry>The agent that backs up and restores to and from targets. Invoked from scheduler or
        manually.</entry>
-      <entry>Nodes needing backup/restore (controllers, &lcm;)</entry>
+      <entry>Nodes needing backup/restore (controllers, &clm;)</entry>
      </row>
     </tbody>
    </tgroup>

--- a/xml/bura-cloud_control_plane_backup.xml
+++ b/xml/bura-cloud_control_plane_backup.xml
@@ -39,7 +39,7 @@
   <title>Setting up SSH backups</title>
   <para>
    By default, during &product; deployment, backup jobs are automatically
-   deployed to Swift, the MySQL database, the &lcm;, and Swift
+   deployed to Swift, the MySQL database, the &clm;, and Swift
    rings. Restore jobs are also deployed for convenience. It is more secure to
    store those backups also outside of the &productname; infrastructure. If you
    provide all the values required in the following file, jobs will also be

--- a/xml/bura-freezer_scheduler.xml
+++ b/xml/bura-freezer_scheduler.xml
@@ -59,7 +59,7 @@
   <title>Freezer (backup/restore service) Scheduler Client-ID</title>
   <para>
    In &product;, Freezer Scheduler is automatically installed on the
-   &lcm; and controller nodes.
+   &clm; and controller nodes.
   </para>
   <para>
    There is a client_id for each node and its corresponds to the hostname. The

--- a/xml/bura-start_stop_freezer_services.xml
+++ b/xml/bura-start_stop_freezer_services.xml
@@ -11,14 +11,14 @@
   <title>Stop, Start and Restart the Backup Services</title>
   <para>
    To stop the Freezer backup and restore service globally, launch the
-   following playbook from the &lcm; (this will stop all
+   following playbook from the &clm; (this will stop all
    freezer-api and all freezer-agent running on your clusters):
   </para>
 <screen>&prompt.ardana;cd ~/scratch/ansible/next/ardana/ansible
 &prompt.ardana;ansible-playbook -i hosts/verb_hosts freezer-stop.yml</screen>
   <para>
    To start the Freezer backup and restore service globally, launch the
-   following playbook from the &lcm;:
+   following playbook from the &clm;:
   </para>
 <screen>&prompt.ardana;cd ~/scratch/ansible/next/ardana/ansible
 &prompt.ardana;ansible-playbook -i hosts/verb_hosts freezer-start.yml</screen>

--- a/xml/bura-supported_services.xml
+++ b/xml/bura-supported_services.xml
@@ -14,9 +14,9 @@
  <itemizedlist>
   <listitem>
    <formalpara>
-    <title>&lcm; Data</title>
+    <title>&clm; Data</title>
     <para>
-     All important information on the &lcm;
+     All important information on the &clm;
     </para>
    </formalpara>
   </listitem>

--- a/xml/clm_admin_addserver.xml
+++ b/xml/clm_admin_addserver.xml
@@ -10,7 +10,7 @@
 <section xml:id="clm-admin-add-server">
  <title>Adding Servers</title>
  <para>
-  The Add Server page in the &lcm; Admin UI allows for adding additional
+  The Add Server page in the &clm; Admin UI allows for adding additional
   &compnode;s to the Cloud.
  </para>
  <figure xml:id="clm_admin_add_server">
@@ -247,7 +247,7 @@
   <para>
    When all newly added servers have an OS provisioned, either via the Install
    OS process detailed above or having previously been provisioned outside of
-   the &lcm; Admin UI, deployment can begin.
+   the &clm; Admin UI, deployment can begin.
   </para>
   <para>
    The <guimenu>Deploy</guimenu> button will be enabled when one or more new

--- a/xml/clm_admin_topology.xml
+++ b/xml/clm_admin_topology.xml
@@ -8,7 +8,7 @@
  xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>Topology</title>
  <para>
-  The topology section of the &lcm; Admin UI displays an overview of how the
+  The topology section of the &clm; Admin UI displays an overview of how the
   Cloud is configured. Each section of the topology represents some facet of
   the Cloud configuration and provides a visual layout of the way components are
   associated with each other. Many of the components in the topology are linked

--- a/xml/config-ansible_playbook.xml
+++ b/xml/config-ansible_playbook.xml
@@ -45,7 +45,7 @@
   </listitem>
  </itemizedlist>
  <para>
-  In order to execute the playbook from the &lcm;, the
+  In order to execute the playbook from the &clm;, the
   <literal>python-networking-vsphere</literal> package must be installed.
  </para>
  <screen>&prompt.sudo;zypper install python-networking-vsphere</screen>

--- a/xml/create-vapp_template-vcenter.xml
+++ b/xml/create-vapp_template-vcenter.xml
@@ -123,7 +123,7 @@
   <step>
    <para>
     Check that the contents of the ISO files are copied to the locations shown
-    below on your &lcm;. This may already be completed on the &lcm;.
+    below on your &clm;. This may already be completed on the &clm;.
    </para>
    <itemizedlist>
     <listitem>
@@ -348,8 +348,8 @@ STARTMODE='auto'</screen>
       Set up SSH access that does not require a password.
      </para>
      <para>
-      When you have started the installation using the &lcm; or if you are
-      adding a &slsa; node to an existing cloud, the &lcm; public key needs to
+      When you have started the installation using the &clm; or if you are
+      adding a &slsa; node to an existing cloud, the &clm; public key needs to
       be copied to the &slsa; node. You can do this by copying
       <filename>~/.ssh/authorized_keys</filename> from another node
       in the cloud to the same location on the &slsa; node. If you are
@@ -363,7 +363,7 @@ STARTMODE='auto'</screen>
       </para>
      </important>
      <para>
-      Test passwordless ssh from the &lcm; and check your ability to remotely
+      Test passwordless ssh from the &clm; and check your ability to remotely
       execute sudo commands.
      </para>
      <screen>&prompt.user;ssh ardana@<replaceable>IP_OF_SLES_NODE</replaceable>

--- a/xml/create-vms-vapp_template.xml
+++ b/xml/create-vms-vapp_template.xml
@@ -52,7 +52,7 @@
     After the VM has been deployed, log in to it with
     <literal>ardana/ardana</literal> credentials. Log in to the VM with SSH using
     the <literal>MGMT</literal> IP address. Make sure that all root level
-    commands work with <literal>sudo</literal>. This is required for the &lcm;
+    commands work with <literal>sudo</literal>. This is required for the &clm;
     to configure the appliance for services and networking.
    </para>
   </step>
@@ -65,7 +65,7 @@
    <note>
     <para>
     The VM must have four interfaces configured in the right order. The VM must
-    be accessible from the Management Network through SSH from the &lcm;.
+    be accessible from the Management Network through SSH from the &clm;.
     </para>
     <itemizedlist>
      <listitem>

--- a/xml/day2_ui_documentation.xml
+++ b/xml/day2_ui_documentation.xml
@@ -6,9 +6,9 @@
  xmlns="http://docbook.org/ns/docbook" version="5.1"
  xmlns:xi="http://www.w3.org/2001/XInclude"
  xmlns:xlink="http://www.w3.org/1999/xlink">
- <title>&lcm; Admin UI User Guide</title>
+ <title>&clm; Admin UI User Guide</title>
  <para>
-  The &lcm; Admin UI is a web-based GUI for viewing and managing the
+  The &clm; Admin UI is a web-based GUI for viewing and managing the
   configuration of an installed cloud. After successfully deploying the cloud
   with the &install_ui;, the final screen displays a link to the CLM Admin
   UI. (For example, see <xref linkend="ui-deploy-successful"/>). Usually the
@@ -31,19 +31,19 @@
  </para>
  <screen>&prompt.ardana;openstack endpoint list --service ardana --interface admin -c URL</screen>
  <para>
-  Accessing the &lcm; Admin UI requires access to the <emphasis
+  Accessing the &clm; Admin UI requires access to the <emphasis
   role="bold">MANAGEMENT</emphasis> network that was configured when the Cloud
   was deployed. Access to this network is necessary to be able to access the
-  &lcm; Admin UI and log in. Depending on the network setup, it may be
+  &clm; Admin UI and log in. Depending on the network setup, it may be
   necessary to use an SSH tunnel similar to what is recommended in <xref
   linkend="running_install_ui"/>.
  </para>
  <para> Logging in requires a &o_ident; user. If the user is not an admin on
- the default domain and one or more projects, the &lcm; Admin UI will not display
+ the default domain and one or more projects, the &clm; Admin UI will not display
  information about the Cloud and may present errors.
  </para>
  <figure xml:id="admin_ui_login_page">
-  <title>&lcm; Admin UI Login Page</title>
+  <title>&clm; Admin UI Login Page</title>
   <mediaobject>
    <imageobject role="fo">
     <imagedata fileref="clm_admin_ui_login_page.png" width="75%"/>
@@ -109,7 +109,7 @@
   </varlistentry>
  </variablelist>
  <figure xml:id="admin_ui_service_info">
-  <title>&lcm; Admin UI Service Information</title>
+  <title>&clm; Admin UI Service Information</title>
   <mediaobject>
    <imageobject role="fo">
     <imagedata fileref="service_information.png" width="75%"/>
@@ -147,7 +147,7 @@
   </varlistentry>
  </variablelist>
  <figure xml:id="admin_ui_cloud_package_versions">
-  <title>&lcm; Admin UI &suse; Cloud Package</title>
+  <title>&clm; Admin UI &suse; Cloud Package</title>
   <mediaobject>
    <imageobject role="fo">
     <imagedata fileref="cloud_package_versions.png" width="75%"/>
@@ -162,7 +162,7 @@
  <title>Roles</title>
  <para>
   The <guimenu>Services Per Role</guimenu> tab displays the list of all roles
-  that have been defined in the &lcm; input model, the list of servers that
+  that have been defined in the &clm; input model, the list of servers that
   role, and the services installed on those servers.
  </para>
  <para>
@@ -203,7 +203,7 @@
   </varlistentry>
  </variablelist>
  <figure xml:id="admin_ui_cloud_pkg_versions">
-  <title>&lcm; Admin UI Services Per Role</title>
+  <title>&clm; Admin UI Services Per Role</title>
   <mediaobject>
    <imageobject role="fo">
     <imagedata fileref="server_role_information.png" width="75%"/>
@@ -270,7 +270,7 @@
   </varlistentry>
  </variablelist>
  <figure xml:id="admin_ui_server_summary">
-  <title>&lcm; Admin UI Server Summary</title>
+  <title>&clm; Admin UI Server Summary</title>
   <mediaobject>
    <imageobject role="fo">
     <imagedata fileref="server_summary.png" width="75%"/>

--- a/xml/edit-input_models.xml
+++ b/xml/edit-input_models.xml
@@ -10,7 +10,7 @@
  <para>
   The following steps should be used to edit the Ardana input model data to add
   and configure the Virtual Appliances that were just created. The process
-  assumes that the &productname; is deployed and a valid &lcm; is in place.
+  assumes that the &productname; is deployed and a valid &clm; is in place.
  </para>
  <procedure>
   <step>

--- a/xml/entity-decl.ent
+++ b/xml/entity-decl.ent
@@ -119,7 +119,7 @@ output (stylesheets!)-->
 <!-- "Ardana" is only the SUSE-internal code name for the thing that used to be
 Helion Lifecycle Manager (HLM). "Cloud Lifecycle Manager" is the
 suggested official replacement from rsalevsky. -->
-<!ENTITY lcm          "Cloud Lifecycle Manager">
+<!ENTITY clm          "Cloud Lifecycle Manager">
 <!ENTITY opscon       "Operations Console">
 <!ENTITY caasp        "&suse; CaaS Platform">
 
@@ -177,9 +177,9 @@ suggested official replacement from rsalevsky. -->
 <!ENTITY clouduser      "<citetitle xmlns='http://docbook.org/ns/docbook'>End User Guide</citetitle>">
 <!ENTITY cloudsuppl     "<citetitle xmlns='http://docbook.org/ns/docbook'>Supplement to &cloudadmin; and &clouduser;</citetitle>">
 
-<!ENTITY soclcminstall  "<citetitle xmlns='http://docbook.org/ns/docbook'>Installing using &lcm;</citetitle>">
+<!ENTITY soclcminstall  "<citetitle xmlns='http://docbook.org/ns/docbook'>Installing using &clm;</citetitle>">
 <!ENTITY rhel-install  "<citetitle xmlns='http://docbook.org/ns/docbook'>Installing &rhla;</citetitle>">
-<!ENTITY soclcmdeploy     "<citetitle xmlns='http://docbook.org/ns/docbook'>Deployment Guide using &lcm;</citetitle>">
+<!ENTITY soclcmdeploy     "<citetitle xmlns='http://docbook.org/ns/docbook'>Deployment Guide using &clm;</citetitle>">
 
 
 <!-- SLES -->

--- a/xml/esx-eon_logging.xml
+++ b/xml/esx-eon_logging.xml
@@ -21,7 +21,7 @@
   <orderedlist>
    <listitem>
     <para>
-     Log in to the &lcm;.
+     Log in to the &clm;.
     </para>
    </listitem>
    <listitem>
@@ -80,7 +80,7 @@ ansible-playbook -i hosts/verb_hosts neutron-reconfigure.yml</screen>
   <orderedlist>
    <listitem>
     <para>
-     Log in to the &lcm;.
+     Log in to the &clm;.
     </para>
    </listitem>
    <listitem>

--- a/xml/esx-eon_service.xml
+++ b/xml/esx-eon_service.xml
@@ -26,7 +26,7 @@
   <title>Architecture</title>
   <para>
    EON is installed on the master control plane node, and the EON CLI is
-   installed on the &lcm;, used by the Cloud Admin to setup
+   installed on the &clm;, used by the Cloud Admin to setup
    vCenter Compute Proxy and OvsvApp nodes.
   </para>
   <informalfigure>

--- a/xml/esx-remove_existing_cluster_compute_resource_pool.xml
+++ b/xml/esx-remove_existing_cluster_compute_resource_pool.xml
@@ -142,7 +142,7 @@ ansible-playbook -i hosts/verb_hosts neutron-stop --limit &lt;hostname&gt;;</scr
    <listitem>
     <para>
      If Monasca-API is installed on different node, copy the
-     <literal>service.orsc</literal> from &lcm; to Monasca API
+     <literal>service.orsc</literal> from &clm; to Monasca API
      server.
     </para>
 <screen>scp service.orsc $USER@ardana-cp1-mtrmon-m1-mgmt:</screen>

--- a/xml/esx-removing_esx_host_from_cluster.xml
+++ b/xml/esx-removing_esx_host_from_cluster.xml
@@ -134,7 +134,7 @@
   <orderedlist>
    <listitem>
     <para>
-     Login to &lcm;.
+     Login to &clm;.
     </para>
    </listitem>
    <listitem>
@@ -180,7 +180,7 @@
    <listitem>
     <para>
      If Monasca-API is installed on different node, copy the
-     <literal>service.orsc</literal> from &lcm; to Monasca API
+     <literal>service.orsc</literal> from &clm; to Monasca API
      server.
     </para>
 <screen>scp service.orsc $USER@ardana-cp1-mtrmon-m1-mgmt:</screen>
@@ -292,7 +292,7 @@
   <orderedlist>
    <listitem>
     <para>
-     Login to &lcm;.
+     Login to &clm;.
     </para>
    </listitem>
    <listitem>
@@ -316,12 +316,12 @@
  <section>
   <title>Remove the OVSVAPP VM from the servers.yml and pass_through.yml files and run the Configuration Processor</title>
   <para>
-   Complete these steps from the &lcm; to remove the OVSvAPP VM:
+   Complete these steps from the &clm; to remove the OVSvAPP VM:
   </para>
   <orderedlist>
    <listitem>
     <para>
-     Log in to the &lcm;
+     Log in to the &clm;
     </para>
    </listitem>
    <listitem>

--- a/xml/install-esx_computes-ovsvapp.xml
+++ b/xml/install-esx_computes-ovsvapp.xml
@@ -18,7 +18,7 @@
   <xi:include xpointer="element(/1/3/2)" href="installation-kvm_xpointer.xml"/>
  </section>
 
- <!-- Setting Up the &lcm; -->
+ <!-- Setting Up the &clm; -->
  <section xml:id="sec.ironic.setup_deployer">
   <xi:include xpointer="element(/1/4/1)" href="installation-kvm_xpointer.xml"/>
   <xi:include xpointer="element(/1/4/2)" href="installation-kvm_xpointer.xml"/>
@@ -84,7 +84,7 @@
      </listitem>
      <listitem>
       <para>
-       Establishing network connectivity between the ESX network and the &lcm;
+       Establishing network connectivity between the ESX network and the &clm;
        &ostack; management network
       </para>
      </listitem>
@@ -93,7 +93,7 @@
    <listitem>
     <para>
      The VMware administration staff is responsible for the review of vCenter
-     logs. These logs are not automatically included in &lcm; &ostack; centralized logging.
+     logs. These logs are not automatically included in &clm; &ostack; centralized logging.
     </para>
    </listitem>
    <listitem>
@@ -105,7 +105,7 @@
    <listitem>
     <para>
      Logging levels for vCenter should be set appropriately to prevent logging
-     of the password for the &lcm; &ostack; message queue.
+     of the password for the &clm; &ostack; message queue.
     </para>
    </listitem>
    <listitem>
@@ -116,13 +116,13 @@
    <listitem>
     <para>
      Backup procedures for vCenter should ensure that the file containing the
-     &lcm; &ostack; configuration as part of &o_comp; and &o_blockstore; volume
+     &clm; &ostack; configuration as part of &o_comp; and &o_blockstore; volume
      services is backed up and the backups are protected appropriately.
     </para>
    </listitem>
    <listitem>
     <para>
-     Since the file containing the &lcm; &ostack; message queue password could
+     Since the file containing the &clm; &ostack; message queue password could
      appear in the swap area of a vCenter server, appropriate controls should
      be applied to the vCenter cluster to prevent discovery of the password via
      snooping of the swap area or memory dumps.

--- a/xml/install_caasp_heat_templates.xml
+++ b/xml/install_caasp_heat_templates.xml
@@ -376,7 +376,7 @@ OR
    </step>
    <step>
     <para>
-     Run <filename>heat-caasp-deploy.yml</filename> on the &lcm; to create a
+     Run <filename>heat-caasp-deploy.yml</filename> on the &clm; to create a
      &caasp; cluster with &o_orch; templates from the
      <literal>caasp-openstack-heat-templates</literal> package.
     </para>
@@ -420,7 +420,7 @@ OR
    </step>
    <step>
     <para>
-     On the &lcm;, run the <filename>heat-caasp-deploy.yml</filename> playbook
+     On the &clm;, run the <filename>heat-caasp-deploy.yml</filename> playbook
      and pass parameters for <literal>caasp_stack_name</literal>,
      <literal>caasp_stack_yaml_file</literal> and
      <literal>caasp_stack_env_yaml_file</literal>.

--- a/xml/installation-ardana-manila.xml
+++ b/xml/installation-ardana-manila.xml
@@ -26,7 +26,7 @@
   <procedure>
    <step>
     <para>
-     Log in to the &lcm;.
+     Log in to the &clm;.
     </para>
    </step>
    <step>
@@ -36,7 +36,7 @@
 <screen>&prompt.ardana;cd /var/lib/ardana/openstack/my_cloud/definition/data/</screen>
     <para>
      Add <literal>manila-client</literal> to the list of service components for
-     &lcm;, <literal>manila-api</literal> to the &contrnode;, and
+     &clm;, <literal>manila-api</literal> to the &contrnode;, and
      <literal>manila-share</literal> to &slsa; &compnode;
     </para>
    </step>
@@ -79,7 +79,7 @@ the changes to take effect:
 <screen>on controller1:
 &prompt.ardana;cd /var/log/manila
 &prompt.ardana;sudo chown manila:manila manila-manage.log
-on &lcm;:
+on &clm;:
 &prompt.ardana;ansible-playbook -i hosts/verb_hosts manila-stop.yml
 &prompt.ardana;ansible-playbook -i hosts/verb_hosts manila-start.yml</screen>
    </step>
@@ -90,7 +90,7 @@ on &lcm;:
 <screen>&prompt.ardana;cd
 &prompt.ardana;. manila.osrc; . service.osrc; manila api-version; manila service-list</screen>
     <para>
-     The &o_sharefs; CLI can be run from &lcm; or controller nodes.
+     The &o_sharefs; CLI can be run from &clm; or controller nodes.
     </para>
    </step>
   </procedure>

--- a/xml/installation-installation-api_verification.xml
+++ b/xml/installation-installation-api_verification.xml
@@ -74,15 +74,15 @@ ansible-playbook -i hosts/verb_hosts ardana-cloud-configure.yml</screen>
    scenarios, and other specific tests to be run against a live OpenStack
    cluster. In &product;, Tempest has been modeled as a service and this
    gives you the ability to locate Tempest anywhere in the cloud. It is
-   recommended that you install Tempest on your &lcm; node - that
+   recommended that you install Tempest on your &clm; node - that
    is where it resides by default in a new installation.
   </para>
   <para>
    A version of the upstream
    <link xlink:href="http://docs.openstack.org/developer/tempest/">Tempest</link>
-   integration tests is pre-deployed on the &lcm; node.
+   integration tests is pre-deployed on the &clm; node.
    For details on what Tempest is testing, you can check the contents of this
-   file on your &lcm;:
+   file on your &clm;:
   </para>
 <screen>/opt/stack/tempest/run_filters/ci.txt</screen>
   <para>
@@ -117,7 +117,7 @@ ansible-playbook -i hosts/verb_hosts ardana-cloud-configure.yml</screen>
   <procedure>
    <step>
     <para>
-     Log in to the &lcm;.
+     Log in to the &clm;.
     </para>
         </step>
    <step>
@@ -161,7 +161,7 @@ ansible-playbook -i hosts/verb_hosts tempest-run.yml</screen>
   <procedure>
    <step>
     <para>
-     Log in to the &lcm;.
+     Log in to the &clm;.
     </para>
    </step>
    <step>
@@ -227,7 +227,7 @@ ansible-playbook -i hosts/verb_hosts tempest-run.yml</screen>
   <procedure>
    <step>
     <para>
-     Log in to the &lcm;.
+     Log in to the &clm;.
     </para>
    </step>
    <step>
@@ -319,7 +319,7 @@ api_v3 = false</screen>
   <procedure>
    <step>
     <para>
-     Log in to the &lcm;.
+     Log in to the &clm;.
     </para>
    </step>
    <step>

--- a/xml/installation-installation-config_availability_zones.xml
+++ b/xml/installation-installation-config_availability_zones.xml
@@ -8,7 +8,7 @@
  xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>Configuring Availability Zones</title>
  <para>
-  The &lcm; only creates a default availability zone during
+  The &clm; only creates a default availability zone during
   installation. If your system has multiple failure/availability zones defined
   in your input model, these zones will not get created automatically.
  </para>

--- a/xml/installation-installation-configure_3par.xml
+++ b/xml/installation-installation-configure_3par.xml
@@ -128,7 +128,7 @@
    If you want to enable multipath for Cinder volumes carved from 3PAR FC/iSCSI
    storage system, please go through the
    <filename>~/openstack/ardana/ansible/roles/multipath/README.md</filename>
-   file on the &lcm;. The <filename>README.md</filename> file contains
+   file on the &clm;. The <filename>README.md</filename> file contains
    detailed procedures for configuring multipath for 3PAR FC/iSCSI Cinder
    volumes.
   </para>
@@ -151,7 +151,7 @@
   <procedure>
    <step>
     <para>
-     Log in to the &lcm;.
+     Log in to the &clm;.
     </para>
    </step>
    <step>
@@ -224,7 +224,7 @@ ansible-playbook -i hosts/verb_hosts nova-reconfigure.yml</screen>
   <procedure>
    <step>
     <para>
-     Log in to &lcm;.
+     Log in to &clm;.
     </para>
    </step>
    <step>
@@ -336,7 +336,7 @@ ansible-playbook -i hosts/verb_hosts cinder-reconfigure.yml</screen>
   <procedure>
    <step>
     <para>
-     Log in to &lcm;.
+     Log in to &clm;.
     </para>
    </step>
    <step>

--- a/xml/installation-installation-configure_lbaas.xml
+++ b/xml/installation-installation-configure_lbaas.xml
@@ -97,7 +97,7 @@
    are demo Certificate Authority (CA) certificates included with
    &product; in
    <filename>~/scratch/ansible/next/ardana/ansible/roles/octavia-common/files</filename>
-   on the &lcm;. For additional security in production deployments, all
+   on the &clm;. For additional security in production deployments, all
    certificate authorities should be replaced with ones you generated yourself
    by running the following commands:
   </para>

--- a/xml/installation-installation-designate-designate_install_overview.xml
+++ b/xml/installation-installation-designate-designate_install_overview.xml
@@ -54,7 +54,7 @@
      <entry>InfoBlox</entry>
      <entry>
       The authoritative DNS server itself is external to &productname;. Management
-      and configuration is out of scope for the &lcm; but remains
+      and configuration is out of scope for the &clm; but remains
       the responsibility of the customer.
      </entry>
      <entry>

--- a/xml/installation-installation-esx-esx_troubleshooting.xml
+++ b/xml/installation-installation-esx-esx_troubleshooting.xml
@@ -14,18 +14,18 @@
  <section>
   <title>Issue: ardana-service.service is not running</title>
   <para>
-   If you perform any maintenance work or reboot the &lcm;/deployer
-   node, make sure to restart the &lcm; API service for standalone deployer node
-   and shared &lcm;/controller node based on your environment.
+   If you perform any maintenance work or reboot the &clm;/deployer
+   node, make sure to restart the &clm; API service for standalone deployer node
+   and shared &clm;/controller node based on your environment.
   </para>
   <para>
    For standalone deployer node, execute <literal>ardana-start.yml</literal>
-   playbook to restart the &lcm; API service on the deployer node after a reboot.
+   playbook to restart the &clm; API service on the deployer node after a reboot.
   </para>
   <para>
    For shared deployer/controller node, execute
    <literal>ardana-start.yml</literal> playbook on all the controllers to
-   restart &lcm; API service.
+   restart &clm; API service.
   </para>
   <para>
    For example:
@@ -35,8 +35,8 @@
 cd ~/scratch/ansible/next/ardana/ansible
 ansible-playbook -i hosts/verb_hosts ardana-start.yml --limit <replaceable>HOST_NAME</replaceable></screen>
   <para>
-   Replace <replaceable>HOST_NAME</replaceable> with the host name of the &lcm;
-   node or the &lcm; Node/Shared Controller.
+   Replace <replaceable>HOST_NAME</replaceable> with the host name of the &clm;
+   node or the &clm; Node/Shared Controller.
   </para>
  </section>
  <section>

--- a/xml/installation-installation-esx-prepare_deploy_esx_cloud_ovsvapp.xml
+++ b/xml/installation-installation-esx-prepare_deploy_esx_cloud_ovsvapp.xml
@@ -21,7 +21,7 @@
  <procedure>
   <step>
    <para>
-    Login to the &lcm;.
+    Login to the &clm;.
    </para>
   </step>
   <step>

--- a/xml/installation-installation-esx-procedure_to_deploy_esx_cloud.xml
+++ b/xml/installation-installation-esx-procedure_to_deploy_esx_cloud.xml
@@ -8,7 +8,7 @@
  xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>Procedure to Deploy ESX Cloud with OVSvApp</title>
 
- <!-- Setting Up the &lcm;
+ <!-- Setting Up the &clm;
       FIXME: This section may still be needed when EON
       situation is resolved. csymons 2018-05-18
  <section xml:id="sec.esx.setup_deployer">

--- a/xml/installation-installation-gui_installer.xml
+++ b/xml/installation-installation-gui_installer.xml
@@ -121,7 +121,7 @@
   allows you to manage your own configuration changes.
  </para>
  <para>
-  The git repository is installed by the &lcm; on the &lcm; node.
+  The git repository is installed by the &clm; on the &clm; node.
  </para>
  <para>
   Using the &install_ui; does not require the use of the git repository. After
@@ -248,7 +248,7 @@ myserver4,10.2.10.24,00:14:22:01:23:44,AZ1,,,,
    <step>
     <para>
      Copy the <filename>.pem</filename> file to the proper location on the
-     &lcm;.
+     &clm;.
     </para>
 <screen>
 cd /etc/pki/trust/anchors
@@ -318,7 +318,7 @@ sudo vi /etc/hosts
    <step>
     <para>
      Copy the <filename>.crt</filename> file to the proper location on the
-     &lcm;.
+     &clm;.
     </para>
 <screen>
 cd /etc/pki/trust/anchors
@@ -362,7 +362,7 @@ sudo vi /etc/hosts
   <important>
    <para>
     The &install_ui; must run continuously without stopping for authentication
-    at any step. When using the &install_ui; it is required to launch the &lcm;
+    at any step. When using the &install_ui; it is required to launch the &clm;
     with the following command:
    </para>
    <screen>ARDANA_INIT_AUTO=1 /usr/bin/ardana-init</screen>
@@ -371,21 +371,21 @@ sudo vi /etc/hosts
    Deploying the cloud to your servers will reconfigure networking and firewall
    rules on your cloud servers. To avoid problems with these networking changes
    when using the &install_ui;, we recommend you run a browser directly on your
-   &lcm; node and point it to <uri>http://localhost:9085</uri>.
+   &clm; node and point it to <uri>http://localhost:9085</uri>.
   </para>
   <para>
-   If you cannot run a browser on the &lcm; node to perform the install, you
+   If you cannot run a browser on the &clm; node to perform the install, you
    can run a browser from a Linux-based computer in your
    <emphasis role="bold">MANAGEMENT</emphasis> network. However, firewall rules
    applied during cloud deployment will block access to the &install_ui;. To
    avoid blocking the connection, you can use the &install_ui; via an SSH
-   tunnel to the &lcm; server. This will allow SSH connections through the
+   tunnel to the &clm; server. This will allow SSH connections through the
    <emphasis role="bold">MANAGEMENT</emphasis> network when you reach the
    "Review Configuration Files" step of the install process.
   </para>
   <para>
    To open an SSH tunnel from your Linux-based computer in your
-   <emphasis role="bold">MANAGEMENT</emphasis> network to the &lcm;:
+   <emphasis role="bold">MANAGEMENT</emphasis> network to the &clm;:
   </para>
   <procedure>
    <step>
@@ -393,7 +393,7 @@ sudo vi /etc/hosts
      Open a new terminal and enter the following command:
     </para>
 <screen>
-ssh -N -L 8080:localhost:9085 ardana@<replaceable>MANAGEMENT IP address of &lcm;</replaceable>
+ssh -N -L 8080:localhost:9085 ardana@<replaceable>MANAGEMENT IP address of &clm;</replaceable>
 </screen>
     <para>
      The user name and password should be what was set in
@@ -405,7 +405,7 @@ ssh -N -L 8080:localhost:9085 ardana@<replaceable>MANAGEMENT IP address of &lcm;
     <para>
      Leave this terminal session open to keep the SSH tunnel open and running.
      This SSH tunnel will forward connections from your Linux-based computer
-     directly to the &lcm;, bypassing firewall restrictions.
+     directly to the &clm;, bypassing firewall restrictions.
     </para>
    </step>
    <step>
@@ -978,7 +978,7 @@ rules:
   </figure>
   <para>
    After installation is complete, shutdown the &install_ui; by logging into
-   the &lcm; and running the following commands:
+   the &clm; and running the following commands:
   </para>
 <screen>
 cd ~/openstack/ardana/ansible

--- a/xml/installation-installation-installation_troubleshooting.xml
+++ b/xml/installation-installation-installation_troubleshooting.xml
@@ -30,13 +30,13 @@
   </listitem>
  </itemizedlist>
  <section xml:id="sec.trouble-deployer_setup">
-  <title>Issues during &lcm; Setup</title>
-  <bridgehead renderas="sect4">Issue: Running the ardana-init.bash script when configuring your &lcm; does not complete</bridgehead>
+  <title>Issues during &clm; Setup</title>
+  <bridgehead renderas="sect4">Issue: Running the ardana-init.bash script when configuring your &clm; does not complete</bridgehead>
   <para>
    Part of what the <literal>ardana-init.bash</literal> script does is
    install Git. So if your DNS server(s) is/are not specified in your
    <filename>/etc/resolv.conf</filename> file, is not valid, or is not
-   functioning properly on your &lcm;, it will not be able to
+   functioning properly on your &clm;, it will not be able to
    complete.
   </para>
   <para>
@@ -250,11 +250,11 @@ FATAL: all hosts have already failed -- aborting</screen>
   </para>
 <screen>netstat -tplan | grep 35357</screen>
   <para>
-   Ensure that your &lcm; did not pick the wrong (unusable) IP
+   Ensure that your &clm; did not pick the wrong (unusable) IP
    address from the list of IP addresses assigned to your Management network.
   </para>
   <para>
-   The &lcm; will take the first available IP address after the
+   The &clm; will take the first available IP address after the
    <literal>gateway-ip</literal> defined in your
    <filename>~/openstack/my_cloud/definition/data/networks.yml</filename> file.
    This IP will be used as the virtual IP address for that particular network.

--- a/xml/installation-installation-installing_kvm.xml
+++ b/xml/installation-installation-installing_kvm.xml
@@ -20,7 +20,7 @@
   <xi:include xpointer="element(/1/3/2)" href="installation-kvm_xpointer.xml"/>
  </section>
 
- <!-- Setting Up the &lcm;
+ <!-- Setting Up the &clm;
  <section xml:id="sec.kvm.setup_deployer">
   <xi:include xpointer="element(/1/4/1)" href="installation-kvm_xpointer.xml"/>
   <xi:include xpointer="element(/1/4/2)" href="installation-kvm_xpointer.xml"/>

--- a/xml/installation-installation-installing_standalone.xml
+++ b/xml/installation-installation-installing_standalone.xml
@@ -6,7 +6,7 @@
  xmlns="http://docbook.org/ns/docbook" version="5.1"
  xmlns:xi="http://www.w3.org/2001/XInclude"
  xmlns:xlink="http://www.w3.org/1999/xlink">
- <title>Installing a Stand-Alone &lcm;</title>
+ <title>Installing a Stand-Alone &clm;</title>
 
  <!-- Important Notes -->
  <section>

--- a/xml/installation-installation-installing_swift_object_storage.xml
+++ b/xml/installation-installation-installing_swift_object_storage.xml
@@ -24,7 +24,7 @@
   <xi:include xpointer="element(/1/3/2)" href="installation-kvm_xpointer.xml"/>
  </section>
 
- <!-- Setting Up the &lcm; -->
+ <!-- Setting Up the &clm; -->
  <section xml:id="sec.swift.setup_deployer">
   <xi:include xpointer="element(/1/4/1)" href="installation-kvm_xpointer.xml"/>
   <xi:include xpointer="element(/1/4/2)" href="installation-kvm_xpointer.xml"/>

--- a/xml/installation-installation-ironic-cert_ramdisk.xml
+++ b/xml/installation-installation-ironic-cert_ramdisk.xml
@@ -13,7 +13,7 @@
  <procedure>
   <step>
    <para>
-    To upload your trusted CA certificate to the &lcm;, follow the directions
+    To upload your trusted CA certificate to the &clm;, follow the directions
     in <xref linkend="sec.upload-toclm"/>.
    </para>
   </step>

--- a/xml/installation-installation-ironic-ironic_multi_control_plane.xml
+++ b/xml/installation-installation-ironic-ironic_multi_control_plane.xml
@@ -33,7 +33,7 @@
   </para>
   <screen>neutron net-list</screen>
   <para>
-   Referring to the diagram below, the &lcm; is a shared service that runs in a
+   Referring to the diagram below, the &clm; is a shared service that runs in a
    Core API Controller in a Core API Cluster. &o_iron; Python Agent (IPA) must
    be able to make REST API calls to the &o_iron; API (the connection is
    represented by the green line to Internal routing). The IPA connect to
@@ -92,7 +92,7 @@
    </step>
    <step>
     <para>
-     Log in to the &lcm; and use the value for
+     Log in to the &clm; and use the value for
      <literal>swift_container</literal> in glance namespace of
      <literal>~/scratch/ansible/next/ardana/ansible/roles/ironic-common/templates/ironic-conductor.conf.j2</literal>
     </para>

--- a/xml/installation-installation-ironic-ironic_oneview.xml
+++ b/xml/installation-installation-ironic-ironic_oneview.xml
@@ -37,7 +37,7 @@ tls_cacert_file: &lt;CA certificate for connection&gt;
   <title>Encrypting the &oneview; Password</title>
   <para>
    Encryption can be applied using <literal>ardanaencrypt.py</literal> or using
-   <literal>openssl</literal>. On the &lcm; node, export the key
+   <literal>openssl</literal>. On the &clm; node, export the key
    used for encryption as environment variable:
   </para>
 <screen>

--- a/xml/installation-installation-ironic-ironic_troubleshooting.xml
+++ b/xml/installation-installation-ironic-ironic_troubleshooting.xml
@@ -393,7 +393,7 @@ Image download failed for all URLs.'"
    </step>
    <step>
     <para>
-     Copy iPXE images to &lcm;
+     Copy iPXE images to &clm;
     </para>
 <screen>&prompt.user;scp bin/undionly.kpxe bin-x86_64-efi/ipxe.efi stack@10.0.0.4:
 stack@10.0.0.4's password:

--- a/xml/installation-installation-ironic-node_cleaning.xml
+++ b/xml/installation-installation-ironic-node_cleaning.xml
@@ -39,7 +39,7 @@
  <section>
   <title>Setup</title>
   <para>
-   Cleaning is enabled by default in ironic when installed via the &lcm;.
+   Cleaning is enabled by default in ironic when installed via the &clm;.
    You can verify this by examining the ironic-conductor.conf file.
    Look for:
   </para>

--- a/xml/installation-installation-ironic_oneview_integration.xml
+++ b/xml/installation-installation-ironic_oneview_integration.xml
@@ -54,7 +54,7 @@
   <procedure>
    <step>
     <para>
-     On the &lcm;, open the file
+     On the &clm;, open the file
      <literal>~/openstack/my_cloud/definition/data/ironic/ironic_config.yml</literal>
     </para>
 <screen>~$ cd ~/openstack
@@ -92,7 +92,7 @@ vi my_cloud/definition/data/ironic/ironic_config.yml</screen>
        string. The encrypted form can be created by running the
        <command>ardanaencrypt.py</command>
        program. This program is shipped as part of &productname; and can be found in
-       <filename>~/openstack/ardana/ansible</filename> directory on &lcm;.
+       <filename>~/openstack/ardana/ansible</filename> directory on &clm;.
       </para>
      </step>
      <step>
@@ -184,7 +184,7 @@ $ cd ~/scratch/ansible/next/ardana/ansible/
   <procedure>
    <step>
     <para>
-     Login to the &lcm; and source respective credentials file
+     Login to the &clm; and source respective credentials file
      (for example <filename>service.osrc</filename> for admin account).
     </para>
    </step>

--- a/xml/installation-installation-magnum-magnum_install.xml
+++ b/xml/installation-installation-magnum-magnum_install.xml
@@ -120,9 +120,9 @@
    <orderedlist>
     <listitem>
      <para>
-      If you modify the cloud model to utilize a dedicated &lcm;, add
+      If you modify the cloud model to utilize a dedicated &clm;, add
       <literal>magnum-client</literal> item to the list of service components
-      for the &lcm; cluster.
+      for the &clm; cluster.
      </para>
     </listitem>
     <listitem>
@@ -169,9 +169,9 @@
    </step>
    <step>
     <para>
-     If your environment utilizes a dedicated &lcm;, add
+     If your environment utilizes a dedicated &clm;, add
      <literal>magnum-client</literal> to the list of service components for the
-     &lcm;.
+     &clm;.
     </para>
    </step>
    <step>
@@ -202,7 +202,7 @@
     <para>
      Ensure that your external endpoint is configured correctly. The current
      public endpoint configuration can be verified by running the following
-     commands on the &lcm;.
+     commands on the &clm;.
     </para>
 <screen>
 <?dbsuse-fo font-size="0.65em"?>

--- a/xml/installation-installation-multipath_boot_from_san.xml
+++ b/xml/installation-installation-multipath_boot_from_san.xml
@@ -161,7 +161,7 @@ IPADDR=10.13.111.14
      <step>
       <para>
        Reboot the &slsa; node and ensure that it can be accessed from the
-       &lcm;.
+       &clm;.
       </para>
      </step>
     </substeps>
@@ -185,8 +185,8 @@ IPADDR=10.13.111.14
    </step>
    <step>
     <para>
-     When you start installation using the &lcm;, or if you are adding a &slsa;
-     node to an existing cloud, you need to copy the &lcm; public key to the
+     When you start installation using the &clm;, or if you are adding a &slsa;
+     node to an existing cloud, you need to copy the &clm; public key to the
      &slsa; node to enable passwordless SSH access. One way of doing this is to
      copy the file <filename>~/.ssh/authorized_keys</filename> from
      another node in the cloud to the same location on the &slsa; node. If you

--- a/xml/installation-installation-postinstall_tasks.xml
+++ b/xml/installation-installation-postinstall_tasks.xml
@@ -11,7 +11,7 @@
  <section>
   <title>Determining Your User Credentials</title>
   <para>
-   On your &lcm;, in the
+   On your &clm;, in the
    <literal>~/scratch/ansible/next/ardana/ansible/group_vars/</literal> directory
    you will find several files. In the one labeled as first control plane node
    you can locate the user credentials for both the Administrator user
@@ -21,7 +21,7 @@
   <para>
    For example, if you are using the Entry-scale KVM model and used
    the default naming scheme given in the example configuration files, you can
-   use these commands on your &lcm; to <command>grep</command> for your user
+   use these commands on your &clm; to <command>grep</command> for your user
    credentials:
   </para>
   <para>
@@ -34,19 +34,19 @@
 <screen>&prompt.ardana;grep keystone_demo_pwd entry-scale-kvm-control-plane-1</screen>
  </section>
  <section>
-  <title>Configure your &lcm; to use the command-line tools</title>
+  <title>Configure your &clm; to use the command-line tools</title>
   <para>
    This playbook will do a series of steps to update your environment variables
    for your cloud so you can use command-line clients.
   </para>
   <para>
    Run the following command, which will replace <literal>/etc/hosts</literal>
-   on the &lcm;:
+   on the &clm;:
   </para>
 <screen>&prompt.ardana;cd ~/scratch/ansible/next/ardana/ansible
 &prompt.ardana;ansible-playbook -i hosts/verb_hosts cloud-client-setup.yml</screen>
   <para>
-   As the <filename>/etc/hosts</filename> file no longer has entries for &lcm;,
+   As the <filename>/etc/hosts</filename> file no longer has entries for &clm;,
    sudo commands may become a bit slower. To fix this issue, once
    this step is complete, add "ardana" after "127.0.0.1 localhost". The result
    will look like this:
@@ -69,7 +69,7 @@
   <para>
    As part of the cloud deployment setup process, SSH keys to access the
    systems are generated and stored in <literal>~/.ssh</literal> on your
-   &lcm;.
+   &clm;.
   </para>
   <para>
    These SSH keys allow access to the subsequently deployed systems and should
@@ -81,7 +81,7 @@
   <procedure>
    <step>
     <para>
-     Log in to your &lcm;.
+     Log in to your &clm;.
     </para>
    </step>
    <step>

--- a/xml/installation-installation-preinstall_checklist.xml
+++ b/xml/installation-installation-preinstall_checklist.xml
@@ -517,7 +517,7 @@
   </informaltable>
  </section>
  <section>
-  <title>&lcm;</title>
+  <title>&clm;</title>
   <para>
    This server contains the &productname; installer, which is based on Git, Ansible,
    and Cobbler.

--- a/xml/installation-installation-preinstall_overview.xml
+++ b/xml/installation-installation-preinstall_overview.xml
@@ -96,9 +96,9 @@
   <note>
    <para>
     Ardana is an open-source project and a generalized lifecycle management
-    framework.  &lcm; is based on Ardana, and delivers the lifecycle management
+    framework.  &clm; is based on Ardana, and delivers the lifecycle management
     functionality required by &productname; &productnumber;. Due to this
-    relationship, some &lcm; commands refer to Ardana.
+    relationship, some &clm; commands refer to Ardana.
    </para>
   </note>
  </chapter>

--- a/xml/installation-installation-ses_integration.xml
+++ b/xml/installation-installation-ses_integration.xml
@@ -153,7 +153,7 @@
     </step>
     <step>
      <para>
-      Reconfigure the &lcm; to complete the deployment.
+      Reconfigure the &clm; to complete the deployment.
      </para>
      <screen>&prompt.ardana;cd ~/scratch/ansible/next/ardana/ansible
 &prompt.ardana;ansible-playbook -i hosts/verb_hosts ardana-reconfigure.yml</screen>
@@ -316,7 +316,7 @@ rgw keystone verify ssl = false # If keystone is using self-signed
     documentation</link>.
    </para>
    <para>
-    The certificate needs to be installed on your &lcm;. On the &lcm;, copy the
+    The certificate needs to be installed on your &clm;. On the &clm;, copy the
     cert to <filename>/tmp/ardana_tls_cacerts</filename>. Then deploy it.
    </para>
    <screen>&prompt.ardana;cd ~/scratch/ansible/next/ardana/ansible
@@ -369,7 +369,7 @@ rgw keystone verify ssl = false # If keystone is using self-signed
     </step>
     <step>
      <para>
-      Reconfigure the &lcm; to complete the deployment.
+      Reconfigure the &clm; to complete the deployment.
      </para>
      <screen>&prompt.ardana;cd ~/scratch/ansible/next/ardana/ansible
 &prompt.ardana;ansible-playbook -i hosts/verb_hosts ardana-reconfigure.yml</screen>

--- a/xml/installation-installation-sles-install_sles.xml
+++ b/xml/installation-installation-sles-install_sles.xml
@@ -6,10 +6,10 @@
  xmlns="http://docbook.org/ns/docbook" version="5.1"
  xmlns:xi="http://www.w3.org/2001/XInclude"
  xmlns:xlink="http://www.w3.org/1999/xlink">
- <title>Using the &lcm; to Deploy &slsa; Compute Nodes</title>
+ <title>Using the &clm; to Deploy &slsa; Compute Nodes</title>
  <para>
   The method used for deploying &slsa; compute nodes using Cobbler on the
-  &lcm; uses legacy BIOS.
+  &clm; uses legacy BIOS.
  </para>
  <note>
   <para>
@@ -68,7 +68,7 @@
  <section xml:id="sles_uefi_overview">
   <title>Deploying UEFI &slsa; compute nodes</title>
   <para>
-   Deploying UEFI nodes has been automated in the &lcm; and requires the
+   Deploying UEFI nodes has been automated in the &clm; and requires the
    following to be met:
   </para>
   <itemizedlist>

--- a/xml/installation-installation-sles-provisioning_sles.xml
+++ b/xml/installation-installation-sles-provisioning_sles.xml
@@ -12,11 +12,11 @@
   that it can be added to a new or existing &product; cloud.
  </para>
  <section>
-  <title>Configure &lcm; to Enable &slsa;</title>
+  <title>Configure &clm; to Enable &slsa;</title>
   <procedure>
    <step>
     <para>
-     Take note of the IP address of the &lcm; node. It will be used below
+     Take note of the IP address of the &clm; node. It will be used below
      during <xref linkend="sec.provisioning_sles.add_zypper"/>.
     </para>
    </step>
@@ -252,7 +252,7 @@
    </step>
    <step>
     <para>
-     Copy the SSH key from the &lcm;.
+     Copy the SSH key from the &clm;.
     </para>
     <screen>&prompt.root;ssh-copy-id ardana@<replaceable>DEPLOYER_IP_ADDRESS</replaceable></screen>
    </step>
@@ -331,7 +331,7 @@ ONBOOT=yes
    <step>
     <para>
      [OPTIONAL] Reboot your &slsa; node and ensure that it can be accessed from
-     the &lcm;.
+     the &clm;.
     </para>
    </step>
   </procedure>
@@ -400,9 +400,9 @@ deployer_ip=192.168.10.254
  <section>
   <title>Set up passwordless SSH access</title>
   <para>
-   Once you have started your installation using the &lcm;, or if
+   Once you have started your installation using the &clm;, or if
    you are adding a &slsa; node to an existing cloud, you need to copy the
-   &lcm; public key to the &slsa; node. One way of doing this is to
+   &clm; public key to the &slsa; node. One way of doing this is to
    copy the <literal>/home/ardana/.ssh/authorized_keys</literal> from another
    node in the cloud to the same location on the &slsa; node. If you are
    installing a new cloud, this file will be available on the nodes after

--- a/xml/installation-installation-sles-sles_overview.xml
+++ b/xml/installation-installation-sles-sles_overview.xml
@@ -24,13 +24,13 @@
  <itemizedlist>
   <listitem>
    <para>
-    Using the &lcm; to automatically deploy &slsa; Compute Nodes.
+    Using the &clm; to automatically deploy &slsa; Compute Nodes.
    </para>
   </listitem>
   <listitem>
    <para>
     Provisioning &slsa; nodes yourself, either manually or using a third-party
-    tool, and then providing the relevant information to the &lcm;.
+    tool, and then providing the relevant information to the &clm;.
    </para>
   </listitem>
  </itemizedlist>

--- a/xml/installation-installation-using_git.xml
+++ b/xml/installation-installation-using_git.xml
@@ -17,13 +17,13 @@
   allows you to manage your own configuration changes.
  </para>
  <para>
-  The git repository is installed by the &lcm; on the &lcm; node.
+  The git repository is installed by the &clm; on the &clm; node.
  </para>
  <section>
   <title>Initialization on a new deployment</title>
   <para>
-   On a system new to &product;, the &lcm; will prepare a git repository
-   under <literal>~/openstack</literal>. The &lcm; provisioning runs the
+   On a system new to &product;, the &clm; will prepare a git repository
+   under <literal>~/openstack</literal>. The &clm; provisioning runs the
    <literal>ardana-init-deployer</literal> script automatically. This calls
    <literal>ansible-playbook -i hosts/localhost git-00-initialise.yml</literal>.
   </para>

--- a/xml/installation-kvm_xpointer.xml
+++ b/xml/installation-kvm_xpointer.xml
@@ -69,7 +69,7 @@
    </listitem>
    <listitem>
     <para>
-     The terms deployer and &lcm; are used interchangeably. They refer to the
+     The terms deployer and &clm; are used interchangeably. They refer to the
      same nodes in your cloud environment.
     </para>
    </listitem>
@@ -116,16 +116,16 @@
    </step>
    <step>
     <para>
-     Prepare the &lcm; node. The &lcm; must be accessible either directly or via
+     Prepare the &clm; node. The &clm; must be accessible either directly or via
      <literal>ssh</literal>, and have &cloudos; installed. All nodes must
-     be accessible to the &lcm;. If the nodes do not have direct access to
-     online Cloud subscription channels, the &lcm; node will need to host the
+     be accessible to the &clm;. If the nodes do not have direct access to
+     online Cloud subscription channels, the &clm; node will need to host the
      Cloud repositories.
     </para>
     <substeps>
      <step>
       <para>
-       If you followed the installation instructions for &lcm; server (see <xref
+       If you followed the installation instructions for &clm; server (see <xref
        linkend="cha.depl.dep_inst"/>), &productname; software should already be
        installed. Double-check whether &sle; and &productname; are properly
        registered at the &scc; by starting &yast; and running <menuchoice>
@@ -147,9 +147,9 @@
       <para>
        Ensure the &productname; media repositories and updates repositories are
        made available to all nodes in your deployment. This can be accomplished
-       either by configuring the &lcm; server as an SMT mirror as described in
+       either by configuring the &clm; server as an SMT mirror as described in
        <xref linkend="app.deploy.smt_lcm" /> or by syncing or mounting the
-       Cloud and updates repositories to the &lcm; server as described in <xref
+       Cloud and updates repositories to the &clm; server as described in <xref
        linkend="cha.depl.repo_conf_lcm"/>.
       </para>
      </step>
@@ -204,13 +204,13 @@
 </section>
 <!-- To include this section: <xi:include xpointer="element(/1/4)" href="installation-kvm_xpointer.xml"/> -->
  <section>
-  <title>Setting Up the &lcm;</title>
+  <title>Setting Up the &clm;</title>
   <section>
-   <title>Installing the &lcm;</title>
+   <title>Installing the &clm;</title>
    <para>
     Running the <command>ARDANA_INIT_AUTO=1</command> command is optional to
     avoid stopping for authentication at any step. You can also run
-    <command>ardana-init</command>to launch the &lcm;.  You will be prompted to
+    <command>ardana-init</command>to launch the &clm;.  You will be prompted to
     enter an optional SSH passphrase, which is used to protect the key used by
     Ansible when connecting to its client nodes.  If you do not want to use a
     passphrase, press <keycap function="enter"/> at the prompt.
@@ -224,10 +224,10 @@
 &prompt.ardana;ssh-add ~/.ssh/id_rsa
 </screen>
    <para>
-    The &lcm; will contain the installation scripts and configuration files to
-    deploy your cloud. You can set up the &lcm; on a dedicated node or you do
+    The &clm; will contain the installation scripts and configuration files to
+    deploy your cloud. You can set up the &clm; on a dedicated node or you do
     so on your first controller node. The default choice is to use the first
-    controller node as the &lcm;.
+    controller node as the &clm;.
    </para>
    <procedure>
     <step>
@@ -244,7 +244,7 @@
     </step>
     <step>
      <para>
-      Boot your &lcm; from the &slsa; ISO contained in the download.
+      Boot your &clm; from the &slsa; ISO contained in the download.
      </para>
     </step>
     <step>
@@ -305,13 +305,13 @@
     </step>
    </procedure>
    <para>
-    Once the initial installation is finished, complete the &lcm; setup with
+    Once the initial installation is finished, complete the &clm; setup with
     these steps:
    </para>
    <procedure>
     <step>
      <para>
-      Ensure your &lcm; has a valid DNS nameserver specified in
+      Ensure your &clm; has a valid DNS nameserver specified in
       <literal>/etc/resolv.conf</literal>.
      </para>
     </step>
@@ -342,7 +342,7 @@
    environment. You should use the <xref linkend="example_configurations"/>
    documentation for detailed information on how to do this. There is also a
    <filename>README.md</filename> file included in each of the example
-   directories on the &lcm; that has useful information about the models.
+   directories on the &clm; that has useful information about the models.
   </para>
   <para>
    In the steps below we show how to set up the directory structure with the
@@ -476,7 +476,7 @@
     <listitem>
      <para>
       Each node must have SSH keys in place that allows the same user from the
-      &lcm; node who will be doing the deployment to SSH to each node without a
+      &clm; node who will be doing the deployment to SSH to each node without a
       password.
      </para>
     </listitem>
@@ -534,10 +534,10 @@
     <para>
      The <literal>cobbler-deploy.yml</literal> playbook prompts for a password
      - this is the password that will be encrypted and stored in Cobbler, which
-     is associated with the user running the command on the &lcm;, that you
+     is associated with the user running the command on the &clm;, that you
      will use to log in to the nodes via their consoles after install. The
      username is the same as the user set up in the initial dialogue when
-     installing the &lcm; from the ISO, and is the same user that is running
+     installing the &clm; from the ISO, and is the same user that is running
      the cobbler-deploy play.
     </para>
     <procedure>
@@ -601,7 +601,7 @@
      </step>
     </procedure>
     <para>
-     Deploying nodes has been automated in the &lcm; and requires the
+     Deploying nodes has been automated in the &clm; and requires the
      following:
     </para>
     <itemizedlist>

--- a/xml/installation-operations-configuring_tls.xml
+++ b/xml/installation-operations-configuring_tls.xml
@@ -307,7 +307,7 @@ debian:&lt;filename to remove&gt; \
    </step>
    <step>
     <para>
-     Next, upload it to the &lcm;. Server certificates should be added to
+     Next, upload it to the &clm;. Server certificates should be added to
      <filename>config/tls/certs</filename> and CA certificates should be added
      to <filename>config/tls/cacerts</filename>. The file extension should be
      CRT file for the CA certificate to be processed by &productname;. Detailed
@@ -666,7 +666,7 @@ subjectKeyIdentifier = hash
 -config openssl.cnf -extensions v3_req</screen>
   <para>
    Finally, concatenate both the server key and certificate in preparation for
-   uploading to the &lcm;.
+   uploading to the &clm;.
   </para>
 <screen><?dbsuse-fo font-size="0.70em"?>&prompt.ardana;cat example-internal-cert.key example-internal-cert.crt &gt; example-internal-cert</screen>
   <para>
@@ -676,10 +676,10 @@ subjectKeyIdentifier = hash
   </para>
  </section>
  <section xml:id="sec.upload-toclm">
-  <title>Upload to the &lcm;</title>
+  <title>Upload to the &clm;</title>
   <para>
    The following two files created from the example run above will need to be
-   uploaded to the &lcm; and copied into <filename>config/tls</filename>.
+   uploaded to the &clm; and copied into <filename>config/tls</filename>.
   </para>
   <itemizedlist xml:id="ul_zcc_v1c_5v">
    <listitem>
@@ -694,7 +694,7 @@ subjectKeyIdentifier = hash
    </listitem>
   </itemizedlist>
   <para>
-   Once on the &lcm;, execute the following two copy commands to copy to their
+   Once on the &clm;, execute the following two copy commands to copy to their
    respective directories. Note if you had created an external cert, you can
    copy that in a similar manner, specifying its name using the copy command as
    well.
@@ -705,7 +705,7 @@ subjectKeyIdentifier = hash
    <emphasis role="bold">Continue with the deployment</emphasis>
   </para>
   <para>
-   Next, log into the &lcm; node, and save and commit the changes to the local
+   Next, log into the &clm; node, and save and commit the changes to the local
    git repository:
   </para>
 <screen>&prompt.ardana;cd ~/openstack/ardana/ansible

--- a/xml/installation-operations-create_extnet.xml
+++ b/xml/installation-operations-create_extnet.xml
@@ -13,7 +13,7 @@
   external network and we provide two of them here. The &productname; installer
   provides an Ansible playbook that will create this network for use across
   your projects. We also show you how to create this network via the command
-  line tool from your &lcm;.
+  line tool from your &clm;.
  </para>
 <!-- Cloud 8 does not have multiple region capability
  <section>
@@ -94,7 +94,7 @@ ansible-playbook -i hosts/verb_hosts neutron-cloud-configure.yml -e EXT_NET_CIDR
   <procedure>
    <step>
     <para>
-     Log in to the &lcm;.
+     Log in to the &clm;.
     </para>
    </step>
    <step>

--- a/xml/installation-operations-upload_image.xml
+++ b/xml/installation-operations-upload_image.xml
@@ -9,7 +9,7 @@
  <title>Uploading an Image for Use</title>
  <para>
   To create a Compute instance, you need to obtain an image that you can use.
-  The &lcm; provides an Ansible playbook that will
+  The &clm; provides an Ansible playbook that will
   download a CirrOS Linux image, and then upload it as a public image to your
   image repository for use across your projects.
  </para>
@@ -69,7 +69,7 @@ ansible-playbook -i hosts/verb_hosts glance-cloud-configure.yml -e proxy=&lt;PRO
   <title>Using the GlanceClient CLI to Create Images</title>
   <para>
    You can use the GlanceClient on a machine accessible to your cloud or on
-   your &lcm; where it is automatically installed.
+   your &clm; where it is automatically installed.
   </para>
   <para>
    The GlanceClient allows you to create, update, list, and delete images as

--- a/xml/installation-preparing-standalone.xml
+++ b/xml/installation-preparing-standalone.xml
@@ -8,23 +8,23 @@
  xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>Preparing for Stand-Alone Deployment</title>
  <section>
- <title>&lcm; Installation Alternatives</title>
+ <title>&clm; Installation Alternatives</title>
  <para>
-  The &lcm; can be installed on a Control Plane or on a stand-alone
+  The &clm; can be installed on a Control Plane or on a stand-alone
   server.
  </para>
  <itemizedlist>
   <listitem>
    <para>
-    Installing the &lcm; on a Control Plane is done during the process of
-    deploying your Cloud. Your Cloud and the &lcm; are deployed together.
+    Installing the &clm; on a Control Plane is done during the process of
+    deploying your Cloud. Your Cloud and the &clm; are deployed together.
    </para>
   </listitem>
   <listitem>
    <para>
-    With a standalone &lcm;, you install the deployer first and then deploy
+    With a standalone &clm;, you install the deployer first and then deploy
     your Cloud in a separate process. Either the &install_ui; or command line
-    can be used to deploy a stand-alone &lcm;.
+    can be used to deploy a stand-alone &clm;.
    </para>
   </listitem>
  </itemizedlist>
@@ -59,7 +59,7 @@
   </listitem>
   <listitem>
    <para>
-    - Installation may be more complex than a Control Plane &lcm;
+    - Installation may be more complex than a Control Plane &clm;
    </para>
   </listitem>
  </itemizedlist>
@@ -89,7 +89,7 @@
   </listitem>
   <listitem>
    <para>
-    - There is a risk to the &lcm; when updating or modifying controllers
+    - There is a risk to the &clm; when updating or modifying controllers
    </para>
   </listitem>
   <listitem>
@@ -104,7 +104,7 @@
  <itemizedlist>
   <listitem>
    <para>
-    A Control Plane &lcm; is best for small, simple Cloud deployments.
+    A Control Plane &clm; is best for small, simple Cloud deployments.
    </para>
   </listitem>
   <listitem>
@@ -119,7 +119,7 @@
   <title>Configuring a Stand-Alone Deployer</title>
   <para>
    If you do not intend to install a stand-alone deployer, proceed to
-   installing the &lcm; on a Control Plane.
+   installing the &clm; on a Control Plane.
   </para>
   <itemizedlist>
    <listitem>
@@ -146,7 +146,7 @@
     <para>
      Copy the &productname; Entry-scale KVM example input model to a
      stand-alone input model. This new input model will be edited so that it
-     can be used as a stand-alone &lcm; installation.
+     can be used as a stand-alone &clm; installation.
     </para>
 <screen>&prompt.user;cp -r ~/openstack/examples/entry-scale-kvm/* \
 ~/openstack/examples/entry-scale-kvm-stand-alone-deployer</screen>
@@ -181,46 +181,46 @@
      <para>
       The indentation of each of the input files is important and will cause
       errors if not done correctly. Use the existing content in each of these
-      files as a reference when adding additional content for your &lcm;.
+      files as a reference when adding additional content for your &clm;.
      </para>
     </important>
     <itemizedlist>
      <listitem>
       <para>
-       Update <filename>control_plane.yml</filename> to add the &lcm;.
+       Update <filename>control_plane.yml</filename> to add the &clm;.
       </para>
      </listitem>
      <listitem>
       <para>
-       Update <filename>server_roles.yml</filename> to add the &lcm; role.
+       Update <filename>server_roles.yml</filename> to add the &clm; role.
       </para>
      </listitem>
      <listitem>
       <para>
        Update <filename>net_interfaces.yml</filename> to add the interface
-       definition for the &lcm;.
+       definition for the &clm;.
       </para>
      </listitem>
      <listitem>
       <para>
        Create a <filename>disks_lifecycle_manager.yml</filename> file to define
-       the disk layout for the &lcm;.
+       the disk layout for the &clm;.
       </para>
      </listitem>
      <listitem>
       <para>
-       Update <filename>servers.yml</filename> to add the dedicated &lcm; node.
+       Update <filename>servers.yml</filename> to add the dedicated &clm; node.
       </para>
      </listitem>
     </itemizedlist>
     <para>
      <filename>Control_plane.yml</filename>: The snippet below shows the
-     addition of a single node cluster into the control plane to host the &lcm;
+     addition of a single node cluster into the control plane to host the &clm;
      service.
     </para>
     <important>
      <para>
-      In addition to adding the new cluster, you also have to remove the &lcm;
+      In addition to adding the new cluster, you also have to remove the &clm;
       component from the <literal>cluster1</literal> in the examples.
      </para>
     </important>
@@ -242,7 +242,7 @@
          - ntp-server</screen>
     <para>
      This specifies a single node of role
-     <literal>LIFECYCLE-MANAGER-ROLE</literal> hosting the &lcm;.
+     <literal>LIFECYCLE-MANAGER-ROLE</literal> hosting the &clm;.
     </para>
     <para>
      <filename>Server_roles.yml</filename>: The snippet below shows the
@@ -295,7 +295,7 @@
 
    disk-models:
 <emphasis role="bold">   - name: LIFECYCLE-MANAGER-DISKS
-     # Disk model to be used for &lcm;s nodes
+     # Disk model to be used for &clm;s nodes
      # /dev/sda_root is used as a volume group for /, /var/log and /var/crash
      # sda_root is a templated value to align with whatever partition is really used
      # This value is checked in os config and replaced by the partition actually used
@@ -322,7 +322,7 @@
               name: os</emphasis></screen>
     <para>
      <filename>Servers.yml</filename>: The snippet below shows the insertion of
-     an additional server used for hosting the &lcm;. Provide the address
+     an additional server used for hosting the &clm;. Provide the address
      information here for the server you are running on, that is, the node
      where you have installed the &productname; ISO.
     </para>

--- a/xml/installation-rhel-install_rhel_compute_node.xml
+++ b/xml/installation-rhel-install_rhel_compute_node.xml
@@ -133,13 +133,13 @@ done</screen>
    SELinux policy updates are needed for
    <literal>nova-compute</literal> to work properly. SELinux policy updates can be
    enabled by changing a flag in default configuration. This needs to be
-   done on the &lcm; <emphasis>before</emphasis> <literal>nova-compute</literal>
+   done on the &clm; <emphasis>before</emphasis> <literal>nova-compute</literal>
    is installed on &rhla; nodes.
   </para>
   <procedure>
    <step>
     <para>
-     On the &lcm; node, edit the following file:
+     On the &clm; node, edit the following file:
     </para>
 <screen>cd ~/openstack/ardana/ansible
 vi roles/NOV-CMP-KVM/defaults/main.yml</screen>

--- a/xml/installation-rhel-provisioning_rhel.xml
+++ b/xml/installation-rhel-provisioning_rhel.xml
@@ -76,7 +76,7 @@ ONBOOT=yes
    </step>
    <step performance="optional">
     <para>
-     Reboot your &rhla; node and ensure that it can be accessed from the &lcm;.
+     Reboot your &rhla; node and ensure that it can be accessed from the &clm;.
     </para>
    </step>
   </procedure>
@@ -205,7 +205,7 @@ gpgcheck=0</screen>
  <section xml:id="sec.provision-rhel.ssh">
   <title>Setting Up Passwordless SSH Access</title>
   <para>
-   After you have started your installation using the &lcm;, or if you are
+   After you have started your installation using the &clm;, or if you are
    adding a &rhla; node to an existing cloud, you need to copy the deployer
    public key to the &rhla; node. One way of doing this is to copy the
    <filename>~/.ssh/authorized_keys</filename> from another node in

--- a/xml/installation-rhel-rhel_overview.xml
+++ b/xml/installation-rhel-rhel_overview.xml
@@ -14,6 +14,6 @@
   Whether you are installing a cloud for the first time or adding a compute node
   to an existing cloud, you will provision new &rhla; nodes yourself (either
   manually or using a third-party tool), and then provide the relevant system
-  information to the &lcm;.
+  information to the &clm;.
  </para>
 </chapter>

--- a/xml/installation-rhel-rhel_preinstall.xml
+++ b/xml/installation-rhel-rhel_preinstall.xml
@@ -14,7 +14,7 @@
  <section>
   <title>Sample iptables rules must be removed on &rh;</title>
   <para>
-   &product; uses iptables to secure access to &lcm; network
+   &product; uses iptables to secure access to &clm; network
    interfaces and on &rh; this requires the package
    <literal>iptables-services</literal> to be installed. The package will
    provide sample iptables configurations for IPv4 and IPv6 if none existed

--- a/xml/installation-sles-sles_preinstall.xml
+++ b/xml/installation-sles-sles_preinstall.xml
@@ -12,7 +12,7 @@
 </sidebar>
 
         <sidebar><title>Sample iptables rules must be removed on SLES</title><para>
-                &product; uses iptables to secure access to &lcm; network interfaces and on
+                &product; uses iptables to secure access to &clm; network interfaces and on
                 Red Hat this requires the package <literal>iptables-services</literal> to be installed.
 
                 The package will provide sample iptables configurations for IPv4 and IPv6 if none existed before.

--- a/xml/maintenance-compute-add_rhel_compute.xml
+++ b/xml/maintenance-compute-add_rhel_compute.xml
@@ -34,7 +34,7 @@
    </step>
    <step>
     <para>
-     Log in to the &lcm;.
+     Log in to the &clm;.
     </para>
    </step>
    <step>
@@ -63,7 +63,7 @@
       set for this host does not conflict with any other IP address in your
       cloud environment. You can confirm this by checking the
       <filename>~/openstack/my_cloud/info/address_info.yml</filename> file on your
-      &lcm;.
+      &clm;.
      </para>
     </important>
    </step>

--- a/xml/metering-metering_notifications.xml
+++ b/xml/metering-metering_notifications.xml
@@ -419,7 +419,7 @@ sinks:
   <procedure>
    <step>
     <para>
-     Log on to the &lcm; (deployer node).
+     Log on to the &clm; (deployer node).
     </para>
    </step>
    <step>

--- a/xml/metering-metering_reconfig.xml
+++ b/xml/metering-metering_reconfig.xml
@@ -21,7 +21,7 @@
  <section xml:id="idg-all-metering-metering_reconfig-xml-7">
   <title>Run the Upgrade Playbook</title>
   <para>
-   Follow Standard Service upgrade mechanism available in the &lcm;
+   Follow Standard Service upgrade mechanism available in the &clm;
    distribution. For Ceilometer, the playbook included with &productname; is
    <emphasis role="bold">ceilometer-upgrade.yml</emphasis>
   </para>

--- a/xml/networking-configure_mtu.xml
+++ b/xml/networking-configure_mtu.xml
@@ -152,7 +152,7 @@
     </para>
     <para>
      To edit these files, begin by checking out the
-     <emphasis role="bold">site</emphasis> branch on the &lcm;
+     <emphasis role="bold">site</emphasis> branch on the &clm;
      node. You may already be on that branch. If so, you will remain there.
     </para>
 <screen>&prompt.ardana;cd ~/openstack/ardana/ansible

--- a/xml/networking-dpdk_setup.xml
+++ b/xml/networking-dpdk_setup.xml
@@ -95,7 +95,7 @@ intended to be used for DPDK.</li> -->
   <title>Setup instructions</title>
   <para>
    These setup instructions and example model are for a three-host system.
-   There is one controller with &lcm; in cloud control plane and
+   There is one controller with &clm; in cloud control plane and
    two compute hosts.
   </para>
   <orderedlist>
@@ -130,7 +130,7 @@ intended to be used for DPDK.</li> -->
   </para>
   <para>
    Before running the spin up script you need to get a copy of the cirros image
-   to your &lcm; node. You can manually scp a copy of the cirros
+   to your &clm; node. You can manually scp a copy of the cirros
    image to the system. You can copy it locallly with wget like so
   </para>
 <screen>&prompt.ardana;wget http://download.cirros-cloud.net/0.3.4/cirros-0.3.4-x86_64-disk.img</screen>

--- a/xml/networking-hugepages.xml
+++ b/xml/networking-hugepages.xml
@@ -20,13 +20,13 @@
  </para>
  <para>
   The hugepage reservation is made in <literal>/etc/default/grub</literal>,
-  but this is handled by the &lcm;.
+  but this is handled by the &clm;.
  </para>
  <para>
   In addition to hugepages, to use DPDK, CPU isolation is required. This is
   achieved with the 'isolcups' command in
   <literal>/etc/default/grub</literal>, but this is also managed by the
-  &lcm; using a new input model file.
+  &clm; using a new input model file.
  </para>
  <para>
   The two new input model files introduced with this release to help you

--- a/xml/networking-isolated_metadata.xml
+++ b/xml/networking-isolated_metadata.xml
@@ -28,7 +28,7 @@
  </para>
  <para>
   Note that the <literal>dhcp_agent.ini.j2</literal> template is found in
-  <literal>~/openstack/my_cloud/config/neutron</literal> on the &lcm;
+  <literal>~/openstack/my_cloud/config/neutron</literal> on the &clm;
   node. The edit can be made there and the standard deployment can be run if
   this is install time. In a deployed cloud, run the Neutron reconfiguration
   procedure outlined here:

--- a/xml/networking-networking_overview.xml
+++ b/xml/networking-networking_overview.xml
@@ -56,7 +56,7 @@ href="../../commercial/GA1/networking/1.1commercial_neutron-intro.dita">Networki
    neutron-reconfigure playbook.
   </para>
   <para>
-   On the &lcm;:
+   On the &clm;:
   </para>
 <screen>&prompt.ardana;cd ~/openstack/ardana/ansible
 &prompt.ardana;ansible-playbook -i hosts/verb_hosts neutron-reconfigure.yml</screen>

--- a/xml/networking-neutron_external_networks.xml
+++ b/xml/networking-neutron_external_networks.xml
@@ -83,7 +83,7 @@
   <orderedlist>
    <listitem>
     <para>
-     Log in to the &lcm;.
+     Log in to the &clm;.
     </para>
    </listitem>
    <listitem>

--- a/xml/networking-octavia_admin.xml
+++ b/xml/networking-octavia_admin.xml
@@ -262,7 +262,7 @@ openssl x509 -in client.pem  -text –noout</screen>
    hosts.
   </para>
   <para>
-   On the &lcm; execute octavia-reconfigure:
+   On the &clm; execute octavia-reconfigure:
   </para>
 <screen>&prompt.ardana;cd ~/scratch/ansible/next/ardana/ansible
 &prompt.ardana;ansible-playbook -i hosts/verb_hosts octavia-reconfigure.yml</screen>

--- a/xml/networking-pcipt_sriov_config.xml
+++ b/xml/networking-pcipt_sriov_config.xml
@@ -379,7 +379,7 @@ connect-x3 Pro). Product part number: 779799-B21</li>-->
    and PCIPT.
   </para>
   <para>
-   the &lcm; input model changes to support SRIOV and PCIPT are as follows. If
+   the &clm; input model changes to support SRIOV and PCIPT are as follows. If
    you were familiar with the configuration settings previously, you will
    notice these changes.
   </para>
@@ -1096,8 +1096,8 @@ neutron port-create net1 --name pci-port2  --vnic_type=direct-physical</screen>
  <section>
   <title>Making input model changes and implementing PCI PT and SR-IOV</title>
   <para>
-   To implent the configuration you require, log into the &lcm; node and update
-   the &lcm; model files to enable SR-IOV or PCIPT following the relevent use
+   To implent the configuration you require, log into the &clm; node and update
+   the &clm; model files to enable SR-IOV or PCIPT following the relevent use
    case explained above. You will need to edit
   </para>
   <itemizedlist>
@@ -1139,7 +1139,7 @@ neutron port-create net1 --name pci-port2  --vnic_type=direct-physical</screen>
    </listitem>
    <listitem>
     <para>
-     Here you will have the &lcm; enable your changes by running the necessary
+     Here you will have the &clm; enable your changes by running the necessary
      playbooks:
     </para>
 <screen>&prompt.ardana;cd ~/openstack/ardana/ansible

--- a/xml/networking-using_ipam.xml
+++ b/xml/networking-using_ipam.xml
@@ -68,7 +68,7 @@
   </para>
   <para>
    As stated, the file you must edit is <literal>neutron.conf.j2</literal> on
-   the &lcm; in the directory
+   the &clm; in the directory
    <literal>~/openstack/my_cloud/config/neutron</literal>. Here is the relevant
    section where you can see the <literal>ipam_driver</literal> parameter
    commented out:

--- a/xml/nsx-configure-vsphere_env.xml
+++ b/xml/nsx-configure-vsphere_env.xml
@@ -81,7 +81,7 @@
     </step>
     <step>
      <para>
-      Deploy the &lcm;
+      Deploy the &clm;
      </para>
     </step>
     <step>

--- a/xml/nsx-create-input-model.xml
+++ b/xml/nsx-create-input-model.xml
@@ -17,7 +17,7 @@
   Refer to the reference input model in
   <filename>ardana-extensions/ardana-extensions-nsx/vmware/examples/models/entry-scale-nsx/</filename>
   for details about how these definitions should be made.  The main differences
-  between this model and the standard &lcm; input models are:
+  between this model and the standard &clm; input models are:
  </para>
  <itemizedlist>
   <listitem>

--- a/xml/nsx-deploy-os-cobbler.xml
+++ b/xml/nsx-deploy-os-cobbler.xml
@@ -10,7 +10,7 @@
  <procedure>
   <step>
    <para>
-    From the &lcm;, run Cobbler to install the operating system on the nodes
+    From the &clm;, run Cobbler to install the operating system on the nodes
     after it has to be deployed:
    </para>
    <screen>&prompt.ardana;cd ~/openstack/ardana/ansible

--- a/xml/nsx-import-third_party.xml
+++ b/xml/nsx-import-third_party.xml
@@ -9,7 +9,7 @@
  <title>Third-Party Import of VMware NSX-v Into &o_netw; and
  Neutronclient</title>
  <para>
-  To import the NSX-v &o_netw; core-plugin into &lcm;, run the third-party
+  To import the NSX-v &o_netw; core-plugin into &clm;, run the third-party
   import playbook.
  </para>
  <screen>&prompt.ardana;cd ~/openstack/ardana/ansible

--- a/xml/nsx-modify-input-model.xml
+++ b/xml/nsx-modify-input-model.xml
@@ -29,7 +29,7 @@
   </step>
   <step>
    <para>
-    Specify the services needed to be deployed on the &lcm; controllers and the
+    Specify the services needed to be deployed on the &clm; controllers and the
     &o_comp; ESX compute proxy nodes.
    </para>
   </step>

--- a/xml/nsx-verification.xml
+++ b/xml/nsx-verification.xml
@@ -15,7 +15,7 @@
  <procedure>
   <step>
    <para>
-    Validating &o_netw; from the &lcm;. All of these commands require that you
+    Validating &o_netw; from the &clm;. All of these commands require that you
     authenticate by <filename>service.osrc</filename> file.
    </para>
    <screen>&prompt.ardana;source ~/service.osrc</screen>

--- a/xml/nsx-vsphere-baremetal.xml
+++ b/xml/nsx-vsphere-baremetal.xml
@@ -240,7 +240,7 @@
   </table>
   <para>
    In addition to the ESXi hosts, it is recommended that there is one physical
-   host for the &lcm; node and three physical hosts for the controller nodes.
+   host for the &clm; node and three physical hosts for the controller nodes.
   </para>
   <section>
    <title>Network Requirements</title>
@@ -1410,7 +1410,7 @@ xlink:href="https://communities.vmware.com/docs/DOC-27683">VMware
      </step>
      <step>
       <para>
-       Deploy the &lcm;
+       Deploy the &clm;
       </para>
      </step>
      <step>
@@ -1548,7 +1548,7 @@ xlink:href="https://communities.vmware.com/docs/DOC-27683">VMware
       </itemizedlist>
      </important>
     </section>
-<!-- Setting Up the &lcm; -->
+<!-- Setting Up the &clm; -->
     <section>
      <xi:include xpointer="element(/1/4/1)" href="installation-kvm_xpointer.xml"/>
      <xi:include xpointer="element(/1/4/2)" href="installation-kvm_xpointer.xml"/>
@@ -1581,7 +1581,7 @@ xlink:href="https://communities.vmware.com/docs/DOC-27683">VMware
      <section>
       <title>Third-Party Import of VMware NSX-v Into &o_netw; and Neutronclient</title>
       <para>
-       To import the NSX-v &o_netw; core-plugin into &lcm;, run the third-party
+       To import the NSX-v &o_netw; core-plugin into &clm;, run the third-party
        import playbook.
       </para>
 <screen>&prompt.ardana;cd ~/openstack/ardana/ansible
@@ -1611,7 +1611,7 @@ xlink:href="https://communities.vmware.com/docs/DOC-27683">VMware
        </step>
        <step>
         <para>
-         Specify the services needed to be deployed on the &lcm; controllers
+         Specify the services needed to be deployed on the &clm; controllers
          and the &o_comp; ESX compute proxy nodes.
         </para>
        </step>
@@ -1650,7 +1650,7 @@ xlink:href="https://communities.vmware.com/docs/DOC-27683">VMware
         Refer to the reference input model in
         <filename>ardana-extensions/ardana-extensions-nsx/vmware/examples/models/entry-scale-nsx/</filename>
         for details about how these definitions should be made. The main
-        differences between this model and the standard &lcm; input models are:
+        differences between this model and the standard &clm; input models are:
        </para>
        <itemizedlist>
         <listitem>
@@ -1906,7 +1906,7 @@ pass-through:
       <procedure>
        <step>
         <para>
-         From the &lcm;, run Cobbler to install the operating system on the
+         From the &clm;, run Cobbler to install the operating system on the
          nodes after it has to be deployed:
         </para>
 <screen>&prompt.ardana;cd ~/openstack/ardana/ansible

--- a/xml/nsx-vsphere-vm.xml
+++ b/xml/nsx-vsphere-vm.xml
@@ -106,7 +106,7 @@
   </table>
   <para>
    <emphasis role="bold">Baremetal: In addition to the ESXi hosts, it is
-   recommended to have one physical host for the &lcm; node and three physical
+   recommended to have one physical host for the &clm; node and three physical
    hosts for the controller nodes.</emphasis>
   </para>
   <xi:include href="nsx-ntwk-requirements.xml"/>
@@ -248,7 +248,7 @@
    <itemizedlist>
     <listitem>
      <para>
-      One &lcm; deployer
+      One &clm; deployer
      </para>
     </listitem>
     <listitem>
@@ -300,7 +300,7 @@
 
  <xi:include href="nsx-advanced-config.xml"/>
 
- <!-- Setting Up the &lcm; -->
+ <!-- Setting Up the &clm; -->
  <section xml:id="sec.nsx.setup_deployer">
   <xi:include xpointer="element(/1/4/1)" href="installation-kvm_xpointer.xml"/>
   <xi:include xpointer="element(/1/4/2)" href="installation-kvm_xpointer.xml"/>

--- a/xml/operations-audit_logs_backup.xml
+++ b/xml/operations-audit_logs_backup.xml
@@ -15,7 +15,7 @@
  <procedure>
   <step>
    <para>
-    First, from the &lcm; node, run the following playbook:
+    First, from the &clm; node, run the following playbook:
    </para>
 <screen>&prompt.sudo;ansible-playbook -i hosts/verb_hosts _freezer_manage_jobs.yml</screen>
    <para>

--- a/xml/operations-audit_logs_checklist.xml
+++ b/xml/operations-audit_logs_checklist.xml
@@ -276,7 +276,7 @@
   <orderedlist>
    <listitem>
     <para>
-     Log in to your &lcm;.
+     Log in to your &clm;.
     </para>
    </listitem>
    <listitem>

--- a/xml/operations-audit_logs_enable.xml
+++ b/xml/operations-audit_logs_enable.xml
@@ -47,7 +47,7 @@ audit-settings:
   <orderedlist>
    <listitem>
     <para>
-     Log in to your &lcm;.
+     Log in to your &clm;.
     </para>
    </listitem>
    <listitem>

--- a/xml/operations-audit_logs_overview.xml
+++ b/xml/operations-audit_logs_overview.xml
@@ -32,7 +32,7 @@
  </para>
  <para>
   By default, audit logging as a post-installation feature is disabled in the
-  cloudConfig file on the &lcm; and it can only be enabled after
+  cloudConfig file on the &clm; and it can only be enabled after
   &productname; installation or upgrade.
  </para>
  <para>

--- a/xml/operations-blockstorage-ceph-config_ceph_boot.xml
+++ b/xml/operations-blockstorage-ceph-config_ceph_boot.xml
@@ -35,7 +35,7 @@
  <orderedlist>
   <listitem>
    <para>
-    Log in to the &lcm;.
+    Log in to the &clm;.
    </para>
   </listitem>
   <listitem>
@@ -63,7 +63,7 @@ openstack role create cinder-advanced</screen>
   </listitem>
   <listitem>
    <para>
-    Log back in to the &lcm;.
+    Log back in to the &clm;.
    </para>
   </listitem>
   <listitem>

--- a/xml/operations-blockstorage-ceph-reconfigure_ceph_services.xml
+++ b/xml/operations-blockstorage-ceph-reconfigure_ceph_services.xml
@@ -13,7 +13,7 @@
  <orderedlist>
   <listitem>
    <para>
-    Login to the &lcm;
+    Login to the &clm;
    </para>
   </listitem>
   <listitem>

--- a/xml/operations-blockstorage-managing_cinder_volumebackup_services.xml
+++ b/xml/operations-blockstorage-managing_cinder_volumebackup_services.xml
@@ -29,7 +29,7 @@
   <orderedlist>
    <listitem>
     <para>
-     Log in to the &lcm; node.
+     Log in to the &clm; node.
     </para>
    </listitem>
    <listitem>
@@ -89,7 +89,7 @@ ok: [ardana-cp1-c1-m1] =&gt; (item=(2, 'ardana-cp1-c1-m3')) =&gt; {
    </listitem>
    <listitem>
     <para>
-     If you are using data encryption on your &lcm;, ensure you
+     If you are using data encryption on your &clm;, ensure you
      have included the encryption key in your environment variables:
     </para>
 <screen>export HOS_USER_PASSWORD_ENCRYPT_KEY=&lt;encryption key&gt;</screen>

--- a/xml/operations-central_log_GS.xml
+++ b/xml/operations-central_log_GS.xml
@@ -24,7 +24,7 @@
  </para>
  <para>
   <emphasis role="bold">Do I need to Configure monasca-log-api?</emphasis> If
-  you are only using &lcm; , then the default
+  you are only using &clm; , then the default
   configuration is ready to use.
  </para>
  <important>
@@ -54,7 +54,7 @@
  <orderedlist>
   <listitem>
    <para>
-    Log on to &lcm; (deployer node).
+    Log on to &clm; (deployer node).
    </para>
   </listitem>
   <listitem>

--- a/xml/operations-central_log_access_data.xml
+++ b/xml/operations-central_log_access_data.xml
@@ -235,7 +235,7 @@
     <listitem>
      <para>
       If your administrator did not set a hostname value, then to determine
-      which IP address to use, from your &lcm;, run:
+      which IP address to use, from your &clm;, run:
      </para>
 <screen>&prompt.ardana;grep HZN-WEB /etc/hosts</screen>
      <para>

--- a/xml/operations-central_log_configure_CL.xml
+++ b/xml/operations-central_log_configure_CL.xml
@@ -44,7 +44,7 @@
   <title>Configuration Files</title>
   <para>
    Centralized Logging settings are stored in the configuration files in the
-   following directory on the &lcm;:
+   following directory on the &clm;:
    <literal>~/openstack/my_cloud/config/logging/</literal>
   </para>
   <para>
@@ -137,7 +137,7 @@
   <para>
    In the entry-scale models, the disk partition sizes on your controller nodes
    for the logging and &elasticsearch; data are set as a percentage of your total
-   disk size. You can see these in the following file on the &lcm;
+   disk size. You can see these in the following file on the &clm;
    (deployer):
    <literal>~/openstack/my_cloud/definition/data/&lt;controller_disk_files_used&gt;</literal>
   </para>
@@ -169,7 +169,7 @@
   <orderedlist>
    <listitem>
     <para>
-     Log in to the &lcm; (deployer).
+     Log in to the &clm; (deployer).
     </para>
    </listitem>
    <listitem>
@@ -322,7 +322,7 @@
   <orderedlist>
    <listitem>
     <para>
-     Log in to the &lcm; (deployer node).
+     Log in to the &clm; (deployer node).
     </para>
    </listitem>
    <listitem>

--- a/xml/operations-central_log_configure_manage.xml
+++ b/xml/operations-central_log_configure_manage.xml
@@ -48,7 +48,7 @@
   </para>
   <important>
    <para>
-    These playbooks must be run from the &lcm;.
+    These playbooks must be run from the &clm;.
    </para>
   </important>
   <para>

--- a/xml/operations-central_log_configure_services.xml
+++ b/xml/operations-central_log_configure_services.xml
@@ -119,7 +119,7 @@
   <procedure>
    <step>
     <para>
-     Log in to the &lcm; (deployer).
+     Log in to the &clm; (deployer).
     </para>
    </step>
    <step>
@@ -223,7 +223,7 @@ barbican_logstash_loglevel: "{{ ardana_loglevel | default('INFO') }}"</screen>
   <procedure>
    <step>
     <para>
-     Log in to the &lcm; (deployer).
+     Log in to the &clm; (deployer).
     </para>
    </step>
    <step>
@@ -330,7 +330,7 @@ cinder_logstash_loglevel: {{ ardana_loglevel | default('INFO') }}</screen>
   <procedure>
    <step>
     <para>
-     Log in to the &lcm; (deployer).
+     Log in to the &clm; (deployer).
     </para>
    </step>
    <step>
@@ -421,7 +421,7 @@ ceilometer_logstash_loglevel:  INFO</screen>
   <procedure>
    <step>
     <para>
-     Log in to the &lcm;.
+     Log in to the &clm;.
     </para>
    </step>
    <step>
@@ -539,7 +539,7 @@ ceilometer_logstash_loglevel:  INFO</screen>
   <procedure>
    <step>
     <para>
-     Log in to the &lcm; (deployer).
+     Log in to the &clm; (deployer).
     </para>
    </step>
    <step>
@@ -633,7 +633,7 @@ ceilometer_logstash_loglevel:  INFO</screen>
   <procedure>
    <step>
     <para>
-     Log in to the &lcm; (deployer).
+     Log in to the &clm; (deployer).
     </para>
    </step>
    <step>
@@ -727,7 +727,7 @@ keystone_logstash_loglevel: INFO</screen>
   <procedure>
    <step>
     <para>
-     Log in to the &lcm; (deployer).
+     Log in to the &clm; (deployer).
     </para>
    </step>
    <step>
@@ -825,7 +825,7 @@ keystone_logstash_loglevel: INFO</screen>
   <procedure>
    <step>
     <para>
-     Log in to the &lcm; (deployer).
+     Log in to the &clm; (deployer).
     </para>
    </step>
    <step>
@@ -940,7 +940,7 @@ ironic_conductor_logstash_loglevel: "{{ ardana_loglevel | default('INFO') }}"</s
   <procedure>
    <step>
     <para>
-     Log in to the &lcm; (deployer).
+     Log in to the &clm; (deployer).
     </para>
    </step>
    <step>
@@ -1065,7 +1065,7 @@ ironic_conductor_logstash_loglevel: "{{ ardana_loglevel | default('INFO') }}"</s
   <procedure>
    <step>
     <para>
-     Log in to the &lcm;.
+     Log in to the &clm;.
     </para>
    </step>
    <step>
@@ -1215,7 +1215,7 @@ ironic_conductor_logstash_loglevel: "{{ ardana_loglevel | default('INFO') }}"</s
   <procedure>
    <step>
     <para>
-     Log in to the &lcm;.
+     Log in to the &clm;.
     </para>
    </step>
    <step>
@@ -1317,7 +1317,7 @@ ironic_conductor_logstash_loglevel: "{{ ardana_loglevel | default('INFO') }}"</s
   <procedure>
    <step>
     <para>
-     Log in to the &lcm;.
+     Log in to the &clm;.
     </para>
    </step>
    <step>
@@ -1410,7 +1410,7 @@ ironic_conductor_logstash_loglevel: "{{ ardana_loglevel | default('INFO') }}"</s
   <procedure>
    <step>
     <para>
-     Log in to the &lcm; (deployer).
+     Log in to the &clm; (deployer).
     </para>
    </step>
    <step>
@@ -1508,7 +1508,7 @@ ironic_conductor_logstash_loglevel: "{{ ardana_loglevel | default('INFO') }}"</s
   <procedure>
    <step>
     <para>
-     Log in to the &lcm; (deployer).
+     Log in to the &clm; (deployer).
     </para>
    </step>
    <step>
@@ -1604,7 +1604,7 @@ ironic_conductor_logstash_loglevel: "{{ ardana_loglevel | default('INFO') }}"</s
   <procedure>
    <step>
     <para>
-     Log in to the &lcm; (deployer).
+     Log in to the &clm; (deployer).
     </para>
    </step>
    <step>
@@ -1682,7 +1682,7 @@ manila_logstash_loglevel: INFO</screen>
   <procedure>
    <step>
     <para>
-     Log in to the &lcm;.
+     Log in to the &clm;.
     </para>
     <para>
      Open the *.yml file for the service or sub-component that you want to
@@ -1796,7 +1796,7 @@ manila_logstash_loglevel: INFO</screen>
   </para>
   <para>
    These specification files are auto-generated based on YML sources delivered
-   with the &lcm; codebase. The source files can be edited and
+   with the &clm; codebase. The source files can be edited and
    reapplied to control the allocation of disk space across services or the
    behavior during a rotation.
   </para>
@@ -1835,7 +1835,7 @@ manila_logstash_loglevel: INFO</screen>
   <procedure>
    <step>
     <para>
-     Navigate to the following directory on your &lcm;:
+     Navigate to the following directory on your &clm;:
     </para>
 <screen>~/stack/scratch/ansible/next/ardana/ansible</screen>
    </step>

--- a/xml/operations-central_log_troubleshoot.xml
+++ b/xml/operations-central_log_troubleshoot.xml
@@ -343,7 +343,7 @@
       <entry/>
       <entry>
        <para>
-        Run an Ansible playbook to get status of the &lcm;:
+        Run an Ansible playbook to get status of the &clm;:
        </para>
 <screen>ansible-playbook -i hosts/verb_hosts ardana-status.yml</screen>
       </entry>
@@ -352,7 +352,7 @@
       <entry/>
       <entry>
        <para>
-        Troubleshoot all specific tasks that have failed on the &lcm;.
+        Troubleshoot all specific tasks that have failed on the &clm;.
        </para>
       </entry>
      </row>
@@ -449,7 +449,7 @@ Listen {{ kronos_api_host }}:{{ kronos_api_port }}
   <orderedlist>
    <listitem>
     <para>
-     Login to the &lcm; and set a mariadb service configurable to
+     Login to the &clm; and set a mariadb service configurable to
      enable slow logging.
     </para>
 <screen>cd ~/openstack/my_cloud</screen>

--- a/xml/operations-change_service_passwords.xml
+++ b/xml/operations-change_service_passwords.xml
@@ -17,7 +17,7 @@
   communications between services in your &productname; deployment,
   promoting better compliance with your organization’s security policies.
   The inter-service passwords that can be changed include (but are not limited
-  to) Keystone, &mariadb;, RabbitMQ, &lcm; cluster, Monasca and Barbican.
+  to) Keystone, &mariadb;, RabbitMQ, &clm; cluster, Monasca and Barbican.
  </para>
  <para>
   The general process for changing the passwords is to:

--- a/xml/operations-compute-creating_aggregates.xml
+++ b/xml/operations-compute-creating_aggregates.xml
@@ -43,12 +43,12 @@
    These steps will show you how to create a Nova aggregate and how to add a
    compute host to it. You can run these steps on any machine that contains the
    NovaClient that also has network access to your cloud environment. These
-   requirements are met by the &lcm;.
+   requirements are met by the &clm;.
   </para>
   <orderedlist>
    <listitem>
     <para>
-     Log in to the &lcm;.
+     Log in to the &clm;.
     </para>
    </listitem>
    <listitem>
@@ -170,7 +170,7 @@
   <orderedlist>
    <listitem>
     <para>
-     Log in to the &lcm;.
+     Log in to the &clm;.
     </para>
    </listitem>
    <listitem>
@@ -251,7 +251,7 @@ scheduler_default_filters = AvailabilityZoneFilter,RetryFilter,ComputeFilter,
   <orderedlist>
    <listitem>
     <para>
-     Log in to the &lcm;.
+     Log in to the &clm;.
     </para>
    </listitem>
    <listitem>

--- a/xml/operations-compute-enabling_resize.xml
+++ b/xml/operations-compute-enabling_resize.xml
@@ -48,7 +48,7 @@
   <orderedlist>
    <listitem>
     <para>
-     Log in to the &lcm;.
+     Log in to the &clm;.
     </para>
    </listitem>
    <listitem>
@@ -80,7 +80,7 @@
   <orderedlist>
    <listitem>
     <para>
-     Log in to the &lcm;.
+     Log in to the &clm;.
     </para>
    </listitem>
    <listitem>

--- a/xml/operations-compute-enabling_resize_esx_compute.xml
+++ b/xml/operations-compute-enabling_resize_esx_compute.xml
@@ -34,7 +34,7 @@
   <orderedlist>
    <listitem>
     <para>
-     Log in to the &lcm;.
+     Log in to the &clm;.
     </para>
    </listitem>
    <listitem>

--- a/xml/operations-compute-forcing_overcommit.xml
+++ b/xml/operations-compute-forcing_overcommit.xml
@@ -96,13 +96,13 @@
   <title>Changing the overcommit ratios for your entire environment</title>
   <para>
    If you wish to change the CPU and/or RAM overcommit ratio settings for your
-   entire environment then you can do so via your &lcm; with these
+   entire environment then you can do so via your &clm; with these
    steps.
   </para>
   <orderedlist>
    <listitem>
     <para>
-     Log in to the &lcm;.
+     Log in to the &clm;.
     </para>
    </listitem>
    <listitem>

--- a/xml/operations-compute_alarmdefinitions.xml
+++ b/xml/operations-compute_alarmdefinitions.xml
@@ -110,7 +110,7 @@
       <orderedlist xml:id="ol_rwq_1xp_mx">
        <listitem>
         <para>
-         Log in to the &lcm;.
+         Log in to the &clm;.
         </para>
        </listitem>
        <listitem>
@@ -183,7 +183,7 @@ ansible-playbook -i hosts/verb_hosts nova-start.yml --limit &lt;hostname&gt;</sc
       <orderedlist xml:id="ol_twq_1xp_mx">
        <listitem>
         <para>
-         Log in to the &lcm;.
+         Log in to the &clm;.
         </para>
        </listitem>
        <listitem>
@@ -259,7 +259,7 @@ ansible-playbook -i hosts/verb_hosts glance-start.yml --limit &lt;hostname&gt;</
       <orderedlist xml:id="ol_vwq_1xp_mx">
        <listitem>
         <para>
-         Log in to the &lcm;.
+         Log in to the &clm;.
         </para>
        </listitem>
        <listitem>
@@ -307,7 +307,7 @@ ansible-playbook -i hosts/verb_hosts ironic-start.yml</screen>
       <orderedlist xml:id="ol_wwq_1xp_mx">
        <listitem>
         <para>
-         Log in to the &lcm;.
+         Log in to the &clm;.
         </para>
        </listitem>
        <listitem>

--- a/xml/operations-configure_firewall.xml
+++ b/xml/operations-configure_firewall.xml
@@ -309,7 +309,7 @@ $ ./webserv.sh</screen>
   <orderedlist>
    <listitem>
     <para>
-     Log in to your &lcm;.
+     Log in to your &clm;.
     </para>
    </listitem>
    <listitem>

--- a/xml/operations-configuring-change_horizon_timeout.xml
+++ b/xml/operations-configuring-change_horizon_timeout.xml
@@ -31,7 +31,7 @@
   <orderedlist>
    <listitem>
     <para>
-     Log in to the &lcm;.
+     Log in to the &clm;.
     </para>
    </listitem>
    <listitem>

--- a/xml/operations-configuring-identity-configure_identity.xml
+++ b/xml/operations-configuring-identity-configure_identity.xml
@@ -18,7 +18,7 @@
    OpenStack services.
   </para>
   <para>
-   The identity service is installed automatically by the &lcm;
+   The identity service is installed automatically by the &clm;
    (just after MySQL and RabbitMQ). When your cloud is up and running, you can
    customize Keystone in a number of ways, including integrating with LDAP
    servers. This topic describes the default configuration. See

--- a/xml/operations-configuring-identity-identity_ldap.xml
+++ b/xml/operations-configuring-identity-identity_ldap.xml
@@ -99,8 +99,8 @@ domain_configurations_from_database = False</screen>
     <para>
      Create a YAML file that contains the definition of the LDAP server
      connection. The sample file below is already provided as part of the
-     &lcm; in the <xref linkend="using_git"/>. It is available on
-     the &lcm; in the following file:
+     &clm; in the <xref linkend="using_git"/>. It is available on
+     the &clm; in the following file:
     </para>
 <screen>~/openstack/my_cloud/config/keystone/keystone_configure_ldap_sample.yml</screen>
     <para>

--- a/xml/operations-configuring-identity-identity_reconfigure.xml
+++ b/xml/operations-configuring-identity-identity_reconfigure.xml
@@ -75,7 +75,7 @@
      The main Keystone Identity service configuration file
      (<emphasis role="bold">/etc/keystone/keystone.conf</emphasis>), located on
      each control plane server, is generated from the following template file
-     located on a &lcm;:
+     located on a &clm;:
      <literal>~/openstack/my_cloud/config/keystone/keystone.conf.j2</literal>
     </para>
     <para>

--- a/xml/operations-configuring-identity-keystone_federation.xml
+++ b/xml/operations-configuring-identity-keystone_federation.xml
@@ -203,7 +203,7 @@ if __name__ == "__main__":
    <listitem>
     <para>
      Create a config file called <literal>k2k.yml</literal> with the following
-     parameters and place it in any directory on your &lcm;, such
+     parameters and place it in any directory on your &clm;, such
      as /tmp.
     </para>
 <screen>keystone_trusted_idp: k2k
@@ -521,7 +521,7 @@ keystone_sp_conf:
    <listitem>
     <para>
      Create a config file <literal>k2k.yml</literal> with the following
-     parameters and place it in any directory on your &lcm;, such
+     parameters and place it in any directory on your &clm;, such
      as <literal>/tmp</literal>. Note that the certificate and key here are
      excerpted for space.
     </para>

--- a/xml/operations-configuring-identity-websso.xml
+++ b/xml/operations-configuring-identity-websso.xml
@@ -301,7 +301,7 @@
    </listitem>
    <listitem>
     <para>
-     Copy adfs_metadata.xml to the &lcm; node in your preferred
+     Copy adfs_metadata.xml to the &clm; node in your preferred
      location. Here it is /tmp.
     </para>
    </listitem>
@@ -311,7 +311,7 @@
   <title>Setting Up WebSSO</title>
   <para>
    Start by creating a config file <filename>adfs_config.yml</filename> with the
-   following parameters and place it in any directory on your &lcm;,
+   following parameters and place it in any directory on your &clm;,
    such as <filename>/tmp</filename>.
   </para>
 <screen>keystone_trusted_idp: adfs

--- a/xml/operations-configuring_check_plugins.xml
+++ b/xml/operations-configuring_check_plugins.xml
@@ -56,7 +56,7 @@
   the detection class.
  </para>
 <screen>- name: _CEI-CMN | monasca_configure |
-    Run Monasca agent &lcm; specific ceilometer detection plugin
+    Run Monasca agent &clm; specific ceilometer detection plugin
   become: yes
   monasca_agent_plugin:
     name: "ARDANACeilometer"</screen>

--- a/xml/operations-console_alarmdefinitions.xml
+++ b/xml/operations-console_alarmdefinitions.xml
@@ -36,7 +36,7 @@
       <para>
        Review logs in <literal>/var/log/ops-console</literal> and logs in
        <literal>/var/log/apache2</literal>. Restart ops-console by running the
-       following commands on the &lcm;:
+       following commands on the &clm;:
       </para>
 <screen>cd ~/scratch/ansible/next/ardana/ansible
 ansible-playbook -i hosts/verb_hosts ops-console-stop.yml
@@ -55,7 +55,7 @@ ansible-playbook -i hosts/verb_hosts ops-console-start.yml</screen>
      <entry>
       <para>
        Review logs in <literal>/var/log/ops-console</literal>. Restart
-       ops-console by running the following commands on the &lcm;:
+       ops-console by running the following commands on the &clm;:
       </para>
 <screen>cd ~/scratch/ansible/next/ardana/ansible
 ansible-playbook -i hosts/verb_hosts ops-console-stop.yml

--- a/xml/operations-dns-designate_initialconfig.xml
+++ b/xml/operations-dns-designate_initialconfig.xml
@@ -170,7 +170,7 @@
    <procedure>
     <step>
      <para>
-      Connect to the &lcm;, and source the <literal>service.osrc</literal>
+      Connect to the &clm;, and source the <literal>service.osrc</literal>
       credentials.
      </para>
     </step>

--- a/xml/operations-identity_alarmdefinitions.xml
+++ b/xml/operations-identity_alarmdefinitions.xml
@@ -43,7 +43,7 @@ api_endpoint=public</screen>
       <orderedlist xml:id="ol_ht2_hzp_mx">
        <listitem>
         <para>
-         Log in to the &lcm;.
+         Log in to the &clm;.
         </para>
        </listitem>
        <listitem>
@@ -73,7 +73,7 @@ api_endpoint=admin</screen>
       <orderedlist xml:id="ol_it2_hzp_mx">
        <listitem>
         <para>
-         Log in to the &lcm;.
+         Log in to the &clm;.
         </para>
        </listitem>
        <listitem>
@@ -109,7 +109,7 @@ monitored_host_type=vip</screen>
       <orderedlist xml:id="ol_jt2_hzp_mx">
        <listitem>
         <para>
-         Log in to the &lcm;.
+         Log in to the &clm;.
         </para>
        </listitem>
        <listitem>
@@ -150,7 +150,7 @@ ansible-playbook -i hosts/verb_hosts FND-CLU-start.yml --limit &lt;hostname&gt;<
       <orderedlist xml:id="ol_lt2_hzp_mx">
        <listitem>
         <para>
-         Log in to the &lcm;.
+         Log in to the &clm;.
         </para>
        </listitem>
        <listitem>

--- a/xml/operations-image-configure_glance.xml
+++ b/xml/operations-image-configure_glance.xml
@@ -63,7 +63,7 @@
   <orderedlist>
    <listitem>
     <para>
-     Log in to the &lcm;.
+     Log in to the &clm;.
     </para>
    </listitem>
    <listitem>
@@ -167,7 +167,7 @@
   <orderedlist>
    <listitem>
     <para>
-     Log in to the &lcm;.
+     Log in to the &clm;.
     </para>
    </listitem>
    <listitem>

--- a/xml/operations-integrating_splunk.xml
+++ b/xml/operations-integrating_splunk.xml
@@ -124,7 +124,7 @@
   <procedure>
    <step>
     <para>
-     Log in to the &lcm;.
+     Log in to the &clm;.
     </para>
    </step>
    <step>

--- a/xml/operations-lbaas.xml
+++ b/xml/operations-lbaas.xml
@@ -45,7 +45,7 @@
   </para>
   <para>
    You can create the new network and router by executing the following command
-   from the &lcm; or a shell with access to the API nodes.
+   from the &clm; or a shell with access to the API nodes.
   </para>
   <procedure>
    <step>

--- a/xml/operations-magnum-deploying_kubernetes_coreos.xml
+++ b/xml/operations-magnum-deploying_kubernetes_coreos.xml
@@ -40,7 +40,7 @@
   <orderedlist>
    <listitem>
     <para>
-     Login to the &lcm;.
+     Login to the &clm;.
     </para>
    </listitem>
    <listitem>
@@ -210,7 +210,7 @@ WARNING (shell) "heat resource-list" is deprecated, please use "openstack stack 
    </listitem>
    <listitem>
     <para>
-     Install kubectl onto your &lcm;.
+     Install kubectl onto your &clm;.
     </para>
 <screen>$ export https_proxy=http://proxy.yourcompany.net:8080
 $ wget https://storage.googleapis.com/kubernetes-release/release/v1.2.0/bin/linux/amd64/kubectl

--- a/xml/operations-magnum-deploying_kubernetes_fedora_atomic.xml
+++ b/xml/operations-magnum-deploying_kubernetes_fedora_atomic.xml
@@ -197,7 +197,7 @@ WARNING (shell) "heat resource-list" is deprecated, please use "openstack stack 
    </listitem>
    <listitem>
     <para>
-     Install kubectl onto your &lcm;.
+     Install kubectl onto your &clm;.
     </para>
 <screen>$ export https_proxy=http://proxy.yourcompany.net:8080
 $ wget https://storage.googleapis.com/kubernetes-release/release/v1.2.0/bin/linux/amd64/kubectl

--- a/xml/operations-maintenance-compute-add_sles_compute.xml
+++ b/xml/operations-maintenance-compute-add_sles_compute.xml
@@ -24,7 +24,7 @@
   <listitem>
    <para>
     Adding &slsa; pre-installed compute hosts. This method does not require the
-    &slsa; ISO be on the &lcm; to complete.
+    &slsa; ISO be on the &clm; to complete.
    </para>
   </listitem>
   <listitem>
@@ -37,7 +37,7 @@
    <para>
     If you want to use the provided Ansible playbooks and Cobbler to setup and
     configure your &slsa; hosts and you did not have the &cloudos; ISO on your
-    &lcm; during your initial installation then ensure you look at
+    &clm; during your initial installation then ensure you look at
     the note at the top of that section before proceeding.
    </para>
   </listitem>
@@ -68,7 +68,7 @@
    </listitem>
    <listitem>
     <para>
-     Log in to the &lcm;.
+     Log in to the &clm;.
     </para>
    </listitem>
    <listitem>
@@ -99,7 +99,7 @@
       choose for this host does not conflict with any other IP address in your
       cloud environment. You can confirm this by checking the
       <literal>~/openstack/my_cloud/info/address_info.yml</literal> file on your
-      &lcm;.
+      &clm;.
      </para>
     </important>
    </listitem>
@@ -191,7 +191,7 @@ ansible-playbook -i hosts/verb_hosts site.yml --limit &lt;hostname&gt;</screen>
    manager.
   </para>
   <para>
-   If you did not have the &cloudos; ISO available on your &lcm;
+   If you did not have the &cloudos; ISO available on your &clm;
    during your initial installation, it must be installed before proceeding
    further. Instructions can be found in <xref linkend="install_sles_compute"/>.
   </para>
@@ -201,7 +201,7 @@ ansible-playbook -i hosts/verb_hosts site.yml --limit &lt;hostname&gt;</screen>
   <procedure>
    <step>
     <para>
-     Log in to your &lcm;.
+     Log in to your &clm;.
     </para>
    </step>
    <step>
@@ -244,7 +244,7 @@ git checkout site</screen>
       choose for this host does not conflict with any other IP address in your
       cloud environment. You can confirm this by checking the
       <literal>~/openstack/my_cloud/info/address_info.yml</literal> file on your
-      &lcm;.
+      &clm;.
      </para>
     </important>
    </step>

--- a/xml/operations-maintenance-compute-planned_computenode.xml
+++ b/xml/operations-maintenance-compute-planned_computenode.xml
@@ -20,7 +20,7 @@
   <procedure>
    <step>
     <para>
-     Log in to the &lcm;.
+     Log in to the &clm;.
     </para>
    </step>
    <step>

--- a/xml/operations-maintenance-compute-reboot_computenode.xml
+++ b/xml/operations-maintenance-compute-reboot_computenode.xml
@@ -20,7 +20,7 @@
  <procedure>
   <step>
    <para>
-    Log in to the &lcm;.
+    Log in to the &clm;.
    </para>
   </step>
   <step>

--- a/xml/operations-maintenance-compute-recover_compute_node.xml
+++ b/xml/operations-maintenance-compute-recover_compute_node.xml
@@ -51,7 +51,7 @@
   <procedure>
    <step>
     <para>
-     Log in to the &lcm;.
+     Log in to the &clm;.
     </para>
    </step>
    <step>
@@ -80,7 +80,7 @@
   <procedure>
    <step>
     <para>
-     Log in to the &lcm;.
+     Log in to the &clm;.
     </para>
    </step>
    <step>
@@ -106,7 +106,7 @@
    the operating system and one that is used as the data disk. These are
    defined during the installation of your cloud, in the
    <literal>~/openstack/my_cloud/definition/data/disks_compute.yml</literal>
-   file on the &lcm;. The data disk(s) are where the
+   file on the &clm;. The data disk(s) are where the
    <literal>nova-compute</literal> service lives. Recovery scenarios will
    depend on whether one or the other, or both, of these disks experienced
    failures.
@@ -123,7 +123,7 @@
   <procedure>
    <step>
     <para>
-     Log in to the &lcm;.
+     Log in to the &clm;.
     </para>
    </step>
    <step>

--- a/xml/operations-maintenance-compute-remove_compute_node.xml
+++ b/xml/operations-maintenance-compute-remove_compute_node.xml
@@ -268,7 +268,7 @@ neutron-ovs-cleanup.service           loaded      inactive   dead     Neutron OV
    OR
   </para>
   <para>
-   From the &lcm; you can use the
+   From the &clm; you can use the
    <literal>bm-power-down.yml</literal> playbook to shut down the node:
   </para>
 <screen>cd ~/openstack/ardana/ansible
@@ -344,12 +344,12 @@ $ neutron agent-delete f0d262d1-7139-40c7-bdc2-f227c6dee5c8</screen>
  <section xml:id="remove_node">
   <title>Remove the Compute Host from the servers.yml File and Run the Configuration Processor</title>
   <para>
-   Complete these steps from the &lcm; to remove the Compute node:
+   Complete these steps from the &clm; to remove the Compute node:
   </para>
   <procedure>
    <step>
     <para>
-     Log in to the &lcm;
+     Log in to the &clm;
     </para>
    </step>
    <step>

--- a/xml/operations-maintenance-controller-full_recovery.xml
+++ b/xml/operations-maintenance-controller-full_recovery.xml
@@ -22,7 +22,7 @@
   <orderedlist>
    <listitem>
     <para>
-     Log in to the &lcm;.
+     Log in to the &clm;.
     </para>
    </listitem>
    <listitem>
@@ -34,13 +34,13 @@
    </listitem>
    <listitem>
     <para>
-     On the &lcm; copy the following files:
+     On the &clm; copy the following files:
     </para>
 <screen>cp -r ~/hp-ci/openstack/* ~/openstack/my_cloud/definition/</screen>
    </listitem>
    <listitem>
     <para>
-     Run this playbook to restore the &lcm; helper:
+     Run this playbook to restore the &clm; helper:
     </para>
 <screen>cd ~/openstack/ardana/ansible/
 ansible-playbook -i hosts/localhost _deployer_restore_helper.yml</screen>
@@ -68,7 +68,7 @@ ansible-playbook -i hosts/verb_hosts site.yml -e '{ "freezer_backup_jobs_upload"
    <listitem>
     <para>
      You can now perform the procedures to restore MySQL and Swift. Once
-     everything is restored, re-enable the backups from the &lcm;:
+     everything is restored, re-enable the backups from the &clm;:
     </para>
 <screen>cd ~/scratch/ansible/next/ardana/ansible
 ansible-playbook -i hosts/verb_hosts _freezer_manage_jobs.yml</screen>

--- a/xml/operations-maintenance-controller-lifecyclemanager_recovery.xml
+++ b/xml/operations-maintenance-controller-lifecyclemanager_recovery.xml
@@ -6,15 +6,15 @@
  <!ENTITY % entities SYSTEM "entity-decl.ent"> %entities;
 ]>
 <section xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="lifecyclemanager_recovery">
- <title>&lcm; Disaster Recovery</title>
+ <title>&clm; Disaster Recovery</title>
  <para>
   In this scenario everything is still running (controller nodes and compute
-  nodes) but you have lost either a dedicated &lcm; or a shared
-  &lcm;/controller node.
+  nodes) but you have lost either a dedicated &clm; or a shared
+  &clm;/controller node.
  </para>
  <para>
   To ensure that you use the same version of &productname; that you previously had
-  loaded on your &lcm;, you will need to download and install the
+  loaded on your &clm;, you will need to download and install the
   lifecycle management software using the instructions from the
   <xref linkend="sec.depl.adm_inst.add_on"/> before proceeding further.
  </para>
@@ -23,7 +23,7 @@
   <procedure>
    <step>
     <para>
-     Log in to the &lcm;.
+     Log in to the &clm;.
     </para>
    </step>
    <step>
@@ -43,39 +43,39 @@
       <para>
        Retrieve the <filename>/var/lib/ardana/backup.osrc</filename> file and
        copy it to the <filename>/var/lib/ardana/</filename> directory on the
-       &lcm;.
+       &clm;.
       </para>
      </step>
      <step>
       <para>
        Copy all the files in the
        <literal>/opt/stack/service/freezer-api/etc/</literal> directory to
-       the same directory on the &lcm;.
+       the same directory on the &clm;.
       </para>
      </step>
      <step>
       <para>
        Copy all the files in the <literal>/var/lib/ca-certificates</literal>
-       directory to the same directory on the &lcm;.
+       directory to the same directory on the &clm;.
       </para>
      </step>
      <step>
       <para>
        Retrieve the <literal>/etc/hosts</literal> file and replace the one
-       found on the &lcm;.
+       found on the &clm;.
       </para>
      </step>
     </substeps>
    </step>
    <step>
     <para>
-     Log back in to the &lcm;.
+     Log back in to the &clm;.
     </para>
    </step>
    <step>
     <para>
      Edit the value for <literal>client_id</literal> in the following file to
-     contain the hostname of your &lcm;:
+     contain the hostname of your &clm;:
     </para>
 <screen>/opt/stack/service/freezer-api/etc/freezer-api.conf</screen>
    </step>
@@ -97,7 +97,7 @@ ff02::2         ip6-allrouters</screen>
    </step>
    <step>
     <para>
-     On the &lcm;, source the backup user credentials:
+     On the &clm;, source the backup user credentials:
     </para>
 <screen>&prompt.ardana;source ~/backup.osrc</screen>
    </step>
@@ -141,7 +141,7 @@ ff02::2         ip6-allrouters</screen>
     </para>
 <screen>&prompt.ardana;freezer job-stop <replaceable>JOB-ID</replaceable></screen>
     <para>
-     If it is present, also stop the &lcm;'s SSH backup.
+     If it is present, also stop the &clm;'s SSH backup.
     </para>
    </step>
    <step>
@@ -164,7 +164,7 @@ ff02::2         ip6-allrouters</screen>
    </step>
    <step>
     <para>
-     When the job completes, the previous &lcm; contents should be
+     When the job completes, the previous &clm; contents should be
      restored to your home directory:
     </para>
 <screen>&prompt.ardana;cd ~
@@ -211,12 +211,12 @@ done</screen>
    </step>
    <step>
     <para>
-     If you are using a dedicated &lcm;, follow these steps:
+     If you are using a dedicated &clm;, follow these steps:
     </para>
     <substeps>
      <step>
       <para>
-       re-run the deployment to ensure the &lcm; is in the correct
+       re-run the deployment to ensure the &clm; is in the correct
        state:
       </para>
 <screen>&prompt.ardana;cd ~/scratch/ansible/next/ardana/ansible
@@ -226,13 +226,13 @@ done</screen>
    </step>
    <step>
     <para>
-     If you are using a shared &lcm;/controller, follow these
+     If you are using a shared &clm;/controller, follow these
      steps:
     </para>
     <substeps>
      <step>
       <para>
-       If the node is also a &lcm; hypervisor, run the following commands to
+       If the node is also a &clm; hypervisor, run the following commands to
        recreate the virtual machines that were lost:
       </para>
 <screen>&prompt.ardana;cd ~/scratch/ansible/next/ardana/ansible
@@ -273,14 +273,14 @@ rabbit_primary_hostname=cloud-cp1-rmq-mysql-m3</screen>
   <procedure>
    <step>
     <para>
-     On the &lcm;, edit the following file so it contains the same
+     On the &clm;, edit the following file so it contains the same
      information as it did previously:
     </para>
 <screen>&prompt.ardana;~/openstack/my_cloud/config/freezer/ssh_credentials.yml</screen>
    </step>
    <step>
     <para>
-     On the &lcm;, copy the following files, change directories,
+     On the &clm;, copy the following files, change directories,
      and run the playbook _deployer_restore_helper.yml:
     </para>
 <screen>&prompt.ardana;cp -r ~/hp-ci/openstack/* ~/openstack/my_cloud/definition/
@@ -309,8 +309,8 @@ rabbit_primary_hostname=cloud-cp1-rmq-mysql-m3</screen>
    </step>
    <step>
     <para>
-     When the &lcm; is restored, re-run the deployment to ensure
-     the &lcm; is in the correct state:
+     When the &clm; is restored, re-run the deployment to ensure
+     the &clm; is in the correct state:
     </para>
 <screen>&prompt.ardana;cd ~/scratch/ansible/next/ardana/ansible
 &prompt.ardana;ansible-playbook -i hosts/verb_hosts site.yml --limit localhost</screen>

--- a/xml/operations-maintenance-controller-onetwo_controller_recovery.xml
+++ b/xml/operations-maintenance-controller-onetwo_controller_recovery.xml
@@ -13,7 +13,7 @@
  <itemizedlist>
   <listitem>
    <para>
-    Your &lcm; is still intact and working.
+    Your &clm; is still intact and working.
    </para>
   </listitem>
   <listitem>
@@ -37,7 +37,7 @@
    </listitem>
    <listitem>
     <para>
-     Log in to the &lcm;.
+     Log in to the &clm;.
     </para>
    </listitem>
    <listitem>

--- a/xml/operations-maintenance-controller-pit_database_recovery.xml
+++ b/xml/operations-maintenance-controller-pit_database_recovery.xml
@@ -8,7 +8,7 @@
 <section xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="pit_database_recovery">
  <title>Point-in-Time &mariadb; Database Recovery</title>
  <para>
-  In this scenario, everything is still running (&lcm;, cloud controller nodes,
+  In this scenario, everything is still running (&clm;, cloud controller nodes,
   and compute nodes) but you want to restore the &mariadb; database to a
   previous state.
  </para>
@@ -17,7 +17,7 @@
   <procedure>
    <step>
     <para>
-     Log in to the &lcm;.
+     Log in to the &clm;.
     </para>
    </step>
    <step>
@@ -116,7 +116,7 @@ ardana002-cp1-c1-m1</screen>
    </step>
    <step>
     <para>
-     Log in to the &lcm;.
+     Log in to the &clm;.
     </para>
    </step>
    <step>
@@ -160,7 +160,7 @@ ardana002-cp1-c1-m1</screen>
    </step>
    <step>
     <para>
-     Log back in to the &lcm;.
+     Log back in to the &clm;.
     </para>
    </step>
    <step>
@@ -188,7 +188,7 @@ ardana002-cp1-c1-m1</screen>
   <procedure>
    <step>
     <para>
-     Log in to the &lcm;.
+     Log in to the &clm;.
     </para>
    </step>
    <step>
@@ -248,7 +248,7 @@ hostname = {{ hostname of the first &mariadb; node }}</screen>
    </step>
    <step>
     <para>
-     Log back in to the &lcm;.
+     Log back in to the &clm;.
     </para>
    </step>
    <step>
@@ -287,7 +287,7 @@ hostname = {{ hostname of the first &mariadb; node }}</screen>
   <title>Point-in-Time Cassandra Recovery</title>
   <para>
    A node may have been removed either due to an intentional action in the
-   &lcm; Admin UI or as a result of a fatal hardware event that requires a
+   &clm; Admin UI or as a result of a fatal hardware event that requires a
    server to be replaced. In either case, the entry for the failed or deleted
    node should be removed from Cassandra before a new node is brought up.
   </para>

--- a/xml/operations-maintenance-controller-pit_lifecyclemanager_recovery.xml
+++ b/xml/operations-maintenance-controller-pit_lifecyclemanager_recovery.xml
@@ -6,16 +6,16 @@
  <!ENTITY % entities SYSTEM "entity-decl.ent"> %entities;
 ]>
 <section xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="pit_lifecyclemanager_recovery">
- <title>Point-in-time &lcm; Recovery</title>
+ <title>Point-in-time &clm; Recovery</title>
  <para>
-  In this scenario, everything is still running (&lcm;, controller nodes, and
-  compute nodes) but you want to restore the &lcm; to a previous state.
+  In this scenario, everything is still running (&clm;, controller nodes, and
+  compute nodes) but you want to restore the &clm; to a previous state.
  </para>
  <procedure xml:id="restore_swift_ssh_bu">
   <title>Restoring from a Swift or SSH Backup</title>
   <step>
    <para>
-    Log in to the &lcm;.
+    Log in to the &clm;.
    </para>
   </step>
   <step>

--- a/xml/operations-maintenance-controller-pit_swiftrings_recovery.xml
+++ b/xml/operations-maintenance-controller-pit_swiftrings_recovery.xml
@@ -8,7 +8,7 @@
 <section xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="pit_swiftrings_recovery">
  <title>Point-in-Time &swift; Rings Recovery</title>
  <para>
-  In this situation, everything is still running (&lcm;, control plane nodes,
+  In this situation, everything is still running (&clm;, control plane nodes,
   and compute nodes) but you want to restore your &swift; rings to a previous
   state.
  </para>
@@ -30,7 +30,7 @@
     <substeps>
      <step>
       <para>
-       On the &lcm;
+       On the &clm;
       </para>
 <screen>&prompt.ardana;cd  ~/scratch/ansible/next/ardana/ansible
 &prompt.ardana;ansible-playbook -i hosts/verb_hosts swift-status.yml \
@@ -111,7 +111,7 @@ ardana-qe102-cp1-c1-m1 : ok=12 changed=0 unreachable=0 failed=0```</screen>
    </step>
    <step>
     <para>
-     Log in to the &lcm;.
+     Log in to the &clm;.
     </para>
    </step>
    <step>
@@ -139,7 +139,7 @@ ardana-qe102-cp1-c1-m1 : ok=12 changed=0 unreachable=0 failed=0```</screen>
    </step>
    <step>
     <para>
-     Log back in to the &lcm;.
+     Log back in to the &clm;.
     </para>
    </step>
    <step>

--- a/xml/operations-maintenance-controller-recovering_controller_nodes.xml
+++ b/xml/operations-maintenance-controller-recovering_controller_nodes.xml
@@ -21,9 +21,9 @@
  </para>
  <note>
   <para>
-   You should have backed up <filename>/etc/group</filename> of the &lcm;
-   manually after installation. While recovering a &lcm; node, manually copy
-   the <filename>/etc/group</filename> file from a backup of the old &lcm;.
+   You should have backed up <filename>/etc/group</filename> of the &clm;
+   manually after installation. While recovering a &clm; node, manually copy
+   the <filename>/etc/group</filename> file from a backup of the old &clm;.
   </para>
  </note>
 

--- a/xml/operations-maintenance-controller-replace_controller.xml
+++ b/xml/operations-maintenance-controller-replace_controller.xml
@@ -16,7 +16,7 @@
   Therefore, adding or removing nodes is not an option. However, if you need to
   repair or replace a controller node, you may do so by following the steps
   outlined here. Note that to run any playbooks whatsoever for cloud
-  maintenance, you will always run the steps from the &lcm;.
+  maintenance, you will always run the steps from the &clm;.
  </para>
  <para>
   These steps will depend on whether you need to replace a shared lifecycle
@@ -33,7 +33,7 @@
   <listitem>
    <para>
     Be aware that all management commands are run on the node where the
-    &lcm; is running.
+    &clm; is running.
    </para>
   </listitem>
  </itemizedlist>

--- a/xml/operations-maintenance-controller-replace_dedicated_lm.xml
+++ b/xml/operations-maintenance-controller-replace_dedicated_lm.xml
@@ -9,12 +9,12 @@
  <title>Replacing a Standalone Controller Node</title>
  <para>
   If the controller node you need to replace is not also being used as the
-  &lcm;, follow the steps below.
+  &clm;, follow the steps below.
  </para>
  <procedure>
   <step>
    <para>
-    Log in to the &lcm;.
+    Log in to the &clm;.
    </para>
   </step>
   <step>

--- a/xml/operations-maintenance-controller-replace_shared_lm.xml
+++ b/xml/operations-maintenance-controller-replace_shared_lm.xml
@@ -6,17 +6,17 @@
  <!ENTITY % entities SYSTEM "entity-decl.ent"> %entities;
 ]>
 <section xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="replace_shared_lm">
- <title>Replacing a Shared &lcm;/Controller Node</title>
+ <title>Replacing a Shared &clm;/Controller Node</title>
  <para>
   If the controller node you need to replace was also being used as your
-  &lcm; then use these steps below. If this is not a shared
+  &clm; then use these steps below. If this is not a shared
   controller then skip to the next section.
  </para>
  <procedure>
   <step>
    <para>
     To ensure that you use the same version of &productname; that you previously had
-    loaded on your &lcm;, you will need to download and install the
+    loaded on your &clm;, you will need to download and install the
     lifecycle management software using the instructions from the installation
     guide:
    </para>
@@ -91,7 +91,7 @@ ansible-playbook -i hosts/localhost cobbler-deploy.yml</screen>
   </step>
   <step>
    <para>
-    Install the software on your new &lcm;/controller node with
+    Install the software on your new &clm;/controller node with
     these three playbooks:
    </para>
 <screen>cd ~/scratch/ansible/next/ardana/ansible

--- a/xml/operations-maintenance-controller-restart_controller.xml
+++ b/xml/operations-maintenance-controller-restart_controller.xml
@@ -40,7 +40,7 @@
    <listitem>
     <para>
      Each of your controller nodes should have network connectivity, verified
-     by SSH connectivity from the &lcm; to them.
+     by SSH connectivity from the &clm; to them.
     </para>
    </listitem>
    <listitem>
@@ -123,18 +123,18 @@ ansible-playbook -i hosts/verb_hosts galera-bootstrap.yml</screen>
  <section xml:id="hlm">
   <title>Restarting Services on the Controller Nodes</title>
   <para>
-   From the &lcm; you should execute the
+   From the &clm; you should execute the
    <literal>ardana-start.yml</literal> playbook for each node that was brought
    down so the services can be started back up.
   </para>
   <para>
-   If you have a dedicated (separate) &lcm; node you can use this
+   If you have a dedicated (separate) &clm; node you can use this
    syntax:
   </para>
 <screen>cd ~/scratch/ansible/next/ardana/ansible
 ansible-playbook -i hosts/verb_hosts ardana-start.yml --limit=&lt;hostname_of_node&gt;</screen>
   <para>
-   If you have a shared &lcm;/controller setup and need to restart
+   If you have a shared &clm;/controller setup and need to restart
    services on this shared node, you can use <literal>localhost</literal> to
    indicate the shared node, like this:
   </para>
@@ -156,7 +156,7 @@ ansible-playbook -i hosts/verb_hosts ardana-start.yml --limit=&lt;hostname_of_no
   <orderedlist>
    <listitem>
     <para>
-     Log in to the &lcm;.
+     Log in to the &clm;.
     </para>
    </listitem>
    <listitem>

--- a/xml/operations-maintenance-controller-swiftrings_recovery.xml
+++ b/xml/operations-maintenance-controller-swiftrings_recovery.xml
@@ -96,7 +96,7 @@ EOF</screen>
      If the SWF-PRX[0] is already deployed, copy the contents of the restored
      directory (<literal>/tmp/swift_builder_dir_restore/<replaceable>CLOUD_NAME</replaceable>/<replaceable>CONTROL_PLANE_NAME</replaceable>/builder_dir/</literal>) to
      <literal>/etc/swiftlm/<replaceable>CLOUD_NAME</replaceable>/<replaceable>CONTROL_PLANE_NAME</replaceable>/builder_dir/</literal> on the SWF-PRX[0] Then from
-     the &lcm; run:
+     the &clm; run:
     </para>
 <screen>&prompt.ardana;sudo cp -pr /tmp/swift_builder_dir_restore/<replaceable>CLOUD_NAME</replaceable>/<replaceable>CONTROL_PLANE_NAME</replaceable>/builder_dir/* \
     /etc/swiftlm/<replaceable>CLOUD_NAME</replaceable>/<replaceable>CONTROL_PLANE_NAME</replaceable>/builder_dir/</screen>
@@ -109,7 +109,7 @@ EOF</screen>
    <listitem>
     <para>
      If the SWF-ACC[0] is<emphasis role="bold"> not </emphasis>deployed, from
-     the &lcm; run these playbooks:
+     the &clm; run these playbooks:
     </para>
 <screen>&prompt.ardana;cd ~/scratch/ansible/next/ardana/ansible
 &prompt.ardana;ansible-playbook -i hosts/verb_hosts guard-deployment.yml
@@ -131,7 +131,7 @@ EOF</screen>
    </listitem>
    <listitem>
     <para>
-     From the &lcm;, run the <filename>ardana-deploy.yml</filename>
+     From the &clm;, run the <filename>ardana-deploy.yml</filename>
      playbook:
     </para>
 <screen>&prompt.ardana;cd ~/scratch/ansible/next/ardana/ansible

--- a/xml/operations-maintenance-controller-three_controller_recovery.xml
+++ b/xml/operations-maintenance-controller-three_controller_recovery.xml
@@ -22,7 +22,7 @@
   <orderedlist>
    <listitem>
     <para>
-     Log in to the &lcm;.
+     Log in to the &clm;.
     </para>
    </listitem>
    <listitem>
@@ -95,7 +95,7 @@ freezer_create_backup_jobs: false</screen>
    </listitem>
    <listitem>
     <para>
-     Log back in to the &lcm;.
+     Log back in to the &clm;.
     </para>
    </listitem>
    <listitem>
@@ -116,7 +116,7 @@ freezer_create_backup_jobs: false</screen>
    </listitem>
    <listitem>
     <para>
-     Log back in to the &lcm; and bootstrap MySQL:
+     Log back in to the &clm; and bootstrap MySQL:
     </para>
 <screen>&prompt.ardana;cd ~/scratch/ansible/next/ardana/ansible
 &prompt.ardana;ansible-playbook -i hosts/verb_hosts galera-bootstrap.yml</screen>

--- a/xml/operations-maintenance-deploy-ptf.xml
+++ b/xml/operations-maintenance-deploy-ptf.xml
@@ -6,7 +6,7 @@
 <!ENTITY % entities SYSTEM "entity-decl.ent"> %entities;
 ]>
 <section xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="deploy_ptf">
- <title>&lcm; Program Temporary Fix (PTF) Deployment</title>
+ <title>&clm; Program Temporary Fix (PTF) Deployment</title>
  <para>
   Occasionally, in order to fix a given issue, &suse; will provide a set of
   packages known as a Program Temporary Fix (PTF). Such a PTF is fully
@@ -24,7 +24,7 @@
     When &suse; has developed a PTF, you will receive a URL for that PTF. It
     will contain the entire Python virtual environment (venv). You should
     download the packages from the location provided by &suse; Support to a
-    temporary location on the &lcm;. Set the variables for your Support ID and
+    temporary location on the &clm;. Set the variables for your Support ID and
     password. For example:
    </para>
    <screen>&prompt.ardana;sudo user=<replaceable>USER_NAME</replaceable>
@@ -84,7 +84,7 @@ Saving other metadata</screen>
   </step>
   <step>
    <para>
-    Refresh the PTF repository before installing package updates on the &lcm;
+    Refresh the PTF repository before installing package updates on the &clm;
    </para>
    <screen>&prompt.ardana;sudo zypper refresh -fr PTF
 Forcing raw metadata refresh
@@ -107,7 +107,7 @@ i | venv-openstack-neutron-x86_64 | Python virtualenv for OpenStack Neutron | pa
   </step>
   <step>
    <para>
-    Install the PTF on the &lcm;
+    Install the PTF on the &clm;
    </para>
    <screen>&prompt.ardana;sudo zypper dup --from PTF
 Refreshing service

--- a/xml/operations-maintenance-live_migration.xml
+++ b/xml/operations-maintenance-live_migration.xml
@@ -387,7 +387,7 @@
   <procedure>
    <step>
     <para>
-     Log in to the &lcm;.
+     Log in to the &clm;.
     </para>
    </step>
    <step>
@@ -400,7 +400,7 @@ ansible-playbook -i hosts/localhost bm-power-down.yml -e nodelist=&lt;node_name&
      <para>
       The value for <literal>&lt;node_name&gt;</literal> will be the name that
       Cobbler has when you run <command>sudo cobbler system list</command> from
-      the &lcm;.
+      the &clm;.
      </para>
     </note>
    </step>
@@ -420,7 +420,7 @@ ansible-playbook -i hosts/localhost bm-power-down.yml -e nodelist=&lt;node_name&
     <note>
      <para>
       The value for <replaceable>HOSTNAME</replaceable> can be obtained by
-      using <command>openstack host list</command> from the &lcm;.
+      using <command>openstack host list</command> from the &clm;.
      </para>
     </note>
    </step>
@@ -513,7 +513,7 @@ ansible-playbook -i hosts/localhost bm-power-down.yml -e nodelist=&lt;node_name&
   </para>
   <para>
    To perform migrations from the command-line, use the NovaClient.
-   The &lcm; node in your cloud environment should have
+   The &clm; node in your cloud environment should have
    the NovaClient already installed. If you will be accessing your environment
    through a different method, ensure that the NovaClient is
    installed. You can do so using Python's <command>pip</command> package
@@ -521,7 +521,7 @@ ansible-playbook -i hosts/localhost bm-power-down.yml -e nodelist=&lt;node_name&
   </para>
   <para>
    To run the commands in the steps below, you need administrator
-   credentials. From the &lcm;, you can source the
+   credentials. From the &clm;, you can source the
    <filename>service.osrc</filename> file which is provided that has the
    necessary credentials:
   </para>
@@ -532,7 +532,7 @@ ansible-playbook -i hosts/localhost bm-power-down.yml -e nodelist=&lt;node_name&
   <procedure>
    <step>
     <para>
-     Log in to the &lcm;.
+     Log in to the &clm;.
     </para>
    </step>
    <step>

--- a/xml/operations-maintenance-networking-add_network_node.xml
+++ b/xml/operations-maintenance-networking-add_network_node.xml
@@ -22,7 +22,7 @@
    separate and the roles are defined. If you are not already using this model
    and wish to add separate networking nodes then you need to ensure that those
    roles are defined. You can look in the <literal>~/openstack/examples</literal>
-   folder on your &lcm; for the mid-scale example model files which
+   folder on your &clm; for the mid-scale example model files which
    show how to do this. We have also added the basic edits that need to be made
    below:
   </para>
@@ -148,7 +148,7 @@
   <orderedlist>
    <listitem>
     <para>
-     Log in to your &lcm;.
+     Log in to your &clm;.
     </para>
    </listitem>
    <listitem>
@@ -186,7 +186,7 @@
       choose for this node does not conflict with any other IP address in your
       cloud environment. You can confirm this by checking the
       <literal>~/openstack/my_cloud/info/address_info.yml</literal> file on your
-      &lcm;.
+      &clm;.
      </para>
     </important>
    </listitem>

--- a/xml/operations-maintenance-reboot_cloud_down.xml
+++ b/xml/operations-maintenance-reboot_cloud_down.xml
@@ -26,12 +26,12 @@
  <section xml:id="idg-all-operations-maintenance-reboot_cloud_down-xml-7">
   <title>Gracefully Bringing Down and Restarting Your Cloud Environment</title>
   <para>
-   You will do the following steps from your &lcm;.
+   You will do the following steps from your &clm;.
   </para>
   <procedure>
    <step>
     <para>
-     Log in to your &lcm;.
+     Log in to your &clm;.
     </para>
    </step>
    <step>
@@ -59,7 +59,7 @@ ansible-playbook -i hosts/verb_hosts ardana-stop.yml</screen>
      </step>
      <step>
       <para>
-       From the &lcm;, you can use the
+       From the &clm;, you can use the
        <literal>bm-power-down.yml</literal> and
        <literal>bm-power-up.yml</literal> playbooks.
       </para>
@@ -79,7 +79,7 @@ ansible-playbook -i hosts/verb_hosts ardana-stop.yml</screen>
    </step>
    <step>
     <para>
-     After the maintenance is complete, power your &lcm; back up
+     After the maintenance is complete, power your &clm; back up
      and then SSH to it.
     </para>
    </step>
@@ -101,7 +101,7 @@ ansible-playbook -i hosts/verb_hosts bm-power-up.yml [-e nodelist=&lt;node_name&
    <note>
     <para>
      Obtain the <literal>&lt;node_name&gt;</literal> by using the
-     <command>sudo cobbler system list</command> command from the &lcm;.
+     <command>sudo cobbler system list</command> command from the &clm;.
     </para>
    </note>
    </step>

--- a/xml/operations-maintenance-reboot_cloud_rolling.xml
+++ b/xml/operations-maintenance-reboot_cloud_rolling.xml
@@ -66,7 +66,7 @@
   </para>
   <note>
    <para>
-    If you have previously rebooted your &lcm; for any reason, ensure that
+    If you have previously rebooted your &clm; for any reason, ensure that
     the <systemitem>apache2</systemitem> service is running before
     continuing. To start the <systemitem>apache2</systemitem> service, use
     this command:
@@ -179,7 +179,7 @@
     <substeps>
      <step>
       <para>
-       From the &lcm;, list out your ports to determine which port
+       From the &clm;, list out your ports to determine which port
        is serving as the router gateway:
       </para>
 <screen>&prompt.ardana;source ~/service.osrc
@@ -382,7 +382,7 @@ Added router e122ea3f-90c5-4662-bf4a-3889f677aacf to L3 agent</screen>
 ~/scratch/ansible/next/ardana/ansible/hosts/verb_hosts \
 | grep ansible_ssh_host | awk '{print $1}'; done</screen>
   <para>
-   Then perform the following steps from your &lcm; for each of
+   Then perform the following steps from your &clm; for each of
    your controller nodes:
   </para>
   <procedure>
@@ -571,7 +571,7 @@ Added router e122ea3f-90c5-4662-bf4a-3889f677aacf to L3 agent</screen>
    </step>
    <step>
     <para>
-     Run the ardana-start.yml playbook from the &lcm;. If needed, use
+     Run the ardana-start.yml playbook from the &clm;. If needed, use
      the bm-power-up.yml playbook to restart the node. Specify just the node(s)
      you want to start in the 'nodelist' parameter arguments, that is,
      nodelist=&lt;node1&gt;[,&lt;node2&gt;][,&lt;node3&gt;].

--- a/xml/operations-maintenance-swift-add_swift_disk.xml
+++ b/xml/operations-maintenance-swift-add_swift_disk.xml
@@ -98,7 +98,7 @@
    </step>
    <step>
     <para>
-     On the &lcm;, update your cloud configuration with the details
+     On the &clm;, update your cloud configuration with the details
      of your additional disks.
     </para>
     <substeps>

--- a/xml/operations-maintenance-swift-add_swift_object_node.xml
+++ b/xml/operations-maintenance-swift-add_swift_object_node.xml
@@ -31,7 +31,7 @@
   <orderedlist>
    <listitem>
     <para>
-     Log in to the &lcm; node.
+     Log in to the &clm; node.
     </para>
    </listitem>
    <listitem>

--- a/xml/operations-maintenance-swift-add_swift_pac_node.xml
+++ b/xml/operations-maintenance-swift-add_swift_pac_node.xml
@@ -32,7 +32,7 @@
   <orderedlist>
    <listitem>
     <para>
-     Log in to the &lcm;.
+     Log in to the &clm;.
     </para>
    </listitem>
    <listitem>

--- a/xml/operations-maintenance-swift-recover_swift_node.xml
+++ b/xml/operations-maintenance-swift-recover_swift_node.xml
@@ -44,7 +44,7 @@
   <orderedlist>
    <listitem>
     <para>
-     Log in to the &lcm;.
+     Log in to the &clm;.
     </para>
    </listitem>
    <listitem>

--- a/xml/operations-maintenance-swift-removing_swift_node.xml
+++ b/xml/operations-maintenance-swift-removing_swift_node.xml
@@ -24,7 +24,7 @@
   <orderedlist>
    <listitem>
     <para>
-     Log in to the &lcm;.
+     Log in to the &clm;.
     </para>
    </listitem>
    <listitem>
@@ -217,7 +217,7 @@ ansible-playbook -i hosts/verb_hosts swift-deploy.yml</screen>
   <orderedlist>
    <listitem>
     <para>
-     Log in to the &lcm;.
+     Log in to the &clm;.
     </para>
    </listitem>
    <listitem>
@@ -268,7 +268,7 @@ ansible-playbook -i hosts/verb_hosts swift-stop.yml --limit <emphasis role="bold
   <orderedlist>
    <listitem>
     <para>
-     Log in to the &lcm;.
+     Log in to the &clm;.
     </para>
    </listitem>
    <listitem>

--- a/xml/operations-maintenance-swift-replacing_drives_swift_node.xml
+++ b/xml/operations-maintenance-swift-replacing_drives_swift_node.xml
@@ -31,7 +31,7 @@
   <orderedlist>
    <listitem>
     <para>
-     Log in to the &lcm;.
+     Log in to the &clm;.
     </para>
    </listitem>
    <listitem>
@@ -104,7 +104,7 @@ ansible-playbook -i hosts/verb_hosts osconfig-run.yml -limit ardana-cp1-swobj000
   <orderedlist>
    <listitem>
     <para>
-     Log onto the &lcm;.
+     Log onto the &clm;.
     </para>
    </listitem>
    <listitem>

--- a/xml/operations-maintenance-swift-replacing_swift_node.xml
+++ b/xml/operations-maintenance-swift-replacing_swift_node.xml
@@ -27,7 +27,7 @@
   <orderedlist>
    <listitem>
     <para>
-     Log in to the &lcm;.
+     Log in to the &clm;.
     </para>
    </listitem>
    <listitem>

--- a/xml/operations-maintenance-update_maintenance.xml
+++ b/xml/operations-maintenance-update_maintenance.xml
@@ -6,13 +6,13 @@
 <!ENTITY % entities SYSTEM "entity-decl.ent"> %entities;
 ]>
 <section xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="maintenance_update">
- <title>&lcm; Maintenance Update Procedure</title>
+ <title>&clm; Maintenance Update Procedure</title>
  <procedure>
   <title>Preparing for Update</title>
   <step>
    <para>
     Ensure that the update repositories have been properly set up on all nodes.
-    The easiest way to provide the required repositories on the &lcm; Server is
+    The easiest way to provide the required repositories on the &clm; Server is
     to set up an &smt; server as described in
     <xref linkend="app.deploy.smt_lcm"/>. Alternatives to setting up an
     &smt; server are described in <xref linkend="cha.depl.repo_conf_lcm"/>.
@@ -106,7 +106,7 @@
      </step>
      <step>
       <para>
-       Initialize the &lcm; and prepare the update playbooks.
+       Initialize the &clm; and prepare the update playbooks.
       </para>
       <substeps>
        <step>

--- a/xml/operations-maintenance-vsa-repair_vsa_maintenance.xml
+++ b/xml/operations-maintenance-vsa-repair_vsa_maintenance.xml
@@ -141,7 +141,7 @@
   <para>
    Even after the VSA node is under maintenance, it should continue to remain
    in the<literal> data/servers.yml</literal> file. You should also create a
-   file (for example offline-vsa) on the &lcm; with a list of VSA
+   file (for example offline-vsa) on the &clm; with a list of VSA
    nodes that are currently offline, so that these nodes get excluded from any
    further reconfiguration or upgrade. Perform the following steps to remove
    the VSA node for maintenance:
@@ -149,7 +149,7 @@
   <orderedlist>
    <listitem>
     <para>
-     Login to the &lcm;.
+     Login to the &clm;.
     </para>
    </listitem>
    <listitem>

--- a/xml/operations-managing_notificationmethods.xml
+++ b/xml/operations-managing_notificationmethods.xml
@@ -41,7 +41,7 @@ troubleshooting alarms, see..."-->
    methods.
   </para>
   <para>
-   These steps will require access to the &lcm; in your cloud
+   These steps will require access to the &clm; in your cloud
    deployment so you may need to contact your Administrator. You can make these
    changes during the initial configuration phase prior to the first
    installation or you can modify your existing environment, the only
@@ -50,7 +50,7 @@ troubleshooting alarms, see..."-->
   <procedure>
    <step>
     <para>
-     Log in to the &lcm;.
+     Log in to the &clm;.
     </para>
    </step>
    <step>

--- a/xml/operations-monitoring-accessing_monitoring.xml
+++ b/xml/operations-monitoring-accessing_monitoring.xml
@@ -17,7 +17,7 @@
   <para>
    For users who prefer using the command line, there is the
    python-monascaclient, which is part of the default installation on your
-   &lcm; node.
+   &clm; node.
   </para>
   <para>
    For details on the CLI, including installation instructions, see

--- a/xml/operations-monitoring-config_mon_notemail.xml
+++ b/xml/operations-monitoring-config_mon_notemail.xml
@@ -25,7 +25,7 @@
   <orderedlist>
    <listitem>
     <para>
-     Log in to the &lcm;.
+     Log in to the &clm;.
     </para>
    </listitem>
    <listitem>
@@ -210,7 +210,7 @@
   <orderedlist>
    <listitem>
     <para>
-     Log in to the &lcm;.
+     Log in to the &clm;.
     </para>
    </listitem>
    <listitem>

--- a/xml/operations-monitoring-crt_adding_transform_spark.xml
+++ b/xml/operations-monitoring-crt_adding_transform_spark.xml
@@ -74,7 +74,7 @@
   </listitem>
   <listitem>
    <para>
-    Run &lcm; Deploy
+    Run &clm; Deploy
    </para>
 <screen>&prompt.ardana;cd ~/scratch/ansible/next/ardana/ansible
 &prompt.ardana;ansible-playbook -i hosts/verb_hosts ardana-deploy.yml</screen>

--- a/xml/operations-monitoring-enable_mon_console.xml
+++ b/xml/operations-monitoring-enable_mon_console.xml
@@ -14,7 +14,7 @@
  <orderedlist>
   <listitem>
    <para>
-    Log in to the &lcm;.
+    Log in to the &clm;.
    </para>
   </listitem>
   <listitem>

--- a/xml/operations-monitoring-libvirt_tuningknobs.xml
+++ b/xml/operations-monitoring-libvirt_tuningknobs.xml
@@ -243,7 +243,7 @@
   <orderedlist>
    <listitem>
     <para>
-     Log in to the &lcm;.
+     Log in to the &clm;.
     </para>
    </listitem>
    <listitem>

--- a/xml/operations-monitoring-monasca_jira_plugin.xml
+++ b/xml/operations-monitoring-monasca_jira_plugin.xml
@@ -68,7 +68,7 @@
   notification types covered in this guide. Because the Python and YAML files
   for this notification type are not yet included in &product;, you must
   perform the following steps to manually retrieve and place them on your
-  &lcm;.
+  &clm;.
  </para>
  <orderedlist>
   <listitem>

--- a/xml/operations-monitoring-monasca_slack_plugin.xml
+++ b/xml/operations-monitoring-monasca_slack_plugin.xml
@@ -118,7 +118,7 @@
   </listitem>
   <listitem>
    <para>
-    Use the CLI on your &lcm; to create a new Slack notification
+    Use the CLI on your &clm; to create a new Slack notification
     type, using the API call that you created in the preceding step. The
     following example creates a notification type named
     <emphasis role="bold">MySlackNotification</emphasis>, using token

--- a/xml/operations-monitoring-ovs_tuningknobs.xml
+++ b/xml/operations-monitoring-ovs_tuningknobs.xml
@@ -115,7 +115,7 @@
   <orderedlist>
    <listitem>
     <para>
-     Log in to the &lcm;.
+     Log in to the &clm;.
     </para>
    </listitem>
    <listitem>

--- a/xml/operations-networking-vpnaas.xml
+++ b/xml/operations-networking-vpnaas.xml
@@ -83,7 +83,7 @@
   <procedure>
    <step>
     <para>
-     From the &lcm;, create first private network, subnet and
+     From the &clm;, create first private network, subnet and
      router assuming that <emphasis>ext-net</emphasis> is created by admin.
     </para>
 <screen>neutron net-create privateA
@@ -107,7 +107,7 @@ neutron router-gateway-set router2 ext-net</screen>
    <title>Starting Virtual Machines</title>
    <step>
     <para>
-     From the &lcm; run the following to start the virtual
+     From the &clm; run the following to start the virtual
      machines. Begin with adding secgroup rules for SSH and ICMP.
     </para>
 <screen>neutron security-group-rule-create default --protocol icmp
@@ -187,7 +187,7 @@ neutron vpn-ipsecpolicy-create ipsecpolicy</screen>
    </step>
    <step>
     <para>
-     On the &lcm;, run the
+     On the &clm;, run the
      <literal>ipsec-site-connection-list</literal> command to see the active
      connections. Be sure to check that the vpn_services are ACTIVE. You can
      check this by running <literal>vpn-service-list</literal> and then

--- a/xml/operations-networking_alarmdefinitions.xml
+++ b/xml/operations-networking_alarmdefinitions.xml
@@ -92,7 +92,7 @@
       <orderedlist xml:id="ol_fdb_dzg_qv">
        <listitem>
         <para>
-         Log in to the &lcm;.
+         Log in to the &clm;.
         </para>
        </listitem>
        <listitem>
@@ -244,7 +244,7 @@ ansible-playbook -i hosts/verb_hosts neutron-status.yml</screen>
       <orderedlist xml:id="ol_b11_gzp_mx">
        <listitem>
         <para>
-         Log in to the &lcm;.
+         Log in to the &clm;.
         </para>
        </listitem>
        <listitem>
@@ -277,7 +277,7 @@ ansible-playbook -i hosts/verb_hosts designate-start.yml --limit 'DES-ZMG'</scre
       <orderedlist xml:id="ol_c11_gzp_mx">
        <listitem>
         <para>
-         Log in to the &lcm;.
+         Log in to the &clm;.
         </para>
        </listitem>
        <listitem>
@@ -310,7 +310,7 @@ ansible-playbook -i hosts/verb_hosts designate-start.yml --limit 'DES-PMG'</scre
       <orderedlist xml:id="ol_d11_gzp_mx">
        <listitem>
         <para>
-         Log in to the &lcm;.
+         Log in to the &clm;.
         </para>
        </listitem>
        <listitem>
@@ -343,7 +343,7 @@ ansible-playbook -i hosts/verb_hosts designate-start.yml --limit 'DES-CEN'</scre
       <orderedlist xml:id="ol_e11_gzp_mx">
        <listitem>
         <para>
-         Log in to the &lcm;.
+         Log in to the &clm;.
         </para>
        </listitem>
        <listitem>
@@ -376,7 +376,7 @@ ansible-playbook -i hosts/verb_hosts designate-start.yml --limit 'DES-API'</scre
       <orderedlist xml:id="ol_f11_gzp_mx">
        <listitem>
         <para>
-         Log in to the &lcm;.
+         Log in to the &clm;.
         </para>
        </listitem>
        <listitem>
@@ -413,7 +413,7 @@ ansible-playbook -i hosts/verb_hosts designate-start.yml --limit 'DES-MDN'</scre
       <orderedlist xml:id="ol_g11_gzp_mx">
        <listitem>
         <para>
-         Log in to the &lcm;.
+         Log in to the &clm;.
         </para>
        </listitem>
        <listitem>
@@ -462,7 +462,7 @@ ansible-playbook -i hosts/verb_hosts designate-start.yml --limit 'DES-API,DES-CE
       <orderedlist xml:id="ol_h11_gzp_mx">
        <listitem>
         <para>
-         Log in to the &lcm;.
+         Log in to the &clm;.
         </para>
        </listitem>
        <listitem>
@@ -497,7 +497,7 @@ ansible-playbook -i hosts/verb_hosts powerdns-start.yml</screen>
       <orderedlist xml:id="ol_i11_gzp_mx">
        <listitem>
         <para>
-         Log in to the &lcm;.
+         Log in to the &clm;.
         </para>
        </listitem>
        <listitem>

--- a/xml/operations-objectstorage-add_new_storage_policy.xml
+++ b/xml/operations-objectstorage-add_new_storage_policy.xml
@@ -21,7 +21,7 @@
  <orderedlist>
   <listitem>
    <para>
-    Log in to the &lcm;.
+    Log in to the &clm;.
    </para>
   </listitem>
   <listitem>

--- a/xml/operations-objectstorage-input_model_change_existing_rings.xml
+++ b/xml/operations-objectstorage-input_model_change_existing_rings.xml
@@ -22,7 +22,7 @@
   <orderedlist>
    <listitem>
     <para>
-     Log in to the &lcm;.
+     Log in to the &clm;.
     </para>
    </listitem>
    <listitem>

--- a/xml/operations-objectstorage-ring_management.xml
+++ b/xml/operations-objectstorage-ring_management.xml
@@ -28,7 +28,7 @@
    The process of modifying or adding a configuration is similar to other
    configuration or topology changes in the cloud. Generally, you make the
    changes to the input model files at
-   <literal>~/openstack/my_cloud/definition/</literal> on the &lcm; and then
+   <literal>~/openstack/my_cloud/definition/</literal> on the &clm; and then
    run Ansible playbooks to reconfigure the system.
   </para>
  </note>

--- a/xml/operations-objectstorage-swift_cli.xml
+++ b/xml/operations-objectstorage-swift_cli.xml
@@ -10,8 +10,8 @@
 <!---->
  <para>
   The <literal>swift</literal> utility (or Swift CLI) is installed on the
-  &lcm; node and also on all other nodes running the Swift proxy
-  service. To use this utility on the &lcm;, you can use the
+  &clm; node and also on all other nodes running the Swift proxy
+  service. To use this utility on the &clm;, you can use the
   <literal>~/service.osrc</literal> file as a basis and then edit it with the
   credentials of another user if you need to.
  </para>

--- a/xml/operations-objectstorage-swift_container_sync.xml
+++ b/xml/operations-objectstorage-swift_container_sync.xml
@@ -129,7 +129,7 @@
   <orderedlist>
    <listitem>
     <para>
-     On the &lcm; of one system, get the public API endpoint of the
+     On the &clm; of one system, get the public API endpoint of the
      system by running the following commands:
     </para>
 <screen>&prompt.ardana;source ~/service.osrc
@@ -226,7 +226,7 @@ Verify return code: 0 (ok)</screen>
   <orderedlist>
    <listitem>
     <para>
-     Log in to the &lcm;.
+     Log in to the &clm;.
     </para>
    </listitem>
    <listitem>
@@ -396,7 +396,7 @@ Containers in policy "erasure-code-ring": 3
   <orderedlist>
    <listitem>
     <para>
-     On the &lcm; create a file called
+     On the &clm; create a file called
      <literal>~/openstack/change_credentials/swift_data_metadata.yml</literal>
      with the contents included below. The <literal>consuming-cp</literal> and
      <literal>cp</literal> are the control plane name specified in

--- a/xml/operations-objectstorage-swift_min_part_hours.xml
+++ b/xml/operations-objectstorage-swift_min_part_hours.xml
@@ -28,7 +28,7 @@
   <orderedlist>
    <listitem>
     <para>
-     Log in to the &lcm;.
+     Log in to the &clm;.
     </para>
    </listitem>
    <listitem>

--- a/xml/operations-objectstorage-swift_ring_mgmt.xml
+++ b/xml/operations-objectstorage-swift_ring_mgmt.xml
@@ -11,7 +11,7 @@
   The following table describes how playbooks relate to ring management.
  </para>
  <para>
-  All of these playbooks will be run from the &lcm; from the
+  All of these playbooks will be run from the &clm; from the
   <literal>~/scratch/ansible/next/ardana/ansible</literal> directory.
  </para>
  <informaltable colsep="1" rowsep="1">

--- a/xml/operations-objectstorage-swift_weight_attribute.xml
+++ b/xml/operations-objectstorage-swift_weight_attribute.xml
@@ -50,7 +50,7 @@
   <orderedlist>
    <listitem>
     <para>
-     Log in to the &lcm;.
+     Log in to the &clm;.
     </para>
    </listitem>
    <listitem>

--- a/xml/operations-ops-console-connect.xml
+++ b/xml/operations-ops-console-connect.xml
@@ -106,7 +106,7 @@
   <orderedlist>
    <listitem>
     <para>
-     To display the password, log on to the &lcm; and run:
+     To display the password, log on to the &clm; and run:
     </para>
 <screen>cat ~/service.osrc</screen>
    </listitem>
@@ -125,7 +125,7 @@
   <orderedlist>
    <listitem>
     <para>
-     Log in to the &lcm;.
+     Log in to the &clm;.
     </para>
    </listitem>
    <listitem>
@@ -182,7 +182,7 @@
    <listitem>
     <para>
      If your administrator did not set a hostname value, then to determine the
-     IP address to use, from your &lcm;, run:
+     IP address to use, from your &clm;, run:
     </para>
 <screen>grep HZN-WEB /etc/hosts</screen>
     <para>

--- a/xml/operations-ops-console-manage-compute-instances.xml
+++ b/xml/operations-ops-console-manage-compute-instances.xml
@@ -112,7 +112,7 @@ https://VIP:9095</screen>
       <term>Host ID</term>
       <listitem>
        <para>
-        &lcm; model's server ID
+        &clm; model's server ID
        </para>
       </listitem>
      </varlistentry>
@@ -120,7 +120,7 @@ https://VIP:9095</screen>
       <term>Host Role</term>
       <listitem>
        <para>
-        Defined in the &lcm; model and cannot be modified in &opscon;
+        Defined in the &clm; model and cannot be modified in &opscon;
        </para>
       </listitem>
      </varlistentry>
@@ -128,7 +128,7 @@ https://VIP:9095</screen>
       <term>Host Group</term>
       <listitem>
        <para>
-        Defined in the &lcm; model and cannot be modified in &opscon;
+        Defined in the &clm; model and cannot be modified in &opscon;
        </para>
       </listitem>
      </varlistentry>
@@ -136,7 +136,7 @@ https://VIP:9095</screen>
       <term>Host NIC Mapping</term>
       <listitem>
        <para>
-        Defined in the &lcm; model and cannot be modified in &opscon;
+        Defined in the &clm; model and cannot be modified in &opscon;
        </para>
       </listitem>
      </varlistentry>

--- a/xml/operations-orchestration-autoscaling.xml
+++ b/xml/operations-orchestration-autoscaling.xml
@@ -146,7 +146,7 @@ monasca_libvirt_vm_probation: 300</screen>
   <orderedlist>
    <listitem>
     <para>
-     Log in to the &lcm;.
+     Log in to the &clm;.
     </para>
    </listitem>
    <listitem>

--- a/xml/operations-orchestration-configure_orchestration.xml
+++ b/xml/operations-orchestration-configure_orchestration.xml
@@ -39,7 +39,7 @@
  <orderedlist>
   <listitem>
    <para>
-    Log in to the &lcm;.
+    Log in to the &clm;.
    </para>
   </listitem>
   <listitem>
@@ -90,13 +90,13 @@ hidden_stack_tags="&lt;hidden_tag&gt;"</screen>
   To begin using the feature, use these steps to create a Heat stack using the
   defined hidden tag. You will need to use credentials that have the Heat admin
   permissions. In the example steps below we are going to do this from the
-  &lcm; using the <literal>admin</literal> credentials and a Heat
+  &clm; using the <literal>admin</literal> credentials and a Heat
   template named <literal>heat.yaml</literal>:
  </para>
  <orderedlist>
   <listitem>
    <para>
-    Log in to the &lcm;.
+    Log in to the &clm;.
    </para>
   </listitem>
   <listitem>

--- a/xml/operations-other_alarmdefinitions.xml
+++ b/xml/operations-other_alarmdefinitions.xml
@@ -109,7 +109,7 @@
       <orderedlist xml:id="ol_krq_lzp_mx">
        <listitem>
         <para>
-         Log in to the &lcm;.
+         Log in to the &clm;.
         </para>
        </listitem>
        <listitem>
@@ -151,7 +151,7 @@ ansible-playbook -i hosts/verb_hosts FND-CLU-start.yml --limit &lt;hostname&gt;<
       <orderedlist xml:id="ol_mrq_lzp_mx">
        <listitem>
         <para>
-         Log in to the &lcm;.
+         Log in to the &clm;.
         </para>
        </listitem>
        <listitem>
@@ -182,7 +182,7 @@ api_endpoint = public or internal</screen>
       <orderedlist xml:id="ol_nrq_lzp_mx">
        <listitem>
         <para>
-         Log in to the &lcm;.
+         Log in to the &clm;.
         </para>
        </listitem>
        <listitem>
@@ -294,7 +294,7 @@ monitored_host_type = vip</screen>
       <orderedlist xml:id="ol_prq_lzp_mx">
        <listitem>
         <para>
-         Log in to the &lcm;.
+         Log in to the &clm;.
         </para>
        </listitem>
        <listitem>
@@ -320,7 +320,7 @@ ansible-playbook -i hosts/verb_hosts octavia-start.yml --limit &lt;hostname&gt;<
       <orderedlist xml:id="ol_qrq_lzp_mx">
        <listitem>
         <para>
-         Log in to the &lcm;.
+         Log in to the &clm;.
         </para>
        </listitem>
        <listitem>
@@ -393,7 +393,7 @@ ansible-playbook -i hosts/verb_hosts octavia-start.yml --limit &lt;hostname&gt;<
       <orderedlist xml:id="ol_rrq_lzp_mx">
        <listitem>
         <para>
-         Log in to the &lcm;.
+         Log in to the &clm;.
         </para>
        </listitem>
        <listitem>
@@ -452,7 +452,7 @@ ansible-playbook -i hosts/verb_hosts heat-start.yml</screen>
       <orderedlist xml:id="ol_srq_lzp_mx">
        <listitem>
         <para>
-         Log in to the &lcm;.
+         Log in to the &clm;.
         </para>
        </listitem>
        <listitem>

--- a/xml/operations-retrieve_adminpassword.xml
+++ b/xml/operations-retrieve_adminpassword.xml
@@ -20,7 +20,7 @@
   <title>Retrieving the Admin Password</title>
   <para>
    You can retrieve the randomly generated Admin password by using this command
-   on the &lcm;:
+   on the &clm;:
   </para>
 <screen>&prompt.ardana;cat ~/service.osrc</screen>
   <para>

--- a/xml/operations-storage_alarmdefinitions.xml
+++ b/xml/operations-storage_alarmdefinitions.xml
@@ -71,7 +71,7 @@
       <orderedlist xml:id="ol_jbr_2zp_mx">
        <listitem>
         <para>
-         Log in to the &lcm;.
+         Log in to the &clm;.
         </para>
        </listitem>
        <listitem>
@@ -109,7 +109,7 @@ ansible-playbook -i hosts/verb_hosts swift-deploy.yml --limit &lt;hostname&gt;</
       <orderedlist xml:id="ol_kbr_2zp_mx">
        <listitem>
         <para>
-         Log in to the &lcm;.
+         Log in to the &clm;.
         </para>
        </listitem>
        <listitem>
@@ -147,7 +147,7 @@ ansible-playbook -i hosts/verb_hosts swift-deploy.yml --limit &lt;hostname&gt;</
       <orderedlist xml:id="ol_lbr_2zp_mx">
        <listitem>
         <para>
-         Log in to the &lcm;.
+         Log in to the &clm;.
         </para>
        </listitem>
        <listitem>
@@ -224,7 +224,7 @@ ansible-playbook -i hosts/verb_hosts swift-deploy.yml --limit &lt;hostname&gt;</
       <orderedlist xml:id="ol_mbr_2zp_mx">
        <listitem>
         <para>
-         Log in to the &lcm;.
+         Log in to the &clm;.
         </para>
        </listitem>
        <listitem>
@@ -262,7 +262,7 @@ ansible-playbook -i hosts/verb_hosts _swift-configure.yml --limit &lt;hostname&g
       <orderedlist xml:id="ol_nbr_2zp_mx">
        <listitem>
         <para>
-         Log in to the &lcm;.
+         Log in to the &clm;.
         </para>
        </listitem>
        <listitem>
@@ -316,7 +316,7 @@ ansible-playbook -i hosts/verb_hosts swift-start.yml --limit &lt;hostname&gt;</s
       <orderedlist xml:id="ol_obr_2zp_mx">
        <listitem>
         <para>
-         Log in to the &lcm;.
+         Log in to the &clm;.
         </para>
        </listitem>
        <listitem>
@@ -346,7 +346,7 @@ ansible-playbook -i hosts/verb_hosts keystone-start.yml</screen>
       <orderedlist xml:id="ol_pbr_2zp_mx">
        <listitem>
         <para>
-         Log in to the &lcm;.
+         Log in to the &clm;.
         </para>
        </listitem>
        <listitem>
@@ -409,7 +409,7 @@ ansible-playbook -i hosts/verb_hosts swift-status.yml --limit SWF-PRX[0]</screen
       <orderedlist xml:id="ol_l4w_tys_lx">
        <listitem>
         <para>
-         Log in to the &lcm;.
+         Log in to the &clm;.
         </para>
        </listitem>
        <listitem>
@@ -427,7 +427,7 @@ ansible-playbook -i hosts/verb_hosts swift-status.yml --limit &lt;hostname&gt;</
       <orderedlist xml:id="ol_rbr_2zp_mx">
        <listitem>
         <para>
-         Log in to the &lcm;.
+         Log in to the &clm;.
         </para>
        </listitem>
        <listitem>
@@ -477,7 +477,7 @@ ansible-playbook -i hosts/verb_hosts swift-start.yml --limit &lt;hostname&gt;</s
       <orderedlist xml:id="ol_sbr_2zp_mx">
        <listitem>
         <para>
-         Log in to the &lcm;.
+         Log in to the &clm;.
         </para>
        </listitem>
        <listitem>
@@ -507,7 +507,7 @@ ansible-playbook -i hosts/verb_hosts swift-reconfigure.yml</screen>
       <orderedlist xml:id="ol_tbr_2zp_mx">
        <listitem>
         <para>
-         Log in to the &lcm;.
+         Log in to the &clm;.
         </para>
        </listitem>
        <listitem>
@@ -548,7 +548,7 @@ ansible-playbook -i hosts/verb_hosts memcached-start.yml --limit &lt;hostname&gt
       <orderedlist xml:id="ol_ubr_2zp_mx">
        <listitem>
         <para>
-         Log in to the &lcm;.
+         Log in to the &clm;.
         </para>
        </listitem>
        <listitem>
@@ -576,7 +576,7 @@ ansible-playbook -i hosts/verb_hosts swift-status.yml</screen>
       <orderedlist xml:id="ol_vbr_2zp_mx">
        <listitem>
         <para>
-         Log in to the &lcm;.
+         Log in to the &clm;.
         </para>
        </listitem>
        <listitem>
@@ -598,7 +598,7 @@ ansible-playbook -i hosts/verb_hosts swift-status.yml</screen>
       <orderedlist xml:id="ol_wbr_2zp_mx">
        <listitem>
         <para>
-         Log in to the &lcm;.
+         Log in to the &clm;.
         </para>
        </listitem>
        <listitem>
@@ -669,7 +669,7 @@ ansible-playbook -i hosts/verb_hosts swift-start.yml --limit &lt;hostname&gt;</s
       <orderedlist xml:id="ol_xbr_2zp_mx">
        <listitem>
         <para>
-         Log in to the &lcm;.
+         Log in to the &clm;.
         </para>
        </listitem>
        <listitem>
@@ -891,7 +891,7 @@ ansible-playbook -i hosts/verb_hosts swift-reconfigure.yml</screen>
       <orderedlist xml:id="ol_yhz_rpk_pw">
        <listitem>
         <para>
-         Log in to the &lcm;.
+         Log in to the &clm;.
         </para>
        </listitem>
        <listitem>
@@ -940,7 +940,7 @@ ansible-playbook -i hosts/verb_hosts cinder-start.yml --limit &lt;hostname&gt;</
       <orderedlist xml:id="ol_zbr_2zp_mx">
        <listitem>
         <para>
-         Log in to the &lcm;.
+         Log in to the &clm;.
         </para>
        </listitem>
        <listitem>
@@ -998,7 +998,7 @@ ansible-playbook -i hosts/verb_hosts cinder-start.yml --limit &lt;hostname&gt;</
       <orderedlist xml:id="ol_ztz_mpk_pw">
        <listitem>
         <para>
-         Log in to the &lcm;.
+         Log in to the &clm;.
         </para>
        </listitem>
        <listitem>
@@ -1039,7 +1039,7 @@ ansible-playbook -i hosts/verb_hosts cinder-migrate-volume.yml</screen>
       <orderedlist xml:id="ol_kgy_4pk_pw">
        <listitem>
         <para>
-         Log in to the &lcm;.
+         Log in to the &clm;.
         </para>
        </listitem>
        <listitem>
@@ -1145,7 +1145,7 @@ ansible-playbook -i hosts/verb_hosts cinder-migrate-volume.yml</screen>
       <orderedlist xml:id="ol_gcr_2zp_mx">
        <listitem>
         <para>
-         Log in to the &lcm;.
+         Log in to the &clm;.
         </para>
        </listitem>
        <listitem>

--- a/xml/operations-telemetry_alarmdefinitions.xml
+++ b/xml/operations-telemetry_alarmdefinitions.xml
@@ -48,7 +48,7 @@
       <orderedlist>
        <listitem>
         <para>
-         Log in to the &lcm;.
+         Log in to the &clm;.
         </para>
        </listitem>
        <listitem>
@@ -82,7 +82,7 @@
       <orderedlist>
        <listitem>
         <para>
-         Log in to the &lcm;.
+         Log in to the &clm;.
         </para>
        </listitem>
        <listitem>
@@ -111,7 +111,7 @@
       <orderedlist>
        <listitem>
         <para>
-         Log in to the &lcm;.
+         Log in to the &clm;.
         </para>
        </listitem>
        <listitem>
@@ -141,7 +141,7 @@
       <orderedlist xml:id="ol_a53_gct_lx">
        <listitem>
         <para>
-         Log in to the &lcm;.
+         Log in to the &clm;.
         </para>
        </listitem>
        <listitem>
@@ -186,7 +186,7 @@
       <orderedlist>
        <listitem>
         <para>
-         Log in to the &lcm;.
+         Log in to the &clm;.
         </para>
        </listitem>
        <listitem>
@@ -219,7 +219,7 @@
       <orderedlist>
        <listitem>
         <para>
-         Log in to the &lcm;.
+         Log in to the &clm;.
         </para>
        </listitem>
        <listitem>
@@ -282,7 +282,7 @@
       <orderedlist xml:id="ol_z3p_2ff_wv">
        <listitem>
         <para>
-         Log in to the &lcm;
+         Log in to the &clm;
         </para>
        </listitem>
        <listitem>
@@ -374,7 +374,7 @@ ansible-playbook -i hosts/verb_hosts monasca-status.yml --tags monasca-persister
       <orderedlist xml:id="ol_lrq_lzp_mx">
        <listitem>
         <para>
-         Log in to the &lcm;.
+         Log in to the &clm;.
         </para>
        </listitem>
        <listitem>
@@ -450,7 +450,7 @@ ansible-playbook -i hosts/verb_hosts monasca-status.yml --tags kafka</screen>
      <entry>
       <para>
        To find the unassigned shards, run the following command on the
-       &lcm; from the
+       &clm; from the
        <literal>~/scratch/ansible/next/ardana/ansible</literal> directory:
       </para>
 <screen>cd ~/scratch/ansible/next/ardana/ansible
@@ -532,7 +532,7 @@ ansible -i hosts/verb_hosts LOG-SVR -m shell -a "curl localhost:9200/_nodes/_loc
       <orderedlist xml:id="ol_ccg_3zp_mx">
        <listitem>
         <para>
-         Log in to the &lcm;.
+         Log in to the &clm;.
         </para>
        </listitem>
        <listitem>
@@ -737,7 +737,7 @@ sudo systemctl restart kibana</screen>
       <orderedlist xml:id="ol_ecg_3zp_mx">
        <listitem>
         <para>
-         Log in to the &lcm;.
+         Log in to the &clm;.
         </para>
        </listitem>
        <listitem>
@@ -789,7 +789,7 @@ ansible-playbook -i hosts/verb_hosts monasca-status.yml --tags monasca-persister
       <orderedlist>
        <listitem>
         <para>
-         Log in to the &lcm;.
+         Log in to the &clm;.
         </para>
        </listitem>
        <listitem>
@@ -837,7 +837,7 @@ ansible-playbook -i hosts/verb_hosts monasca-status.yml --tags monasca-api</scre
       <orderedlist xml:id="ol_gcg_3zp_mx">
        <listitem>
         <para>
-         Log in to the &lcm;.
+         Log in to the &clm;.
         </para>
        </listitem>
        <listitem>
@@ -885,7 +885,7 @@ ansible-playbook -i hosts/verb_hosts monasca-agent-status.yml</screen>
       <orderedlist>
        <listitem>
         <para>
-         Log in to the &lcm;.
+         Log in to the &clm;.
         </para>
        </listitem>
        <listitem>
@@ -932,7 +932,7 @@ ansible-playbook -i hosts/verb_hosts monasca-status.yml --tags kafka</screen>
       <orderedlist>
        <listitem>
         <para>
-         Log in to the &lcm;.
+         Log in to the &clm;.
         </para>
        </listitem>
        <listitem>
@@ -980,7 +980,7 @@ ansible-playbook -i hosts/verb_hosts monasca-status.yml --tags notification</scr
       <orderedlist>
        <listitem>
         <para>
-         Log in to the &lcm;.
+         Log in to the &clm;.
         </para>
        </listitem>
        <listitem>
@@ -1028,7 +1028,7 @@ ansible-playbook -i hosts/verb_hosts monasca-agent-status.yml</screen>
       <orderedlist>
        <listitem>
         <para>
-         Log in to the &lcm;.
+         Log in to the &clm;.
         </para>
        </listitem>
        <listitem>
@@ -1076,7 +1076,7 @@ ansible-playbook -i hosts/verb_hosts monasca-status.yml --tags monasca-api</scre
       <orderedlist>
        <listitem>
         <para>
-         Log in to the &lcm;.
+         Log in to the &clm;.
         </para>
        </listitem>
        <listitem>
@@ -1135,7 +1135,7 @@ component = apache-storm</screen>
       <orderedlist>
        <listitem>
         <para>
-         Log in to the &lcm;.
+         Log in to the &clm;.
         </para>
        </listitem>
        <listitem>
@@ -1191,7 +1191,7 @@ component = apache-storm</screen>
       <orderedlist>
        <listitem>
         <para>
-         Log in to the &lcm;.
+         Log in to the &clm;.
         </para>
        </listitem>
        <listitem>
@@ -1245,7 +1245,7 @@ component = apache-storm</screen>
       <orderedlist>
        <listitem>
         <para>
-         Log in to the &lcm;.
+         Log in to the &clm;.
         </para>
        </listitem>
        <listitem>
@@ -1289,7 +1289,7 @@ component = apache-storm</screen>
       <orderedlist>
        <listitem>
         <para>
-         Log in to the &lcm;.
+         Log in to the &clm;.
         </para>
        </listitem>
        <listitem>

--- a/xml/operations-troubleshooting-objectstorage-examine_details_planned_ring_changes_prior_deploy.xml
+++ b/xml/operations-troubleshooting-objectstorage-examine_details_planned_ring_changes_prior_deploy.xml
@@ -14,7 +14,7 @@
  <procedure>
   <step>
    <para>
-    Log in to the &lcm;.
+    Log in to the &clm;.
    </para>
   </step>
   <step>

--- a/xml/operations-troubleshooting-objectstorage-filesystem_usage_nowipe.xml
+++ b/xml/operations-troubleshooting-objectstorage-filesystem_usage_nowipe.xml
@@ -60,7 +60,7 @@ sudo systemctl stop swift-object-replicator</screen>
    <substeps>
     <step>
      <para>
-      Log in to the &lcm;.
+      Log in to the &clm;.
      </para>
     </step>
     <step>

--- a/xml/operations-troubleshooting-objectstorage-identify_ring_builder.xml
+++ b/xml/operations-troubleshooting-objectstorage-identify_ring_builder.xml
@@ -16,7 +16,7 @@
   <procedure>
    <step>
     <para>
-     Log in to the &lcm;.
+     Log in to the &clm;.
     </para>
    </step>
    <step>

--- a/xml/operations-troubleshooting-objectstorage-increase_timeout.xml
+++ b/xml/operations-troubleshooting-objectstorage-increase_timeout.xml
@@ -34,7 +34,7 @@
  <procedure>
   <step>
    <para>
-    Log in to the &lcm;.
+    Log in to the &clm;.
    </para>
   </step>
   <step>

--- a/xml/operations-troubleshooting-objectstorage-recovering_builder_file.xml
+++ b/xml/operations-troubleshooting-objectstorage-recovering_builder_file.xml
@@ -91,7 +91,7 @@
   </step>
   <step>
    <para>
-    Log in to the &lcm;.
+    Log in to the &clm;.
    </para>
   </step>
   <step>

--- a/xml/operations-troubleshooting-recover_rabbit.xml
+++ b/xml/operations-troubleshooting-recover_rabbit.xml
@@ -75,7 +75,7 @@
    using a mid-scale model or have a dedicated cluster that &rabbit; lives on
    you may need to alter the steps accordingly. To determine which nodes
    &rabbit; is on you can use the <filename>rabbit-status.yml</filename> playbook
-   from your &lcm;.
+   from your &clm;.
   </para>
 <screen>&prompt.ardana;cd ~/scratch/ansible/next/ardana/ansible
 &prompt.ardana;ansible-playbook -i hosts/verb_hosts rabbitmq-status.yml</screen>
@@ -130,7 +130,7 @@
    First step here is to determine whether the controller that went down is the
    primary &rabbit; host or not. The primary host is going to be the first host
    member in the <literal>FND-RMQ</literal> group in the file below on your
-   &lcm;:
+   &clm;:
   </para>
 <screen>&prompt.ardana;~/scratch/ansible/next/ardana/ansible/hosts/verb_hosts</screen>
   <para>
@@ -177,7 +177,7 @@ ardana-cp1-c1-m3-mgmt</screen>
   <procedure>
    <step>
     <para>
-     Log into the &lcm;.
+     Log into the &clm;.
     </para>
    </step>
    <step>
@@ -265,7 +265,7 @@ rabbit@cloud-cp1-rmq-mysql-m3-mgmt</screen>
    </step>
    <step>
     <para>
-     On the &lcm;, run the <filename>ardana-start.yml</filename> playbook.
+     On the &clm;, run the <filename>ardana-start.yml</filename> playbook.
     </para>
    </step>
   </procedure>
@@ -320,7 +320,7 @@ rabbit@cloud-cp1-rmq-mysql-m3-mgmt</screen>
   <procedure>
    <step>
     <para>
-     Log in to the &lcm;.
+     Log in to the &clm;.
     </para>
    </step>
    <step>
@@ -375,7 +375,7 @@ ardana-cp1-c1-m3-mgmt  : ok=2    changed=0    unreachable=0    failed=0</screen>
   <procedure>
    <step>
     <para>
-     Log in to your &lcm;.
+     Log in to your &clm;.
     </para>
    </step>
    <step>
@@ -418,7 +418,7 @@ ardana-cp1-c1-m3-mgmt  : ok=2    changed=0    unreachable=0    failed=0</screen>
   </para>
   <para>
    If your primary &rabbit; controller node has gone down and you need to
-   perform a disaster recovery, use this playbook from your &lcm;:
+   perform a disaster recovery, use this playbook from your &clm;:
   </para>
 <screen>&prompt.ardana;cd ~/scratch/ansible/next/ardana/ansible
 &prompt.ardana;ansible-playbook -i hosts/verb_hosts rabbitmq-disaster-recovery.yml -e rabbit_primary_hostname=&lt;new_primary_hostname&gt; --limit &lt;hostname_of_node_that_needs_recovered&gt;</screen>

--- a/xml/operations-troubleshooting-troubleshooting_sosreport.xml
+++ b/xml/operations-troubleshooting-troubleshooting_sosreport.xml
@@ -20,7 +20,7 @@
   <procedure>
    <step>
     <para>
-     Log in to the &lcm;.
+     Log in to the &clm;.
     </para>
    </step>
    <step>
@@ -33,7 +33,7 @@ ansible-playbook -i hosts/verb_hosts sosreport-run.yml</screen>
    <step>
     <para>
      Retrieve the SOS report tarballs, which will be in the following
-     directories on your &lcm;:
+     directories on your &clm;:
     </para>
 <screen>/tmp
 /tmp/sosreport-report-archives/</screen>

--- a/xml/operations-troubleshooting-ts_blockstorage.xml
+++ b/xml/operations-troubleshooting-ts_blockstorage.xml
@@ -62,7 +62,7 @@
   </informalfigure>
   <para>
    You can refer to your configuration files (usually located in
-   <literal>~/openstack/my_cloud/definition/</literal> on the &lcm;) for
+   <literal>~/openstack/my_cloud/definition/</literal> on the &clm;) for
    specifics about where your services are located. They will usually be
    located on the controller nodes.
   </para>
@@ -260,14 +260,14 @@
    <step>
     <para>
      Check if the &o_blockstore; API service is active by listing the available volumes
-     from the &lcm;:
+     from the &clm;:
     </para>
 <screen>source ~/service.osrc
 openstack volume list</screen>
    </step>
    <step>
     <para>
-     Run a basic diagnostic from the &lcm;:
+     Run a basic diagnostic from the &clm;:
     </para>
 <screen>cd ~/scratch/ansible/next/ardana/ansible
 ansible-playbook -i hosts/verb_hosts _cinder_post_check.yml</screen>

--- a/xml/operations-troubleshooting-ts_compute.xml
+++ b/xml/operations-troubleshooting-ts_compute.xml
@@ -131,7 +131,7 @@
   <procedure>
    <step>
     <para>
-     Log in to the &lcm;.
+     Log in to the &clm;.
     </para>
    </step>
    <step>

--- a/xml/operations-troubleshooting-ts_image.xml
+++ b/xml/operations-troubleshooting-ts_image.xml
@@ -35,7 +35,7 @@
   <procedure>
    <step>
     <para>
-     Log in to the &lcm;.
+     Log in to the &clm;.
     </para>
    </step>
    <step>

--- a/xml/operations-tutorials-installing_cli.xml
+++ b/xml/operations-tutorials-installing_cli.xml
@@ -11,7 +11,7 @@
  <title>Installing the Command-Line Clients</title>
  <para>
   During the installation, by default, the suite of OpenStack command-line
-  tools are installed on the &lcm; and the control plane in your
+  tools are installed on the &clm; and the control plane in your
   environment. This includes the OpenStack Command-Line Interface as well as
   the clients for the individual services such as the NovaClient, CinderClient,
   and SwiftClient. You can learn more about these in the OpenStack
@@ -34,7 +34,7 @@
   <procedure>
    <step>
     <para>
-     Log in to the &lcm;.
+     Log in to the &clm;.
     </para>
    </step>
    <step>
@@ -125,7 +125,7 @@ git commit -m "My config or other commit message"</screen>
   <orderedlist>
    <listitem>
     <para>
-     Log in to the &lcm;.
+     Log in to the &clm;.
     </para>
    </listitem>
    <listitem>

--- a/xml/operations-tutorials-manage_logs.xml
+++ b/xml/operations-tutorials-manage_logs.xml
@@ -132,7 +132,7 @@
   <orderedlist xml:id="ol_mtz_mnr_bx">
    <listitem>
     <para>
-     Begin by logging in to the &lcm;.
+     Begin by logging in to the &clm;.
     </para>
    </listitem>
    <listitem>

--- a/xml/operations-tutorials-quickstart_guide.xml
+++ b/xml/operations-tutorials-quickstart_guide.xml
@@ -76,13 +76,13 @@
  <section xml:id="section_v5g_dvv_xw">
   <title>Getting Started</title>
   <para>
-   When your network infrastructure is in place, go ahead and set up the &lcm;.
+   When your network infrastructure is in place, go ahead and set up the &clm;.
    This is the server that will orchestrate the deployment of the rest of your
    cloud. It is also the server you will run most of your deployment and
    management commands on.
   </para>
   <para>
-   <emphasis role="bold">Set up the &lcm;</emphasis>
+   <emphasis role="bold">Set up the &clm;</emphasis>
   </para>
   <procedure>
    <step>
@@ -151,12 +151,12 @@
     </substeps>
     <para>
      You now have a server running SUSE Linux Enterprise Server (&slsa;).
-     The next step is to configure this machine as a &lcm;.
+     The next step is to configure this machine as a &clm;.
     </para>
    </step>
    <step>
     <para>
-     <emphasis role="bold">Configure the &lcm;</emphasis>
+     <emphasis role="bold">Configure the &clm;</emphasis>
     </para>
     <para>
      The installation media you used to install the OS on the server also has
@@ -188,7 +188,7 @@
      <step>
       <para>
        Now you will install and configure all the components needed to turn this
-       server into a &lcm;. Run the <filename>ardana-init.bash</filename>
+       server into a &clm;. Run the <filename>ardana-init.bash</filename>
        script from the uncompressed tar file:
       </para>
 <screen>~/ardana-x.x.x/ardana-init.bash</screen>
@@ -223,7 +223,7 @@
      the storage backends for your cloud.
     </para>
     <para>
-     There are several example configurations, which you can find on your &lcm;
+     There are several example configurations, which you can find on your &clm;
      in the <filename>~/openstack/examples/</filename> directory.
     </para>
     <substeps>
@@ -360,7 +360,7 @@ git commit -m "My commit message"</screen>
     <substeps>
      <step>
       <para>
-       Prepare the &lcm; to deploy your cloud configuration to all the nodes:
+       Prepare the &clm; to deploy your cloud configuration to all the nodes:
       </para>
 <screen>ansible-playbook -i hosts/localhost ready-deployment.yml</screen>
       <para>
@@ -426,12 +426,12 @@ ansible-playbook -i hosts/verb_hosts site.yml</screen>
      nodes by viewing the <filename>/etc/hosts</filename> file.
     </para>
     <para>
-     For security reasons, you can only SSH to your nodes from the &lcm;. SSH
-     connections from any machine other than the &lcm; will be refused by the
+     For security reasons, you can only SSH to your nodes from the &clm;. SSH
+     connections from any machine other than the &clm; will be refused by the
      nodes.
     </para>
     <para>
-     From the &lcm;, SSH to your nodes:
+     From the &clm;, SSH to your nodes:
     </para>
 <screen>ssh &lt;management IP address of node&gt;</screen>
     <para>

--- a/xml/operations-tutorials-using_cli.xml
+++ b/xml/operations-tutorials-using_cli.xml
@@ -26,7 +26,7 @@
   <para>
    &o_ident; identity service query and administration tasks can be performed
    using the &ostack; command line utility. The utility is installed by the
-   &lcm; onto the &lcm;.
+   &clm; onto the &clm;.
   </para>
   <note>
    <para>
@@ -62,7 +62,7 @@
    <emphasis role="bold">List users in the default domain</emphasis>
   </para>
   <para>
-   These users are created by the &lcm; in the MySQL back end:
+   These users are created by the &clm; in the MySQL back end:
   </para>
 <screen>openstack user list</screen>
   <para>
@@ -534,12 +534,12 @@ export OS_CACERT=/etc/ssl/certs/ca-certificates.crt</screen>
 cinder_admin</screen>
  </section>
  <section xml:id="customize.policy">
-  <title>Customize policy.json on the &lcm;</title>
+  <title>Customize policy.json on the &clm;</title>
   <para>
    One way to deploy <filename>policy.json</filename> for a service is by going to each of the
    target nodes and making changes there. This is not necessary anymore. This
    process has been streamlined and policy.json files can be edited on the
-   &lcm; and then deployed to nodes. Please exercise caution when modifying
+   &clm; and then deployed to nodes. Please exercise caution when modifying
    policy.json files. It is best to validate the changes in a non-production
    environment before rolling out policy.json changes into production. It is
    not recommended that you make policy.json changes without a way to validate
@@ -574,14 +574,14 @@ cinder_admin</screen>
   </para>
   <para>
    Service policy files can be modified and deployed to control nodes from the
-   &lcm;. Administrators are advised to validate policy changes before checking
+   &clm;. Administrators are advised to validate policy changes before checking
    in the changes to the site branch of the local git repository before rolling
    the changes into production. Do not make changes to policy files without
    having a way to validate them.
   </para>
   <para>
    The policy files are located at the following site branch directory on the
-   &lcm;.
+   &clm;.
   </para>
 <screen>~/openstack/ardana/ansible/roles/</screen>
   <para>

--- a/xml/operations-understanding_identity.xml
+++ b/xml/operations-understanding_identity.xml
@@ -271,7 +271,7 @@
    [SERVICE_CODENAME] represents a specific OpenStack service name. For
    example, the OpenStack Nova service would have a policy file called
    /etc/nova/policy.json. With Service policy files can be modified and
-   deployed to control nodes from the &lcm;. Administrators are
+   deployed to control nodes from the &clm;. Administrators are
    advised to validate policy changes before checking in the changes to the
    site branch of the local git repository before rolling the changes into
    production. Do not make changes to policy files without having a way to
@@ -279,7 +279,7 @@
   </para>
   <para>
    The policy files are located at the following site branch locations on the
-   &lcm;.
+   &clm;.
   </para>
 <screen>~/openstack/ardana/ansible/roles/GLA-API/templates/policy.json.j2
 ~/openstack/ardana/ansible/roles/ironic-common/files/policy.json

--- a/xml/planning-architecture-alternative-alternative_configurations.xml
+++ b/xml/planning-architecture-alternative-alternative_configurations.xml
@@ -19,7 +19,7 @@
 with One Network</xref></li>
 <li><xref keyref="entryscale_kvm_ceph_twonetwork">Entry-scale KVM with Ceph Model
 with Two Networks</xref></li>
-<li><xref keyref="standalone_deployer">Using a Standalone &lcm;
+<li><xref keyref="standalone_deployer">Using a Standalone &clm;
 Node</xref>
 </li>
 <li><xref keyref="without_dvr">Configuring <keyword keyref="kw-hos"/> without

--- a/xml/planning-architecture-alternative-standalone_deployer.xml
+++ b/xml/planning-architecture-alternative-standalone_deployer.xml
@@ -4,11 +4,11 @@
 ]>
 <section xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude"
   xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="standalone_deployer" version="5.1">
- <title>Using a Dedicated &lcm; Node</title>
+ <title>Using a Dedicated &clm; Node</title>
  <para>
-  All of the example configurations included host the &lcm; on the first
+  All of the example configurations included host the &clm; on the first
   &contrnode;. It is also possible to deploy this service on a dedicated
-  node. One use case for wanting to run the dedicated &lcm; is to be able to
+  node. One use case for wanting to run the dedicated &clm; is to be able to
   test the deployment of different configurations without having to re-install
   the first server. Some administrators prefer the additional security of
   keeping all of the configuration data on a separate server from those that
@@ -29,52 +29,52 @@
   </mediaobject>
  </informalfigure>
  <section xml:id="sec.specify-lifecycle-manager">
-  <title>Specifying a dedicated &lcm; in your input model</title>
+  <title>Specifying a dedicated &clm; in your input model</title>
   <para>
-   To specify a dedicated &lcm; in your input model, make the following edits
+   To specify a dedicated &clm; in your input model, make the following edits
    to your configuration files.
   </para>
   <important>
    <para>
     The indentation of each of the input files is important and will cause
     errors if not done correctly. Use the existing content in each of these
-    files as a reference when adding additional content for your &lcm;.
+    files as a reference when adding additional content for your &clm;.
    </para>
   </important>
   <itemizedlist>
    <listitem>
     <para>
-     Update <filename>control_plane.yml</filename> to add the &lcm;.
+     Update <filename>control_plane.yml</filename> to add the &clm;.
     </para>
    </listitem>
    <listitem>
     <para>
-     Update <filename>server_roles.yml</filename> to add the &lcm; role.
+     Update <filename>server_roles.yml</filename> to add the &clm; role.
     </para>
    </listitem>
    <listitem>
     <para>
      Update <filename>net_interfaces.yml</filename> to add the interface
-     definition for the &lcm;.
+     definition for the &clm;.
     </para>
    </listitem>
    <listitem>
     <para>
      Create a <filename>disks_lifecycle_manager.yml</filename> file to define
-     the disk layout for the &lcm;.
+     the disk layout for the &clm;.
     </para>
    </listitem>
    <listitem>
     <para>
-     Update <filename>servers.yml</filename> to add the dedicated &lcm; node.
+     Update <filename>servers.yml</filename> to add the dedicated &clm; node.
     </para>
    </listitem>
   </itemizedlist>
   <para>
    <filename>Control_plane.yml</filename>: The snippet below shows the addition
-   of a single node cluster into the control plane to host the &lcm; service.
+   of a single node cluster into the control plane to host the &clm; service.
    Note that, in addition to adding the new cluster, you also have to remove
-   the &lcm; component from the <literal>cluster1</literal> in the examples:
+   the &clm; component from the <literal>cluster1</literal> in the examples:
   </para>
 <screen>  clusters:
 <emphasis role="bold">     - name: cluster0
@@ -94,7 +94,7 @@
          - ntp-server</screen>
   <para>
    This specifies a single node of role
-   <literal>LIFECYCLE-MANAGER-ROLE</literal> hosting the &lcm;.
+   <literal>LIFECYCLE-MANAGER-ROLE</literal> hosting the &clm;.
   </para>
   <para>
    <filename>Server_roles.yml</filename>: The snippet below shows the insertion
@@ -150,7 +150,7 @@
 
    disk-models:
 <emphasis role="bold">   - name: LIFECYCLE-MANAGER-DISKS
-     # Disk model to be used for &lcm;s nodes
+     # Disk model to be used for &clm;s nodes
      # /dev/sda_root is used as a volume group for /, /var/log and /var/crash
      # sda_root is a templated value to align with whatever partition is really used
      # This value is checked in os config and replaced by the partition actually used
@@ -177,7 +177,7 @@
               name: os</emphasis></screen>
   <para>
    <filename>Servers.yml</filename>: The snippet below shows the insertion of an
-   additional server used for hosting the &lcm;. Provide the address
+   additional server used for hosting the &clm;. Provide the address
    information here for the server you are running on, that is, the node where
    you have installed the &productname; ISO.
   </para>

--- a/xml/planning-architecture-alternative-twosystems.xml
+++ b/xml/planning-architecture-alternative-twosystems.xml
@@ -48,7 +48,7 @@ Dec 16 15:43:43 ardana-cp1-c1-m1-mgmt Keepalived_vrrp[2218]: VRRP_Instance(VI_2)
  <procedure>
   <step>
    <para>
-    Log in to your &lcm;.
+    Log in to your &clm;.
    </para>
   </step>
   <step>

--- a/xml/planning-architecture-alternative-without_dvr.xml
+++ b/xml/planning-architecture-alternative-without_dvr.xml
@@ -12,7 +12,7 @@
   achieve this.
  </para>
  <para>
-  On your &lcm;, make the following changes:
+  On your &clm;, make the following changes:
  </para>
  <procedure>
   <step>

--- a/xml/planning-architecture-alternative-without_l3agent.xml
+++ b/xml/planning-architecture-alternative-without_l3agent.xml
@@ -10,7 +10,7 @@
   routers only, here are the steps to achieve this.
  </para>
  <para>
-  On your &lcm;, make the following changes:
+  On your &clm;, make the following changes:
  </para>
  <procedure>
   <step>

--- a/xml/planning-architecture-architecture_index.xml
+++ b/xml/planning-architecture-architecture_index.xml
@@ -4,7 +4,7 @@
 ]>
 <part xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude"
  xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="architecture" version="5.1">
- <title>&lcm; Overview</title>
+ <title>&clm; Overview</title>
  <info>
   <abstract>
    <para>

--- a/xml/planning-architecture-examples-entry-scale-kvm-esx-mml.xml
+++ b/xml/planning-architecture-examples-entry-scale-kvm-esx-mml.xml
@@ -42,12 +42,12 @@
    </listitem>
   </varlistentry>
   <varlistentry>
-   <term>&lcm;</term>
+   <term>&clm;</term>
    <listitem>
     <para>
-     The &lcm; runs on one of the control-plane nodes of type
+     The &clm; runs on one of the control-plane nodes of type
      <literal>CONTROLLER-ROLE</literal>. The IP address of the node that will
-     run the &lcm; needs to be included in the
+     run the &clm; needs to be included in the
      <filename>data/servers.yml</filename> file.
     </para>
    </listitem>

--- a/xml/planning-architecture-examples-entry-scale-kvm-esx.xml
+++ b/xml/planning-architecture-examples-entry-scale-kvm-esx.xml
@@ -21,12 +21,12 @@
    </listitem>
   </varlistentry>
   <varlistentry>
-   <term>&lcm;</term>
+   <term>&clm;</term>
    <listitem>
     <para>
-     The &lcm; runs on one of the control-plane nodes of type
+     The &clm; runs on one of the control-plane nodes of type
      <literal>CONTROLLER-ROLE</literal>. The IP address of the node that will
-     run the &lcm; needs to be included in the
+     run the &clm; needs to be included in the
      <filename>data/servers.yml</filename> file.
     </para>
    </listitem>

--- a/xml/planning-architecture-examples-entry-scale-kvm-mml.xml
+++ b/xml/planning-architecture-examples-entry-scale-kvm-mml.xml
@@ -42,12 +42,12 @@
    </listitem>
   </varlistentry>
   <varlistentry>
-   <term>&lcm;</term>
+   <term>&clm;</term>
    <listitem>
     <para>
-     The &lcm; runs on one of the control-plane nodes of type
+     The &clm; runs on one of the control-plane nodes of type
      <literal>CONTROLLER-ROLE</literal>. The IP address of the node that will
-     run the &lcm; needs to be included in the
+     run the &clm; needs to be included in the
      <filename>data/servers.yml</filename>file.
     </para>
    </listitem>

--- a/xml/planning-architecture-examples-entry-scale-kvm.xml
+++ b/xml/planning-architecture-examples-entry-scale-kvm.xml
@@ -21,12 +21,12 @@
    </listitem>
   </varlistentry>
   <varlistentry>
-   <term>&lcm;</term>
+   <term>&clm;</term>
    <listitem>
     <para>
-     The &lcm; runs on one of the control-plane nodes of type
+     The &clm; runs on one of the control-plane nodes of type
      <literal>CONTROLLER-ROLE</literal>. The IP address of the node that will
-     run the &lcm; needs to be included in the
+     run the &clm; needs to be included in the
      <filename>data/servers.yml</filename> file.
     </para>
    </listitem>

--- a/xml/planning-architecture-examples-entryscale_ironic.xml
+++ b/xml/planning-architecture-examples-entryscale_ironic.xml
@@ -32,12 +32,12 @@
    </listitem>
   </varlistentry>
   <varlistentry>
-   <term>&lcm;</term>
+   <term>&clm;</term>
    <listitem>
     <para>
-     The &lcm; runs on one of the control-plane nodes of type
+     The &clm; runs on one of the control-plane nodes of type
      <literal>CONTROLLER-ROLE</literal>. The IP address of the node that will
-     run the &lcm; needs to be included in the
+     run the &clm; needs to be included in the
      <filename>data/servers.yml</filename> file.
     </para>
    </listitem>

--- a/xml/planning-architecture-examples-entryscale_ironic_multi_tenancy.xml
+++ b/xml/planning-architecture-examples-entryscale_ironic_multi_tenancy.xml
@@ -34,12 +34,12 @@
    </listitem>
   </varlistentry>
   <varlistentry>
-   <term>&lcm;</term>
+   <term>&clm;</term>
    <listitem>
     <para>
-     The &lcm; runs on one of the control-plane nodes of type
+     The &clm; runs on one of the control-plane nodes of type
      <literal>CONTROLLER-ROLE</literal>. The IP address of the node that will
-     run the &lcm; needs to be included in the
+     run the &clm; needs to be included in the
      <filename>data/servers.yml</filename>file.
     </para>
    </listitem>

--- a/xml/planning-architecture-examples-entryscale_swift.xml
+++ b/xml/planning-architecture-examples-entryscale_swift.xml
@@ -67,7 +67,7 @@
  <para>
   If you are using &productname; to install the operating system, then an IPMI
   network connected to the IPMI ports of all servers and routable from the
-  &lcm; is also required for BIOS and power management of the node during the
+  &clm; is also required for BIOS and power management of the node during the
   operating system installation process.
  </para>
  <para>
@@ -117,7 +117,7 @@
    </thead>
    <tbody>
     <row>
-     <entry>Dedicated &lcm; (optional)</entry>
+     <entry>Dedicated &clm; (optional)</entry>
      <entry>Lifecycle-manager</entry>
      <entry>1</entry>
      <entry>300 GB</entry>

--- a/xml/planning-architecture-examples-mid-scale-kvm.xml
+++ b/xml/planning-architecture-examples-mid-scale-kvm.xml
@@ -59,12 +59,12 @@
    </listitem>
   </varlistentry>
   <varlistentry>
-   <term>&lcm;</term>
+   <term>&clm;</term>
    <listitem>
     <para>
-     The &lcm; runs on one of the control-plane nodes of type
+     The &clm; runs on one of the control-plane nodes of type
      <literal>CONTROLLER-ROLE</literal>. The IP address of the node that will
-     run the &lcm; needs to be included in the
+     run the &clm; needs to be included in the
      <filename>data/servers.yml</filename> file.
     </para>
    </listitem>

--- a/xml/planning-architecture-input_model-concepts-concepts.xml
+++ b/xml/planning-architecture-input_model-concepts-concepts.xml
@@ -45,7 +45,7 @@
   and the configuration processor is shown in the following diagram. Below the
   line are the directories that you, the cloud administrator, edit to declare
   the cloud configuration. Above the line are the directories that are
-  internal to the &lcm; such as Ansible playbooks and variables.
+  internal to the &clm; such as Ansible playbooks and variables.
  </para>
  <informalfigure>
   <mediaobject>

--- a/xml/planning-architecture-input_model-configobj-network_interfaces.xml
+++ b/xml/planning-architecture-input_model-configobj-network_interfaces.xml
@@ -72,8 +72,8 @@
       A list of one or more network-groups (see
       <xref linkend="configobj_networkgroups"/>) containing networks (see
       <xref linkend="configobj_networks"/>) that can be accessed by servers
-      running as virtual machines on an &lcm; hypervisor server. Networks in
-      these groups are not configured on the &lcm; hypervisor server unless
+      running as virtual machines on an &clm; hypervisor server. Networks in
+      these groups are not configured on the &clm; hypervisor server unless
       they also are specified in the <literal>network-groups</literal> or
       <literal>forced-network-groups</literal> attributes.
      </entry>

--- a/xml/planning-architecture-input_model-configobj-servers.xml
+++ b/xml/planning-architecture-input_model-configobj-servers.xml
@@ -194,15 +194,15 @@
      <entry>hypervisor-id (optional)</entry>
      <entry>
       This attribute serves two purposes: it indicates that this server is a
-      virtual machine (VM), and it specifies the server id of the &lcm;
+      virtual machine (VM), and it specifies the server id of the &clm;
       hypervisor that will host the VM.
      </entry>
     </row>
     <row>
      <entry>ardana-hypervisor (optional)</entry>
      <entry>
-      When set to True, this attribute identifies a server as a &lcm;
-      hypervisor. A &lcm; hypervisor is a server that may be used to host
+      When set to True, this attribute identifies a server as a &clm;
+      hypervisor. A &clm; hypervisor is a server that may be used to host
       other servers that are themselves virtual machines. Default value is
       <literal>False</literal>.
      </entry>

--- a/xml/planning-architecture-input_model-other_topics-services_components.xml
+++ b/xml/planning-architecture-input_model-other_topics-services_components.xml
@@ -174,7 +174,7 @@ ceilometer-polling</screen>
      </entry>
     </row>
     <row>
-     <entry>&lcm;</entry>
+     <entry>&clm;</entry>
      <entry>ardana</entry>
      <entry>
 <screen>ardana-ux-services

--- a/xml/planning-architecture-input_model-other_topics-standalonedeployer.xml
+++ b/xml/planning-architecture-input_model-other_topics-standalonedeployer.xml
@@ -4,11 +4,11 @@
 ]>
 <section xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude"
   xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="standalonedeployer" version="5.1">
- <title>Standalone &lcm;</title>
+ <title>Standalone &clm;</title>
  <para>
   All the example configurations use a <quote>deployer-in-the-cloud</quote>
-  scenario where the first controller is also the deployer/&lcm;. If you want
-  to use a standalone &lcm;, you need to add the relevant details in
+  scenario where the first controller is also the deployer/&clm;. If you want
+  to use a standalone &clm;, you need to add the relevant details in
   <literal>control_plane.yml</literal>, <literal>servers.yml</literal> and
   related configuration files. Detailed instructions are available at <xref
   linkend="standalone_deployer"/>.

--- a/xml/planning-planning-high_availability.xml
+++ b/xml/planning-planning-high_availability.xml
@@ -531,10 +531,10 @@
   <title>What is not Highly Available?</title>
   <variablelist>
    <varlistentry>
-    <term>&lcm;</term>
+    <term>&clm;</term>
     <listitem>
      <para>
-      The &lcm; in &productname; is not highly available.
+      The &clm; in &productname; is not highly available.
      </para>
     </listitem>
    </varlistentry>

--- a/xml/planning-planning-hw_support_diskcalc.xml
+++ b/xml/planning-planning-hw_support_diskcalc.xml
@@ -296,7 +296,7 @@
    <step>
     <para>
      Determine which services you have enabled to collect audit logging
-     information. This is part of &lcm; configuration.
+     information. This is part of &clm; configuration.
     </para>
    </step>
    <step>

--- a/xml/planning-planning-objectstorage-modify_swift_service_config_files.xml
+++ b/xml/planning-planning-objectstorage-modify_swift_service_config_files.xml
@@ -8,7 +8,7 @@
  <para>
   &product; enables you to modify various Swift service configuration
   files. The following Swift service configuration files are located on the
-  &lcm; in the <filename>~/openstack/my_cloud/config/swift/</filename> directory:
+  &clm; in the <filename>~/openstack/my_cloud/config/swift/</filename> directory:
  </para>
  <itemizedlist>
   <listitem>
@@ -83,7 +83,7 @@
   <procedure>
    <step>
     <para>
-     Log in to the &lcm;.
+     Log in to the &clm;.
     </para>
    </step>
    <step>
@@ -149,7 +149,7 @@ container_ratelimit_5000000 = 50</screen>
   <procedure>
    <step>
     <para>
-     Log in to the &lcm;.
+     Log in to the &clm;.
     </para>
    </step>
    <step>

--- a/xml/planning-planning-planning_index.xml
+++ b/xml/planning-planning-planning_index.xml
@@ -4,7 +4,7 @@
 ]>
 <part xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude"
  xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="planning_index" version="5.1">
- <title>Planning an Installation using &lcm;</title>
+ <title>Planning an Installation using &clm;</title>
  <xi:include href="planning-planning-suse-register_suse_overview.xml"/>
  <xi:include href="planning-planning-hw_support_matrix.xml"/>
  <xi:include href="planning-planning-recommended_hardware_minimums.xml"/>

--- a/xml/planning-planning-rec_min_entryscale_esx_kvm.xml
+++ b/xml/planning-planning-rec_min_entryscale_esx_kvm.xml
@@ -74,7 +74,7 @@
    </thead>
    <tbody>
     <row>
-     <entry>Dedicated &lcm; (optional)</entry>
+     <entry>Dedicated &clm; (optional)</entry>
      <entry>Lifecycle-manager</entry>
      <entry>1</entry>
      <entry>300 GB</entry>

--- a/xml/planning-planning-rec_min_entryscale_esx_kvm_mml.xml
+++ b/xml/planning-planning-rec_min_entryscale_esx_kvm_mml.xml
@@ -76,7 +76,7 @@
    </thead>
    <tbody>
     <row>
-     <entry>Dedicated &lcm; (optional)</entry>
+     <entry>Dedicated &clm; (optional)</entry>
      <entry>Lifecycle-manager</entry>
      <entry>1</entry>
      <entry>300 GB</entry>

--- a/xml/planning-planning-rec_min_entryscale_kvm.xml
+++ b/xml/planning-planning-rec_min_entryscale_kvm.xml
@@ -45,7 +45,7 @@
    </thead>
    <tbody>
     <row>
-     <entry>Dedicated &lcm; (optional)</entry>
+     <entry>Dedicated &clm; (optional)</entry>
      <entry>Lifecycle-manager</entry>
      <entry>1</entry>
      <entry>300 GB</entry>

--- a/xml/planning-planning-rec_min_ironic.xml
+++ b/xml/planning-planning-rec_min_ironic.xml
@@ -43,7 +43,7 @@
    </thead>
    <tbody>
     <row>
-     <entry>Dedicated &lcm; (optional)</entry>
+     <entry>Dedicated &clm; (optional)</entry>
      <entry>Lifecycle-manager</entry>
      <entry>1</entry>
      <entry>300 GB</entry>

--- a/xml/planning-planning-rec_min_swift.xml
+++ b/xml/planning-planning-rec_min_swift.xml
@@ -47,7 +47,7 @@
    </thead>
    <tbody>
     <row>
-     <entry>Dedicated &lcm; (optional)</entry>
+     <entry>Dedicated &clm; (optional)</entry>
      <entry>Lifecycle-manager</entry>
      <entry>1</entry>
      <entry>300 GB</entry>

--- a/xml/preinstall-configure-deployer-repos.xml
+++ b/xml/preinstall-configure-deployer-repos.xml
@@ -12,14 +12,14 @@
   Software repositories containing products, extensions, and the respective
   updates for all software need to be available to all nodes in &productname;
   in order to complete the deployment. These can be managed manually, or they
-  can be hosted on the &lcm; server. In this configuration step, these
-  repositories are made available on the &lcm; server. There are two types of
+  can be hosted on the &clm; server. In this configuration step, these
+  repositories are made available on the &clm; server. There are two types of
   repositories:
  </para>
  <para>
   <emphasis role="bold">Product Media Repositories</emphasis>: Product media
   repositories are copies of the installation media. They need to be
-  directly copied to the &lcm; server, <quote>loop-mounted</quote> from an iso
+  directly copied to the &clm; server, <quote>loop-mounted</quote> from an iso
   image, or mounted from a remote server via NFS. Affected are &cloudos; and
   &productname; &productnumber;. These are static repositories; they do not
   change or receive updates. See <xref
@@ -151,14 +151,14 @@ mount -t nfs <replaceable>nfs.&exampledomain;:/exports/SUSE-OPENSTACK-CLOUD/DVD1
   <sect1 xml:id="sec.depl.adm_conf.repos.scc">
    <title>Update and Pool Repositories</title>
    <para>
-    Update and Pool Repositories are required on the &lcm; server to set up and
+    Update and Pool Repositories are required on the &clm; server to set up and
     maintain the &productname; nodes. They are provided by &scc; and contain all
     software packages needed to install &cloudos; and the extensions (pool
     repositories). In addition, they contain all updates and patches (update
     repositories).
    </para>
    <para>
-    The repositories can be made available on the &lcm; server using one or more of the
+    The repositories can be made available on the &clm; server using one or more of the
     following methods:
    </para>
    <itemizedlist mark="bullet" spacing="normal">
@@ -175,12 +175,12 @@ mount -t nfs <replaceable>nfs.&exampledomain;:/exports/SUSE-OPENSTACK-CLOUD/DVD1
    </itemizedlist>
    <sect2 xml:id="sec.depl.adm_conf.repos.scc.local_smt">
     <title>
-     Repositories Hosted on an &smt; Server Installed on the &lcm;
+     Repositories Hosted on an &smt; Server Installed on the &clm;
     </title>
     <para>
      When all update and pool repositories are managed by an &smt; server
-     installed on the &lcm; server (see <xref linkend="app.deploy.smt_lcm"/>),
-     the &lcm; automatically detects all available repositories. No further
+     installed on the &clm; server (see <xref linkend="app.deploy.smt_lcm"/>),
+     the &clm; automatically detects all available repositories. No further
      action is required.
     </para>
    </sect2>
@@ -213,7 +213,7 @@ mount -t nfs <replaceable>nfs.&exampledomain;:/exports/SUSE-OPENSTACK-CLOUD/DVD1
     </itemizedlist>
     <para>
      The repositories must be made available at the
-     default locations on the &lcm; server as listed in <xref
+     default locations on the &clm; server as listed in <xref
      linkend="tab.depl.adm_conf.local-repos"/>.
     </para>
    </sect2>
@@ -309,7 +309,7 @@ The following tables show the locations of all repositories that can be used for
  </para>
 
  <table xml:id="tab.depl.adm_conf.local-repos">
-  <title>Repository Locations on the &lcm; server</title>
+  <title>Repository Locations on the &clm; server</title>
   <tgroup cols="2">
    <colspec colnum="1" colname="1" colwidth="25*"/>
    <colspec colnum="2" colname="2" colwidth="75*"/>

--- a/xml/preinstall-prepare-deployer.xml
+++ b/xml/preinstall-prepare-deployer.xml
@@ -6,10 +6,10 @@
 ]>
 <chapter xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.0" xml:id="cha.depl.dep_inst">
  <info>
-  <title>Installing the &lcm; server</title>
+  <title>Installing the &clm; server</title>
   <abstract>
    <para>
-    This chapter will show how to install the &lcm; from scratch. It will run
+    This chapter will show how to install the &clm; from scratch. It will run
     on &cloudos;, include the &productname; extension, and, optionally, the
     &smtool; (&smt;) server.
    </para>
@@ -120,7 +120,7 @@
  <sect1 xml:id="sec.depl.adm_inst.user">
   <title>Creating a User</title>
   <para>
-   Setting up &lcm; requires a regular user which you can set up during the
+   Setting up &clm; requires a regular user which you can set up during the
    installation. You are free to choose any available user name except for
    <systemitem class="username">ardana</systemitem>, because the <systemitem
    class="username">ardana</systemitem> user is reserved by &productname;.
@@ -130,7 +130,7 @@
   <title>Installation Settings</title>
   <para>
    With <guimenu>Installation Settings</guimenu>, you need to adjust the
-   software selection for your &lcm; setup. For more information refer to the
+   software selection for your &clm; setup. For more information refer to the
    <link
    xlink:href="&suse-onlinedoc;/sles-12/book_sle_deployment/data/sec_i_yast2_proposal.html">Installation
    Settings</link> section of the &cloudos; <citetitle>Deployment
@@ -203,7 +203,7 @@
    <title>Installing the &productname; Extension</title>
    <para>
     &productname; is an extension to &sls;. Installing it during the &sls;
-    installation is the easiest and recommended way to set up the &lcm;. To get
+    installation is the easiest and recommended way to set up the &clm;. To get
     access to the extension selection dialog, you need to register &cloudos;
     during the installation. After a successful registration, the &cloudos;
     installation continues with the <guimenu>Extension &amp; Module
@@ -214,7 +214,7 @@
    </para>
    <para>
     If you do not have Internet access or are not able to register during
-    installation, then once Internet access is available for the &lcm; do the
+    installation, then once Internet access is available for the &clm; do the
     following steps:
    </para>
    <procedure>

--- a/xml/preinstall-smt-setup.xml
+++ b/xml/preinstall-smt-setup.xml
@@ -5,29 +5,29 @@
   %entities;
 ]>
 <chapter xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.0" xml:id="app.deploy.smt_lcm">
- <title>Installing and Setting Up an &smt; Server on the &lcm; server (Optional)</title>
+ <title>Installing and Setting Up an &smt; Server on the &clm; server (Optional)</title>
  <info>
   <abstract>
    <para>
     One way to provide the repositories needed to set up the nodes in
-    &productname; is to install a &smtool; (&smt;) server on the &lcm; server, and then mirror all
+    &productname; is to install a &smtool; (&smt;) server on the &clm; server, and then mirror all
     repositories from &scc; via this server. Installing an &smt; server
-    on the &lcm; server is optional. If your organization already provides an
+    on the &clm; server is optional. If your organization already provides an
     &smt; server or a &susemgr; server that can be accessed from the
-    &lcm; server, skip this step.
+    &clm; server, skip this step.
    </para>
   </abstract>
  </info>
  <important>
   <title>Use of &smt; Server and Ports</title>
   <para>
-   When installing an &smt; server on the &lcm; server, use it exclusively
+   When installing an &smt; server on the &clm; server, use it exclusively
    for &productname;. To use the &smt; server for other
    products, run it outside of &productname;. Make sure it can be accessed
-   from the &lcm; for mirroring the repositories needed for &productname;.
+   from the &clm; for mirroring the repositories needed for &productname;.
   </para>
   <para>
-   When the &smt; server is installed on the &lcm; server, &lcm;
+   When the &smt; server is installed on the &clm; server, &clm;
    provides the mirrored repositories on port <literal>79</literal>.
   </para>
  </important>
@@ -35,7 +35,7 @@
   <title>&smt; Installation</title>
 
   <para>
-   If you have not installed the &smt; server during the initial &lcm; server
+   If you have not installed the &smt; server during the initial &clm; server
    installation as suggested in <xref
    linkend="sec.depl.adm_inst.settings.software"/>, run the following command
    to install it:
@@ -64,7 +64,7 @@
    </para>
    <para>
     If you did not register with the &scc; during installation, then at this
-    point you will need to register in order to proceed. Ensure that the &lcm; has external
+    point you will need to register in order to proceed. Ensure that the &clm; has external
     network access and then run the following command:
    </para>
    <screen>&prompt.sudo;SUSEConnect -r
@@ -220,7 +220,7 @@ done</screen>
     up to several hours. A log file is written to
     <filename>/var/log/smt/smt-mirror.log</filename>. After this first manual update the repositories are updated automatically via cron
     job. A list of all
-    repositories and their location in the file system on the &lcm; server can be
+    repositories and their location in the file system on the &clm; server can be
     found at <xref linkend="tab.smt.repos_local"/>.
    </para>
   </sect2>

--- a/xml/security-barbican.xml
+++ b/xml/security-barbican.xml
@@ -210,7 +210,7 @@
    <step>
     <para>
      Generate the master key using the provided python *generate_kek* script on
-     the &lcm; node:
+     the &clm; node:
     </para>
 <screen>python ~/openstack/ardana/ansible/roles/KEYMGR-API/templates/generate_kek</screen>
     <para>
@@ -404,7 +404,7 @@ ansible-playbook -i hosts/localhost ready-deployment.yml</screen>
    it as the default option when auditing is enabled.
   </para>
   <para>
-   Auditing can be disabled or enabled by following these steps on the &lcm;
+   Auditing can be disabled or enabled by following these steps on the &clm;
    node.
   </para>
   <procedure>
@@ -527,7 +527,7 @@ ansible-playbook -i hosts/localhost ready-deployment.yml</screen>
        <para>
         Password is randomly generated and made available in the &secret_store;
         client environment setup script, <literal>barbican.osrc,</literal>, on
-        the &lcm; node.
+        the &clm; node.
        </para>
       </entry>
      </row>

--- a/xml/security-barbican_admin.xml
+++ b/xml/security-barbican_admin.xml
@@ -12,7 +12,7 @@
   <para>
    In a production environment, you can verify your installation of the
    &secret_store; key management service by running the
-   <filename>barbican-status.yml</filename> Ansible playbook on the &lcm; node.
+   <filename>barbican-status.yml</filename> Ansible playbook on the &clm; node.
   </para>
 <screen>ansible-playbook -i hosts/verb_hosts barbican-status.yml</screen>
   <para>
@@ -24,7 +24,7 @@
   <title>Updating the &secret_store; Key Management Service</title>
   <para>
    Some &secret_store; features and service configurations can be changed. This
-   is done using the &lcm; Reconfigure Ansible playbook. For example, the log
+   is done using the &clm; Reconfigure Ansible playbook. For example, the log
    level can be changed from INFO to DEBUG and vice-versa. If needed, this
    change can be restricted to a set of nodes via the playbook's host limit
    option. &secret_store; administration tasks should be performed by an admin
@@ -97,7 +97,7 @@
   <title>Enable or Disable Auditing of &secret_store; Events</title>
   <para>
    Auditing of &secret_store; key manager events can be disabled or enabled by
-   following steps on the &lcm; node.
+   following steps on the &clm; node.
   </para>
   <procedure>
    <step>
@@ -168,7 +168,7 @@ ansible-playbook -i hosts/verb_hosts barbican-reconfigure.yml</screen>
      The &secret_store; API service configuration file
      (<literal>/etc/barbican/barbican.conf</literal>), located on each control
      plane server (controller node) is generated from the following template
-     file located on the &lcm; node:
+     file located on the &clm; node:
      <filename>/var/lib/ardana/openstack/my_cloud/config/barbican/barbican.conf.j2</filename>.
      Modify this template file as appropriate. This is a Jinja2 template, which
      expects certain template variables to be set. Do not change values inside
@@ -207,7 +207,7 @@ ansible-playbook -i hosts/verb_hosts barbican-reconfigure.yml</screen>
  <section>
   <title>Starting and Stopping the Barbican Service</title>
   <para>
-   You can start or stop the &secret_store; service from the &lcm; nodes by
+   You can start or stop the &secret_store; service from the &clm; nodes by
    running the appropriate Ansible playbooks:
   </para>
   <para>
@@ -292,7 +292,7 @@ ansible-playbook -i hosts/verb_hosts barbican-reconfigure-credentials-change.yml
   <title>Checking Barbican Status</title>
   <para>
    You can check the status of &secret_store; by running the
-   <literal>barbican-status.yml</literal> Ansible playbook on the &lcm; node.
+   <literal>barbican-status.yml</literal> Ansible playbook on the &clm; node.
   </para>
 <screen>ansible-playbook -i hosts/verb_hosts barbican-status.yml</screen>
  <note>
@@ -308,7 +308,7 @@ ansible-playbook -i hosts/verb_hosts barbican-reconfigure-credentials-change.yml
   <title>Updating Logging Configuration</title>
   <para>
    All &secret_store; logging is set to INFO by default. To change the
-   level from the &lcm;, there are two options available
+   level from the &clm;, there are two options available
   </para>
   <orderedlist>
    <listitem>

--- a/xml/security-dar.xml
+++ b/xml/security-dar.xml
@@ -34,7 +34,7 @@
   store</emphasis>
  </para>
  <para>
-  Using the &lcm; reconfigure playbook, you can configure one of two back ends
+  Using the &clm; reconfigure playbook, you can configure one of two back ends
   for the Barbican key management service:
  </para>
  <itemizedlist>
@@ -60,7 +60,7 @@
      To configure KMIP + Atalla ESKM in place of the default database, begin by
      providing certificate information by modifying the sample configuration
      file, <literal>barbican_kmip_plugin_config_sample.yml</literal>, on the
-     &lcm; node:
+     &clm; node:
     </para>
 <screen>~/openstack/ardana/ansible/roles/KEYMGR-API/files/samples/barbican_kmip_plugin_config_sample.yml</screen>
    </listitem>

--- a/xml/security-encrypted_ephvol.xml
+++ b/xml/security-encrypted_ephvol.xml
@@ -29,7 +29,7 @@
   <orderedlist>
    <listitem>
     <para>
-     Log in to the &lcm;.
+     Log in to the &clm;.
     </para>
    </listitem>
    <listitem>

--- a/xml/security-encrypted_storage.xml
+++ b/xml/security-encrypted_storage.xml
@@ -96,7 +96,7 @@
    <listitem>
     <para>
      The SSH private key used by Ansible to connect to client nodes from the
-     &lcm; is protected with a passphrase.
+     &clm; is protected with a passphrase.
     </para>
    </listitem>
    <listitem>
@@ -145,11 +145,11 @@
   </para>
  </section>
  <section xml:id="protection">
-  <title>Protecting sensitive data on the &lcm;</title>
+  <title>Protecting sensitive data on the &clm;</title>
   <para>
    There are a number of mechanisms that can be used to protect sensitive data
    such as passwords, some Ansible inputs, and the SSH key used by Ansible on
-   the &lcm;. See the installation documents for details. Please
+   the &clm;. See the installation documents for details. Please
    remember the need to guard against exposure of your environment variables,
    which may happen through observation over the shoulder.
   </para>

--- a/xml/security-header_poisoning.xml
+++ b/xml/security-header_poisoning.xml
@@ -28,7 +28,7 @@
    <orderedlist>
     <listitem>
      <para>
-      On your &lcm; node, make a backup copy of this file and then open
+      On your &clm; node, make a backup copy of this file and then open
       <emphasis role="bold">/usr/share/ardana/input-model/2.0/services/horizon.yml</emphasis>
      </para>
     </listitem>
@@ -59,7 +59,7 @@
    <orderedlist>
     <listitem>
      <para>
-      While still on your &lcm; node, open
+      While still on your &clm; node, open
       <filename>~/openstack/my_cloud/config/horizon/local_settings.py</filename>.
      </para>
     </listitem>

--- a/xml/security-middleware_auditing.xml
+++ b/xml/security-middleware_auditing.xml
@@ -86,7 +86,7 @@
   <title>Centralized auditing configuration</title>
   <para>
    In &productname;, all auditing configuration is centrally managed and controlled
-   via input model YAML files on the &lcm; node. The settings are
+   via input model YAML files on the &clm; node. The settings are
    configured in the file
    <literal>~/openstack/my_cloud/definition/cloudConfig.yml</literal> in a newly
    added audit-settings section shown below the following table.

--- a/xml/security-security_features.xml
+++ b/xml/security-security_features.xml
@@ -62,7 +62,7 @@
    authenticating communications between services in your &productname; deployment,
    promoting better compliance with your organization’s security policies.
    The inter-service passwords that can be changed include (but are not limited
-   to) &o_ident;, &mariadb;, &rabbit;, &lcm;, &o_monitor; and &secret_store;. Admins can
+   to) &o_ident;, &mariadb;, &rabbit;, &clm;, &o_monitor; and &secret_store;. Admins can
    implement this feature by running the configuration processor to generate
    new passwords followed by Ansible playbook commands to change the
    credentials.

--- a/xml/security-tls_config.xml
+++ b/xml/security-tls_config.xml
@@ -302,7 +302,7 @@ ansible -i hosts/verb_hosts FND-STN -a 'sudo keytool -delete -alias debian:&lt;f
    </step>
    <step>
     <para>
-     Upload to the &lcm;. Server certificates should be added to
+     Upload to the &clm;. Server certificates should be added to
      <filename>config/tls/certs</filename> and CA certificates should be added
      to <filename>config/tls/cacerts</filename>. The file extension should be
      <filename>.crt</filename> for the CA certificate to be processed by
@@ -659,7 +659,7 @@ openssl ca -batch -notext -md sha256 -in "$EXAMPLE_SERVER_CSR_FILE" \
    <step>
     <para>
      Concatenate both the server key and certificate in preparation for
-     uploading to the &lcm;.
+     uploading to the &clm;.
     </para>
 <screen>
 <?dbsuse-fo font-size="0.70em"?>
@@ -676,12 +676,12 @@ cat example-internal-cert.key example-internal-cert.crt &gt; example-internal-ce
   </procedure>
  </section>
  <section>
-  <title>Upload to the &lcm;</title>
+  <title>Upload to the &clm;</title>
   <procedure>
    <step>
     <para>
      The two files created from the example above will need to be uploaded to
-     the &lcm; and copied into <filename>config/tls</filename>:
+     the &clm; and copied into <filename>config/tls</filename>:
     </para>
     <itemizedlist xml:id="idg-all-security-tls_config-xml-7">
      <listitem>
@@ -698,7 +698,7 @@ cat example-internal-cert.key example-internal-cert.crt &gt; example-internal-ce
    </step>
    <step>
     <para>
-     On the &lcm;, execute the following copy commands. If you created an
+     On the &clm;, execute the following copy commands. If you created an
      external cert, copy that in a similar manner.
     </para>
 <screen>cp example-internal-cert ~/openstack/my_cloud/config/tls/certs/
@@ -706,7 +706,7 @@ cp example-CA.crt ~/openstack/my_cloud/config/tls/cacerts/</screen>
    </step>
    <step>
     <para>
-     Log into the &lcm; node. Save and commit the changes to the local Git
+     Log into the &clm; node. Save and commit the changes to the local Git
      repository:
     </para>
 <screen>cd ~/openstack/ardana/ansible

--- a/xml/security-tls_mysql.xml
+++ b/xml/security-tls_mysql.xml
@@ -85,7 +85,7 @@ cd ~/scratch/ansible/next/ardana/ansible</screen>
   <procedure>
    <step>
     <para>
-     Log in to the &lcm; node and before running the config
+     Log in to the &clm; node and before running the config
      processor, edit the
      <literal>~/openstack/my_cloud/config/mariadb/defaults.yml</literal> file.
     </para>
@@ -156,7 +156,7 @@ mysql_gcomms_bind_tls: "{{ host.bind['FND_MDB'].mysql_gcomms.tls }}"
   <orderedlist>
    <listitem>
     <para>
-     Log into the &lcm; as root and run the mysql command.
+     Log into the &clm; as root and run the mysql command.
     </para>
 <screen>root@&lt;server&gt;:~# mysql</screen>
     <para>


### PR DESCRIPTION
This matches the {lcm} attribute entry used in the Release Notes.

SOC 8 version of these changes at #817.