### PR TITLE
Fix command for listing compute hosts (SCRD-7602)

### DIFF
--- a/xml/operations-compute-creating_aggregates.xml
+++ b/xml/operations-compute-creating_aggregates.xml
@@ -91,11 +91,10 @@
    <listitem>
     <para>
      Next, you need to add compute hosts to this aggregate so you can start by
-     listing your current hosts. You will want to limit the output of this
-     command to only the hosts running the <literal>compute</literal> service,
-     like this:
+     listing your current hosts. You can view the current list of hosts running 
+     running the <literal>compute</literal> service like this:
     </para>
-<screen>&prompt.ardana;openstack host list | grep compute</screen>
+<screen>&prompt.ardana;openstack hypervisor list</screen>
    </listitem>
    <listitem>
     <para>


### PR DESCRIPTION
Section 6.1.1 had an outdated command in step 5 for listing hosts running compute services, updated to currently used command