### PR TITLE
Replace postgres with mariadb (bz#1130795)

### DIFF
--- a/xml/depl_overview.xml
+++ b/xml/depl_overview.xml
@@ -175,7 +175,7 @@
   <itemizedlist mark="bullet" spacing="normal">
    <listitem>
     <para>
-     &postgres; database.
+     &mariadb; database.
     </para>
    </listitem>
    <listitem>


### PR DESCRIPTION
Crowbar default database is MariaDB since Cloud8