### PR TITLE
Isolated Metadata Settings (SCRD-8557)

### DIFF
--- a/xml/networking-isolated_metadata.xml
+++ b/xml/networking-isolated_metadata.xml
@@ -11,20 +11,23 @@
   In &productname;, Neutron currently sets <literal>enable_isolated_metadata =
   True</literal> by default in <literal>dhcp_agent.ini</literal> because
   several services require isolated networks (Neutron networks without a
-  router). This has the effect of spawning a neutron-ns-metadata-proxy process
-  on one of the controller nodes for every active Neutron network.
+  router). It also sets <literal>force_metadata = True</literal> if DVR is 
+  enabled to improve the scalability on large environments with a high churn 
+  rate. However, this has the effect of spawning a neutron-ns-metadata-proxy
+  process on one of the controller nodes for every active Neutron network.
  </para>
  <para>
   In environments that create many Neutron networks, these extra
   <literal>neutron-ns-metadata-proxy</literal> processes can quickly eat up a
-  lot of memory on the controllers, which does not scale well.
+  lot of memory on the controllers, which does not scale up well.
  </para>
  <para>
   For deployments that do not require isolated metadata (that is, they do not
   require the Platform Services and will always create networks with an
-  attached router), you can set <literal>enable_isolated_metadata =
-  False</literal> in dhcp_agent.ini to reduce Neutron memory usage on
-  controllers, allowing a greater number of active Neutron networks.
+  attached router) and do not have a high churn rate, you can set 
+  <literal>enable_isolated_metadata = False</literal> and <literal>force_metadata = False</literal>
+  in dhcp_agent.ini to reduce Neutron memory usage on controllers,
+  allowing a greater number of active Neutron networks.
  </para>
  <para>
   Note that the <literal>dhcp_agent.ini.j2</literal> template is found in
@@ -45,9 +48,11 @@
    <para>
     Edit the <literal>dhcp_agent.ini.j2</literal> file to change the
     <literal>enable_isolated_metadata = {{ neutron_enable_isolated_metadata }}</literal>
+    <literal>force_metadata = {{ router_distributed }}</literal>
     line in the <literal>[DEFAULT]</literal> section to read:
    </para>
 <screen>enable_isolated_metadata = False</screen>
+<screen>force_metadata = False</screen>
   </step>
   <step>
    <para>

--- a/xml/networking-isolated_metadata.xml
+++ b/xml/networking-isolated_metadata.xml
@@ -13,7 +13,7 @@
   several services require isolated networks (Neutron networks without a
   router). It also sets <literal>force_metadata = True</literal> if DVR is 
   enabled to improve the scalability on large environments with a high churn 
-  rate. However, this has the effect of spawning a neutron-ns-metadata-proxy
+  rate. However, this has the effect of spawning a <literal>neutron-ns-metadata-proxy</literal>
   process on one of the controller nodes for every active Neutron network.
  </para>
  <para>
@@ -26,7 +26,7 @@
   require the Platform Services and will always create networks with an
   attached router) and do not have a high churn rate, you can set 
   <literal>enable_isolated_metadata = False</literal> and <literal>force_metadata = False</literal>
-  in dhcp_agent.ini to reduce Neutron memory usage on controllers,
+  in <literal>dhcp_agent.ini</literal> to reduce Neutron memory usage on controllers,
   allowing a greater number of active Neutron networks.
  </para>
  <para>


### PR DESCRIPTION
In order to disable metadata in the dhcp namespaces you have to disable
enable_isolated_metadata = False
force_metadata = False

Previously, force_metadata was always false, so it never was documented that we have to change it.
Currently, there is a situation when we are enabling it, hence we need to document it.