### PR TITLE
Update Day2 access reqs to include keystone and HAProxy (SCRD-8513)

### DIFF
--- a/xml/day2_ui_documentation.xml
+++ b/xml/day2_ui_documentation.xml
@@ -36,7 +36,9 @@
   was deployed. Access to this network is necessary to be able to access the
   &clm; Admin UI and log in. Depending on the network setup, it may be
   necessary to use an SSH tunnel similar to what is recommended in <xref
-  linkend="running_install_ui"/>.
+  linkend="running_install_ui"/>. The Admin UI requires &o_ident; and &haproxy;
+  to be running and to be accesible. If Keystone or HAProxy are not running,
+  cloud reconfiguration is limited to the command line.
  </para>
  <para> Logging in requires a &o_ident; user. If the user is not an admin on
  the default domain and one or more projects, the &clm; Admin UI will not display

--- a/xml/day2_ui_documentation.xml
+++ b/xml/day2_ui_documentation.xml
@@ -37,7 +37,7 @@
   &clm; Admin UI and log in. Depending on the network setup, it may be
   necessary to use an SSH tunnel similar to what is recommended in <xref
   linkend="running_install_ui"/>. The Admin UI requires &o_ident; and &haproxy;
-  to be running and to be accesible. If Keystone or HAProxy are not running,
+  to be running and to be accesible. If &o_ident; or &haproxy; are not running,
   cloud reconfiguration is limited to the command line.
  </para>
  <para> Logging in requires a &o_ident; user. If the user is not an admin on


### PR DESCRIPTION
HAProxy and Keystone are required to access the Day2 UI, updated the access paragraph to indicate as much