### PR TITLE
delete cache volume when source volume is changed (bsc#1142032)

### DIFF
--- a/xml/operations-image-configure_glance.xml
+++ b/xml/operations-image-configure_glance.xml
@@ -25,8 +25,8 @@
    This only becomes a problem if users can publicize or share images with
    others. If users can share images AND cannot publicize images then your
    system is not vulnerable. If the system has also been purged (via
-   <literal>glance-manage db purge</literal>) then it is possible for deleted image IDs to be
-   reused.
+   <literal>glance-manage db purge</literal>) then it is possible for deleted
+   image IDs to be reused.
   </para>
   <para>
    If deleted image IDs can be reused then recycling of public and shared
@@ -131,6 +131,12 @@
    An existing volume image cache is not properly deleted when &o_blockstore;
    detects the source image has changed. After updating any source image,
    delete the cache volume so that the cache is refreshed.
+  </para>
+  <para>
+   The volume image cache must be deleted before trying to use the associated
+   source image in any other volume operations. This includes creating bootable
+   volumes or booting an instance with <literal>create volume</literal> enabled
+   and the updated image as the source image.
   </para>
  </section>
  <section xml:id="copyfrom">

--- a/xml/operations-image-configure_glance.xml
+++ b/xml/operations-image-configure_glance.xml
@@ -60,13 +60,13 @@
    file. You will specify the mount point for the logical volume you wish to
    use for this.
   </para>
-  <orderedlist>
-   <listitem>
+  <procedure>
+   <step>
     <para>
      Log in to the &clm;.
     </para>
-   </listitem>
-   <listitem>
+   </step>
+   <step>
     <para>
      Edit your
      <literal>~/openstack/my_cloud/definition/data/disks_controller.yml</literal>
@@ -95,8 +95,8 @@
      post-installation then you will need to commit your changes with the steps
      below.
     </para>
-   </listitem>
-   <listitem>
+   </step>
+   <step>
     <para>
      Commit your configuration to the Git repository
      (<xref linkend="using_git"/>), as follows:
@@ -104,29 +104,34 @@
 <screen>&prompt.ardana;cd ~/openstack/ardana/ansible
 &prompt.ardana;git add -A
 &prompt.ardana;git commit -m "My config or other commit message"</screen>
-   </listitem>
-   <listitem>
+   </step>
+   <step>
     <para>
      Run the configuration processor:
     </para>
 <screen>&prompt.ardana;cd ~/openstack/ardana/ansible
 &prompt.ardana;ansible-playbook -i hosts/localhost config-processor-run.yml</screen>
-   </listitem>
-   <listitem>
+   </step>
+   <step>
     <para>
      Update your deployment directory:
     </para>
 <screen>&prompt.ardana;cd ~/openstack/ardana/ansible
 &prompt.ardana;ansible-playbook -i hosts/localhost ready-deployment.yml</screen>
-   </listitem>
-   <listitem>
+   </step>
+   <step>
     <para>
      Run the &o_img; reconfigure playbook:
     </para>
 <screen>&prompt.ardana;cd ~/scratch/ansible/next/ardana/ansible
 &prompt.ardana;ansible-playbook -i hosts/verb_hosts glance-reconfigure.yml</screen>
-   </listitem>
-  </orderedlist>
+   </step>
+  </procedure>
+  <para>
+   An existing volume image cache is not properly deleted when &o_blockstore;
+   detects the source image has changed. After updating any source image,
+   delete the cache volume so that the cache is refreshed.
+  </para>
  </section>
  <section xml:id="copyfrom">
   <title>Allowing the &o_img; copy-from option in your environment</title>


### PR DESCRIPTION
cache volumes are not automatically refreshed when source volumes
are changed, despite OpenStack documentation to the contrary.

(cherry picked from commit 316e216b68920d70788ba3aa44f1b70fb5b99039)