### PR TITLE
replace empty ESX compatibility guide (noref)

### DIFF
--- a/xml/planning-planning-hw_support_esxguestos.xml
+++ b/xml/planning-planning-hw_support_esxguestos.xml
@@ -7,7 +7,8 @@
  <para>
   For ESX, refer to the <link
   xlink:href="https://www.vmware.com/resources/compatibility/search.php?deviceCategory=software&amp;details=1&amp;releases=273,274,338&amp;productNames=15&amp;page=1&amp;display_interval=500&amp;sortColumn=Partner&amp;sortOrder=Asc&amp;testConfig=16">&vmware;
-  Compatibility Guide - scroll down</link>.
+  Compatibility Guide</link>. The information for &productname; is below the
+  search form.
  </para>
 
 </section>

--- a/xml/planning-planning-hw_support_esxguestos.xml
+++ b/xml/planning-planning-hw_support_esxguestos.xml
@@ -4,11 +4,10 @@
 ]>
 <section xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="hw_support_esxguestos" version="5.1">
  <title>ESX Guest OS Support</title>
- <!-- FIXME: This link leads to an empty search form instead of to a document
- - sknorr, 2018-03-02 -->
  <para>
-  For ESX, refer to the
-  <link xlink:href="http://www.vmware.com/resources/compatibility/search.php?action=search&amp;deviceCategory=software&amp;advancedORbasic=advanced&amp;maxDisplayRows=50&amp;key=&amp;productId=4&amp;gos_vmw_product_release%5B%5D=90&amp;datePosted=-1&amp;partnerId%5B%5D=-1&amp;os_bits=-1&amp;os_use%5B%5D=-1&amp;os_family%5B%5D=-1&amp;os_type%5B%5D=-1&amp;rorre=0">&vmware;
-  Compatibility Guide</link>.
+  For ESX, refer to the <link
+  xlink:href="https://www.vmware.com/resources/compatibility/search.php?deviceCategory=software&amp;details=1&amp;releases=273,274,338&amp;productNames=15&amp;page=1&amp;display_interval=500&amp;sortColumn=Partner&amp;sortOrder=Asc&amp;testConfig=16">&vmware;
+  Compatibility Guide - scroll down</link>.
  </para>
+
 </section>


### PR DESCRIPTION
the link in ESX Guest OS Support went to an empty form.
Replace with form filled in with proper information.

Remove FIXME:

(cherry picked from commit 877b2d8fcf2434179c9ffa610937a5c6ce68583b)