### PR TITLE
Add warning about Day2 disconnects with self-signed certs (SCRD-6373)

### DIFF
--- a/xml/day2_ui_documentation.xml
+++ b/xml/day2_ui_documentation.xml
@@ -163,7 +163,7 @@
  <title>Configuration</title>
  <para>
   The <guimenu>Configuration</guimenu> tab displays services that
-  are deployed in the cloud and the configuration files associated with thosei
+  are deployed in the cloud and the configuration files associated with those
   services. Services may be reconfigured by editing the 
   <filename>.j2</filename> files listed and clicking the 
   <guimenu>Update</guimenu> button.
@@ -183,7 +183,7 @@
   Clicking one of the listed files will open up the file editor where
   changes can be made to the service configuration. Files that have
   been edited but have not had their updates applied to the cloud
-  will be identifed by an asterisk `*` in the file list.
+  will be identified by an asterisk `*` in the file list.
  </para>
  <figure xml:id="admin_ui_cloud_service_configuration_editor">
   <title>&clm; Admin UI &suse; Service Configuration Editor</title>
@@ -201,6 +201,15 @@
   button to begin deploying configuration changes to the cloud. The status of
   those changes will be streamed to the UI.
  </para>
+ <note>
+   <para>
+     If the cloud is configured using self-signed certificates, the streaming
+     status updates (including the log) may be interupted and require a reload
+     of the CLM Admin UI. See 
+     <xref linkend="idg-all-security-tls_config-xml-1"/> for details on using 
+     signed certificates.
+   </para>
+ </note>
  <figure xml:id="admin_ui_cloud_service_configuration_update">
   <title>&clm; Admin UI &suse; Service Configuration Update</title>
   <mediaobject>


### PR DESCRIPTION
Add a warning block in the configuration section of the Day 2 docs that informs users that if they're using self-signed certificates, their streaming configuration updates may disconnect. References the security guide (where there are instructions for using signed certs)