### PR TITLE
remove empty step in procedure (no reference, trivial)

### DIFF
--- a/xml/operations-maintenance-reboot_cloud_down.xml
+++ b/xml/operations-maintenance-reboot_cloud_down.xml
@@ -68,10 +68,6 @@ ansible-playbook -i hosts/verb_hosts ardana-stop.yml</screen>
        their services quickly.
       </para>
      </step>
-     <step>
-      <para>
-      </para>
-     </step>
     </substeps>
    </step>
    <step>


### PR DESCRIPTION
Remove step-para-/para-/step which created an empty item in this
procedure. Looked odd in the rendered content.

Replaces https://github.com/SUSE-Cloud/doc-cloud/pull/1012