### PR TITLE
manually set MTU or br-init with jumbo frames (bsc#1139750)

### DIFF
--- a/xml/networking-configure_mtu.xml
+++ b/xml/networking-configure_mtu.xml
@@ -198,6 +198,15 @@ global_physnet_mtu = 9000</screen>
    </step>
    <step>
     <para>
+     OvS will set <literal>br-int</literal> to the value of the lowest physical
+     interface. If you are using Jumbo frames on some of your networks,
+     <literal>br-int</literal> on the controllers may be set to 1500 instead of
+     9000. Work around this condition by running:
+    </para>
+    <screen>ovs-vsctl set int br-int mtu_request=9000</screen>
+   </step>
+   <step>
+    <para>
      Commit your changes
     </para>
 <screen>&prompt.ardana;git add -A


### PR DESCRIPTION
applies to SOC/HOS 8 and SOC 9. OvS sets br-int to lowest level of
physical interfaces. If jumbo frames are being used, then br-int
may be set to the wrong level.

replaces https://github.com/SUSE-Cloud/doc-cloud/pull/1010

(cherry picked from commit b88491e9c09f92f25d54da9e88b79df282bf11ba)