### PR TITLE
add cobbler deprecation notice (no bsc#, no SCRD)

### DIFF
--- a/xml/installation-rhel-rhel_preinstall.xml
+++ b/xml/installation-rhel-rhel_preinstall.xml
@@ -117,4 +117,10 @@ COMMIT
    </para>
   </important>
  </section>
+ <section>
+  <title>Cobbler Support Removed</title>
+  <para>
+   Cobbler support for deploying &rhel; compute nodes has been removed.
+  </para>
+ </section>
 </chapter>


### PR DESCRIPTION
as directed by T.R. and Jeremy;
Rocket Chat 20190422 in cloud-documentation channel