### PR TITLE
improve performance, image-volume-cache (bsc#1140663)

### DIFF
--- a/xml/installation-installation-configure_3par.xml
+++ b/xml/installation-installation-configure_3par.xml
@@ -287,7 +287,9 @@ default_volume_type = <replaceable>YOUR VOLUME TYPE</replaceable></screen>
      <step>
       <para>
        Uncomment the <literal>StoreServ (3par) iscsi cluster</literal> section
-       and fill the values per your cluster information. Here is an example:
+       and fill the values per your cluster information. Storage performance
+       can be improved by enabling the <literal>Image-Volume</literal>
+       cache. Here is an example:
       </para>
 <screen>[3par_FC]
 san_ip: &#60;3par-san-ipaddr>
@@ -298,7 +300,8 @@ hpe3par_password: &#60;hpe3par_password>
 hpe3par_api_url: https://&#60;3par-san-ipaddr>:8080/api/v1
 hpe3par_cpg: &#60;3par-cpg-name-1>[,&#60;3par-cpg-name-2>, ...]
 volume_backend_name: &#60;3par-backend-name>
-volume_driver = cinder.volume.drivers.hpe.hpe_3par_iscsi.HPE3PARISCSIDriver</screen>
+volume_driver = cinder.volume.drivers.hpe.hpe_3par_iscsi.HPE3PARISCSIDriver
+image_volume_cache_enabled = True</screen>
        </step>
      </substeps>
     <important>


### PR DESCRIPTION
add explanation and example for improving storage performance
by enabling the Image-Volume cache.

replaces a81f058