### PR TITLE
add hostnamectl to ardana-update-pkgs process (bsc#1138967)

### DIFF
--- a/xml/operations-maintenance-update_maintenance.xml
+++ b/xml/operations-maintenance-update_maintenance.xml
@@ -165,6 +165,20 @@
         </para>
        </listitem>
       </itemizedlist>
+     </step>
+     <step>
+      <para>
+       Confirm version changes by running <literal>hostnamectl</literal>
+       before and after running the <literal>ardana-update-pkgs</literal>
+       playbook on each node.
+      </para>
+      <screen>&prompt.ardana;hostnamectl</screen>
+      <para>
+       Notice that <literal>Boot ID:</literal> and <literal>Kernel:</literal>
+       have changed.
+      </para>
+     </step>
+     <step>
       <para>
        By default, the <filename>ardana-update-pkgs.yml</filename> playbook
        will install patches and updates that do not require a system


### PR DESCRIPTION
the hostnamectl command can be used to demonstrate that
ardana-update-pkgs has made changes. Customer request to
assist with update process.

minor change to language for clarity (bsc#1138967)
use confirm rather than demonstrate

(cherry picked from commit 96ff575d3cb1ed179761978f2b5d42951ba194f5)