### PR TITLE
replace SUSE ca-cert instructions with public (bsc#1136569)

### DIFF
--- a/xml/book_cloud_deploy_crowbar.xml
+++ b/xml/book_cloud_deploy_crowbar.xml
@@ -46,7 +46,7 @@
   <xi:include href="depl_nodes.xml"/>
   <xi:include href="depl_policy_json.xml"/>
   <xi:include href="depl_ostack_configs.xml"/>
-  <xi:include href="install_caasp_heat_templates.xml"/>
+  <xi:include href="crowbar_install_caasp_heat_templates.xml"/>
   </part>
   <part xml:id="part.depl.nostack">
   <title>Setting Up Non-&ostack; Services</title>

--- a/xml/crowbar_install_caasp_heat_templates.xml
+++ b/xml/crowbar_install_caasp_heat_templates.xml
@@ -147,7 +147,7 @@ git clone https://github.com/SUSE/caasp-openstack-heat-templates
    checking that the <literal>provisioning_status</literal> changes to
    <literal>Active</literal>.
   </para>
-  <screen>&prompt.ardana;openstack loadbalancer show
+  <screen>&prompt.user;openstack loadbalancer show
 &lt;<replaceable>LOAD_BALANCER_ID</replaceable>&gt;</screen>
   <para>
    HAProxy is the default load balancer provider in &productname;.
@@ -157,13 +157,13 @@ git clone https://github.com/SUSE/caasp-openstack-heat-templates
    and IPs for a test <literal>lb_net1</literal> network with
    <literal>lb_subnet1</literal> subnet.
   </para>
-  <screen>&prompt.ardana;openstack network create lb_net1
-  &prompt.ardana;openstack subnet create --name lb_subnet1 lb_net1 \
+  <screen>&prompt.user;openstack network create lb_net1
+  &prompt.user;openstack subnet create --name lb_subnet1 lb_net1 \
 --subnet-range 172.29.0.0/24 --gateway 172.29.0.2
-&prompt.ardana;openstack router create lb_router1
-&prompt.ardana;openstack router add subnet lb_router1 lb_subnet1
-&prompt.ardana;openstack router set lb_router1 --external-gateway ext-net
-&prompt.ardana;openstack network list</screen>
+&prompt.user;openstack router create lb_router1
+&prompt.user;openstack router add subnet lb_router1 lb_subnet1
+&prompt.user;openstack router set lb_router1 --external-gateway ext-net
+&prompt.user;openstack network list</screen>
   <procedure>
    <title>Steps to Install &caasp; with Multiple Masters</title>
    <step>
@@ -185,7 +185,7 @@ git clone https://github.com/SUSE/caasp-openstack-heat-templates
      Create a stack in &o_orch; by passing the template, environment file, and
      parameters:
     </para>
-    <screen>&prompt.ardana;openstack stack create -t caasp-multi-master-stack.yaml \
+    <screen>&prompt.user;openstack stack create -t caasp-multi-master-stack.yaml \
 -e caasp-multi-master-environment.yaml --parameter image=CaaSP-3 caasp-multi-master-stack
     </screen>
    </step>
@@ -196,14 +196,14 @@ git clone https://github.com/SUSE/caasp-openstack-heat-templates
     </para>
     <substeps>
      <step>
-      <screen>&prompt.ardana;openstack loadbalancer list --provider</screen>
+      <screen>&prompt.user;openstack loadbalancer list --provider</screen>
      </step>
      <step>
       <para>
        From the output, copy the <literal>id</literal> and enter it in the
        following command as shown in the following example:
       </para>
-      <screen>&prompt.ardana;openstack loadbalancer show id</screen>
+      <screen>&prompt.user;openstack loadbalancer show id</screen>
       <screen>+---------------------+------------------------------------------------+
 | Field               | Value                                          |
 +---------------------+------------------------------------------------+
@@ -228,7 +228,7 @@ git clone https://github.com/SUSE/caasp-openstack-heat-templates
       <para>
        Search the floating IP list for <literal>vip_address</literal>
       </para>
-      <screen>&prompt.ardana;openstack floating ip list | grep 172.28.0.6
+      <screen>&prompt.user;openstack floating ip list | grep 172.28.0.6
 | d636f3...481b0c | fd7ff...deb4c1 | 172.28.0.6  | 10.84.65.37  | 53ad2...373e8b |</screen>
      </step>
      <step>
@@ -351,104 +351,6 @@ git clone https://github.com/SUSE/caasp-openstack-heat-templates
     </imageobject>
    </mediaobject>
   </informalfigure>
- </section>
- <section>
-  <title>Deploy &caasp; Stack Using &o_orch; &caasp; Playbook</title>
-  <procedure>
-   <step>
-    <para>
-     Install the <package>caasp-openstack-heat-templates</package> package on a
-     machine with &productname; repositories:
-    </para>
-    <screen>&prompt.ardana;zypper in caasp-openstack-heat-templates</screen>
-    <para>
-     The installed templates are located in
-     <filename>/usr/share/caasp-openstack-heat-templates</filename>.
-    </para>
-   </step>
-   <step>
-    <para>
-     Run <filename>heat-caasp-deploy.yml</filename> on the &clm; to create a
-     &caasp; cluster with &o_orch; templates from the
-     <literal>caasp-openstack-heat-templates</literal> package.
-    </para>
-    <screen>&prompt.ardana;cd ~/scratch/ansible/next/ardana/ansible
-&prompt.ardana;ansible-playbook -i hosts/localhost heat-caasp-deploy.yml</screen>
-   </step>
-   <step>
-    <para>
-     In a browser, navigate to the &o_dash; UI to determine the floating IP
-     address assigned to the admin node.
-    </para>
-   </step>
-   <step>
-    <para>
-     Go to http://<replaceable>ADMIN-NODE-FLOATING-IP</replaceable>/ to bring
-     up the Velum dashboard.
-    </para>
-   </step>
-   <step>
-    <para>
-     Complete the web-based bootstrap process to bring up the &caasp;
-     Kubernetes cluster. Refer to the &caasp; documentation for specifics.</para>
-    <para>
-     When prompted, set the <literal>Internal Dashboard Location</literal> to the
-     private network IP address (i.e. in the the 172.x.x.x subnet) of the &caasp;
-     admin node created during the <filename>heat-caasp-deploy.yml</filename>
-     playbook. Do not use the floating IP address which is also associated with
-     the node.
-    </para>
-   </step>
-  </procedure>
- </section>
- <section>
-  <title>Deploy &caasp; Cluster with Multiple Masters Using &o_orch; CaasP
-  Playbook</title>
-  <procedure>
-   <step>
-    <para>
-     Install the <package>caasp-openstack-heat-templates</package> package on a
-     machine with &productname; repositories:
-    </para>
-    <screen>&prompt.ardana;zypper in caasp-openstack-heat-templates</screen>
-    <para>
-     The installed templates are located in
-     <filename>/usr/share/caasp-openstack-heat-templates</filename>.
-    </para>
-   </step>
-   <step>
-    <para>
-     On the &clm;, run the <filename>heat-caasp-deploy.yml</filename> playbook
-     and pass parameters for <literal>caasp_stack_name</literal>,
-     <literal>caasp_stack_yaml_file</literal> and
-     <literal>caasp_stack_env_yaml_file</literal>.
-    </para>
-    <screen>&prompt.ardana;ansible-playbook -i hosts/localhost heat-caasp-deploy.yml -e "caasp_stack_name=caasp_multi-master caasp_stack_yaml_file=caasp-multi-master-stack.yaml caasp_stack_env_yaml_file=caasp-multi-master-environment.yaml"</screen>
-   </step>
-  </procedure>
- </section>
- <section>
-  <title>&caasp; &ostack; Image for &o_orch; &caasp; Playbook</title>
-  <para>
-   By default the &o_orch; &caasp; playbook downloads the &caasp; image from <link
-   xlink:href="http://download.suse.de/install/SUSE-CaaSP-3-GM/SUSE-CaaS-Platform-3.0-for-OpenStack-Cloud.x86_64-3.0.0-GM.qcow2"/>. If
-   this URL is not accessible, the &caasp; image can be downloaded from <link
-   xlink:href="https://download.suse.com/Download?buildid=z7ezhywXXRc"/> and
-   copied to the deployer.
-  </para>
-  <para>
-   To create a &caasp; cluster and pass the path to the downloaded image, run the
-   following commands:
-  </para>
-  <screen>&prompt.ardana;cd ~/scratch/ansible/next/ardana/ansible
-&prompt.ardana;ansible-playbook -i hosts/localhost heat-caasp-deploy.yml -e "caasp_image_tmp_path=~/SUSE-CaaS-Platform-3.0-for-OpenStack-Cloud.x86_64-3.0.0-GM.qcow2"</screen>
-  <para>
-   To create a &caasp; cluster with multiple masters and pass the path to the
-   downloaded image, run the following commands:
-  </para>
-  <screen>&prompt.ardana;cd ~/scratch/ansible/next/ardana/ansible
-&prompt.ardana;ansible-playbook -i hosts/localhost heat-caasp-deploy.yml -e "caasp_image_tmp_path=caasp_image_tmp_path=~/SUSE-CaaS-Platform-3.0-for-OpenStack-Cloud.x86_64-3.0.0-GM.qcow2
- caasp_stack_name=caasp_multi-master caasp_stack_yaml_file=caasp-multi-master-stack.yaml caasp_stack_env_yaml_file=caasp-multi-master-environment.yaml"</screen>
  </section>
  <section>
   <title>Enabling the Cloud Provider Integration (CPI) Feature</title>
@@ -598,11 +500,11 @@ i | sles12-velum-image | package    | 3.1.7-3.27.3  | x86_64 | update_caasp</scr
      <para>
       If your &ostack; service SSL infrastructure was self-signed during the
       installation of &product; (as is done by default), its CA certificate
-      can be retrieved from the &clm; node in the <filename>/etc/ssl/certs/</filename>
-      directory. The filename should match the node name of your primary
-      controller node. For example:
-      <filename>/etc/ssl/certs/ardana-stack1-cp1-core-m1.pem</filename>    
-      Download this file and provide it as the system-wide certificate.</para>
+      (with the file extension <literal>.pem</literal>) can be retrieved from
+      the admin node in the <filename>/etc/ssl/certs/</filename> directory. The
+      filename should match the node name of your primary controller
+      node. Download this file and provide it as the system-wide
+      certificate.</para>
     </note>
     <para>
      The CPI configuration settings match the values provided

--- a/xml/install_caasp_heat_templates.xml
+++ b/xml/install_caasp_heat_templates.xml
@@ -147,7 +147,7 @@ git clone https://github.com/SUSE/caasp-openstack-heat-templates
    checking that the <literal>provisioning_status</literal> changes to
    <literal>Active</literal>.
   </para>
-  <screen>&prompt.ardana;openstack loadbalancer show
+  <screen>$ openstack loadbalancer show
 &lt;<replaceable>LOAD_BALANCER_ID</replaceable>&gt;</screen>
   <para>
    HAProxy is the default load balancer provider in &productname;.
@@ -157,13 +157,13 @@ git clone https://github.com/SUSE/caasp-openstack-heat-templates
    and IPs for a test <literal>lb_net1</literal> network with
    <literal>lb_subnet1</literal> subnet.
   </para>
-  <screen>&prompt.ardana;openstack network create lb_net1
-  &prompt.ardana;openstack subnet create --name lb_subnet1 lb_net1 \
+  <screen>$ openstack network create lb_net1
+  $ openstack subnet create --name lb_subnet1 lb_net1 \
 --subnet-range 172.29.0.0/24 --gateway 172.29.0.2
-&prompt.ardana;openstack router create lb_router1
-&prompt.ardana;openstack router add subnet lb_router1 lb_subnet1
-&prompt.ardana;openstack router set lb_router1 --external-gateway ext-net
-&prompt.ardana;openstack network list</screen>
+$ openstack router create lb_router1
+$ openstack router add subnet lb_router1 lb_subnet1
+$ openstack router set lb_router1 --external-gateway ext-net
+$ openstack network list</screen>
   <procedure>
    <title>Steps to Install &caasp; with Multiple Masters</title>
    <step>
@@ -185,7 +185,7 @@ git clone https://github.com/SUSE/caasp-openstack-heat-templates
      Create a stack in &o_orch; by passing the template, environment file, and
      parameters:
     </para>
-    <screen>&prompt.ardana;openstack stack create -t caasp-multi-master-stack.yaml \
+    <screen>$ openstack stack create -t caasp-multi-master-stack.yaml \
 -e caasp-multi-master-environment.yaml --parameter image=CaaSP-3 caasp-multi-master-stack
     </screen>
    </step>
@@ -196,14 +196,14 @@ git clone https://github.com/SUSE/caasp-openstack-heat-templates
     </para>
     <substeps>
      <step>
-      <screen>&prompt.ardana;openstack loadbalancer list --provider</screen>
+      <screen>$ openstack loadbalancer list --provider</screen>
      </step>
      <step>
       <para>
        From the output, copy the <literal>id</literal> and enter it in the
        following command as shown in the following example:
       </para>
-      <screen>&prompt.ardana;openstack loadbalancer show id</screen>
+      <screen>$ openstack loadbalancer show id</screen>
       <screen>+---------------------+------------------------------------------------+
 | Field               | Value                                          |
 +---------------------+------------------------------------------------+
@@ -228,7 +228,7 @@ git clone https://github.com/SUSE/caasp-openstack-heat-templates
       <para>
        Search the floating IP list for <literal>vip_address</literal>
       </para>
-      <screen>&prompt.ardana;openstack floating ip list | grep 172.28.0.6
+      <screen>$ openstack floating ip list | grep 172.28.0.6
 | d636f3...481b0c | fd7ff...deb4c1 | 172.28.0.6  | 10.84.65.37  | 53ad2...373e8b |</screen>
      </step>
      <step>
@@ -351,104 +351,6 @@ git clone https://github.com/SUSE/caasp-openstack-heat-templates
     </imageobject>
    </mediaobject>
   </informalfigure>
- </section>
- <section>
-  <title>Deploy &caasp; Stack Using &o_orch; &caasp; Playbook</title>
-  <procedure>
-   <step>
-    <para>
-     Install the <package>caasp-openstack-heat-templates</package> package on a
-     machine with &productname; repositories:
-    </para>
-    <screen>&prompt.ardana;zypper in caasp-openstack-heat-templates</screen>
-    <para>
-     The installed templates are located in
-     <filename>/usr/share/caasp-openstack-heat-templates</filename>.
-    </para>
-   </step>
-   <step>
-    <para>
-     Run <filename>heat-caasp-deploy.yml</filename> on the &clm; to create a
-     &caasp; cluster with &o_orch; templates from the
-     <literal>caasp-openstack-heat-templates</literal> package.
-    </para>
-    <screen>&prompt.ardana;cd ~/scratch/ansible/next/ardana/ansible
-&prompt.ardana;ansible-playbook -i hosts/localhost heat-caasp-deploy.yml</screen>
-   </step>
-   <step>
-    <para>
-     In a browser, navigate to the &o_dash; UI to determine the floating IP
-     address assigned to the admin node.
-    </para>
-   </step>
-   <step>
-    <para>
-     Go to http://<replaceable>ADMIN-NODE-FLOATING-IP</replaceable>/ to bring
-     up the Velum dashboard.
-    </para>
-   </step>
-   <step>
-    <para>
-     Complete the web-based bootstrap process to bring up the &caasp;
-     Kubernetes cluster. Refer to the &caasp; documentation for specifics.</para>
-    <para>
-     When prompted, set the <literal>Internal Dashboard Location</literal> to the
-     private network IP address (i.e. in the the 172.x.x.x subnet) of the &caasp;
-     admin node created during the <filename>heat-caasp-deploy.yml</filename>
-     playbook. Do not use the floating IP address which is also associated with
-     the node.
-    </para>
-   </step>
-  </procedure>
- </section>
- <section>
-  <title>Deploy &caasp; Cluster with Multiple Masters Using &o_orch; CaasP
-  Playbook</title>
-  <procedure>
-   <step>
-    <para>
-     Install the <package>caasp-openstack-heat-templates</package> package on a
-     machine with &productname; repositories:
-    </para>
-    <screen>&prompt.ardana;zypper in caasp-openstack-heat-templates</screen>
-    <para>
-     The installed templates are located in
-     <filename>/usr/share/caasp-openstack-heat-templates</filename>.
-    </para>
-   </step>
-   <step>
-    <para>
-     On the &clm;, run the <filename>heat-caasp-deploy.yml</filename> playbook
-     and pass parameters for <literal>caasp_stack_name</literal>,
-     <literal>caasp_stack_yaml_file</literal> and
-     <literal>caasp_stack_env_yaml_file</literal>.
-    </para>
-    <screen>&prompt.ardana;ansible-playbook -i hosts/localhost heat-caasp-deploy.yml -e "caasp_stack_name=caasp_multi-master caasp_stack_yaml_file=caasp-multi-master-stack.yaml caasp_stack_env_yaml_file=caasp-multi-master-environment.yaml"</screen>
-   </step>
-  </procedure>
- </section>
- <section>
-  <title>&caasp; &ostack; Image for &o_orch; &caasp; Playbook</title>
-  <para>
-   By default the &o_orch; &caasp; playbook downloads the &caasp; image from <link
-   xlink:href="http://download.suse.de/install/SUSE-CaaSP-3-GM/SUSE-CaaS-Platform-3.0-for-OpenStack-Cloud.x86_64-3.0.0-GM.qcow2"/>. If
-   this URL is not accessible, the &caasp; image can be downloaded from <link
-   xlink:href="https://download.suse.com/Download?buildid=z7ezhywXXRc"/> and
-   copied to the deployer.
-  </para>
-  <para>
-   To create a &caasp; cluster and pass the path to the downloaded image, run the
-   following commands:
-  </para>
-  <screen>&prompt.ardana;cd ~/scratch/ansible/next/ardana/ansible
-&prompt.ardana;ansible-playbook -i hosts/localhost heat-caasp-deploy.yml -e "caasp_image_tmp_path=~/SUSE-CaaS-Platform-3.0-for-OpenStack-Cloud.x86_64-3.0.0-GM.qcow2"</screen>
-  <para>
-   To create a &caasp; cluster with multiple masters and pass the path to the
-   downloaded image, run the following commands:
-  </para>
-  <screen>&prompt.ardana;cd ~/scratch/ansible/next/ardana/ansible
-&prompt.ardana;ansible-playbook -i hosts/localhost heat-caasp-deploy.yml -e "caasp_image_tmp_path=caasp_image_tmp_path=~/SUSE-CaaS-Platform-3.0-for-OpenStack-Cloud.x86_64-3.0.0-GM.qcow2
- caasp_stack_name=caasp_multi-master caasp_stack_yaml_file=caasp-multi-master-stack.yaml caasp_stack_env_yaml_file=caasp-multi-master-environment.yaml"</screen>
  </section>
  <section>
   <title>Enabling the Cloud Provider Integration (CPI) Feature</title>
@@ -598,11 +500,11 @@ i | sles12-velum-image | package    | 3.1.7-3.27.3  | x86_64 | update_caasp</scr
      <para>
       If your &ostack; service SSL infrastructure was self-signed during the
       installation of &product; (as is done by default), its CA certificate
-      can be retrieved from the &clm; node in the <filename>/etc/ssl/certs/</filename>
-      directory. The filename should match the node name of your primary
-      controller node. For example:
-      <filename>/etc/ssl/certs/ardana-stack1-cp1-core-m1.pem</filename>    
-      Download this file and provide it as the system-wide certificate.</para>
+      (with the file extension <literal>.pem</literal>) can be retrieved from
+      the admin node in the <filename>/etc/ssl/certs/</filename> directory. The
+      filename should match the node name of your primary controller
+      node. Download this file and provide it as the system-wide
+      certificate.</para>
     </note>
     <para>
      The CPI configuration settings match the values provided


### PR DESCRIPTION
The instructions for CaaSP ca-certificates refer to internal SUSE
certificates. These don't work for external customers.

Crowbar instructions for CaaSP and ca-certs refer to CLM steps.
Remove from install-caasp-heat-templates file