### PR TITLE
remove HA SNAT section, not supported in SOC9 (bsc#1135354)

### DIFF
--- a/xml/planning-planning-high_availability.xml
+++ b/xml/planning-planning-high_availability.xml
@@ -226,25 +226,7 @@
 <!-- FIXME: <para>For information on more creating HA routers, see:
                    <xref linkend="CreateHARouter"/></para> -->
  </section>
- <section xml:id="DVR">
-  <title>High Availability Routing - Distributed</title>
-  <para>
-   The OpenStack Distributed Virtual Router (DVR) function delivers HA through
-   its distributed architecture. The one centralized function remaining is
-   source network address translation (SNAT), where high availability is
-   provided by DVR SNAT HA.
-  </para>
-  <para>
-   DVR SNAT HA is enabled on a per router basis and requires that two or more
-   L3 agents capable of providing SNAT services be running on the system. If a
-   minimum number of L3 agents is configured to 1 or lower, the neutron server
-   will fail to start and a log message will be created. The L3 Agents must be
-   running on a control-plane node, L3 agents running on a compute node do not
-   provide SNAT services.
-  </para>
-<!-- FIXME: <para>For more information on creating HA routers, see:
-                 <xref linkend="CreateHARouter"/>.</para> -->
- </section>
+
  <section xml:id="availability_zones">
   <title>Availability Zones</title>
   <figure xml:id="DeploymentZones">


### PR DESCRIPTION
remove misleading section-SNAT is shown as not supported in
planning-core_non-core_openstack_support.xml

(cherry picked from commit b371b37926b74fa41529b03ba84d3c518ee67f31)