### PR TITLE
replace SUSE ca-certificate instructions (bsc#1136569)

### DIFF
--- a/xml/book_cloud_deploy.xml
+++ b/xml/book_cloud_deploy.xml
@@ -47,7 +47,7 @@
   <xi:include href="depl_nodes.xml"/>
   <xi:include href="depl_policy_json.xml"/>
   <xi:include href="depl_ostack_configs.xml"/>
-  <xi:include href="install_caasp_heat_templates.xml"/>
+  <xi:include href="crowbar_install_caasp_heat_templates.xml"/>
   </part>
   <part xml:id="part.depl.nostack">
   <title>Setting Up Non-&ostack; Services</title>

--- a/xml/crowbar_install_caasp_heat_templates.xml
+++ b/xml/crowbar_install_caasp_heat_templates.xml
@@ -147,7 +147,7 @@ git clone https://github.com/SUSE/caasp-openstack-heat-templates
    checking that the <literal>provisioning_status</literal> changes to
    <literal>Active</literal>.
   </para>
-  <screen>&prompt.ardana;openstack loadbalancer show
+  <screen>&prompt.user;openstack loadbalancer show
 &lt;<replaceable>LOAD_BALANCER_ID</replaceable>&gt;</screen>
   <para>
    HAProxy is the default load balancer provider in &productname;.
@@ -157,13 +157,13 @@ git clone https://github.com/SUSE/caasp-openstack-heat-templates
    and IPs for a test <literal>lb_net1</literal> network with
    <literal>lb_subnet1</literal> subnet.
   </para>
-  <screen>&prompt.ardana;openstack network create lb_net1
-  &prompt.ardana;openstack subnet create --name lb_subnet1 lb_net1 \
+  <screen>&prompt.user;openstack network create lb_net1
+  &prompt.user;openstack subnet create --name lb_subnet1 lb_net1 \
 --subnet-range 172.29.0.0/24 --gateway 172.29.0.2
-&prompt.ardana;openstack router create lb_router1
-&prompt.ardana;openstack router add subnet lb_router1 lb_subnet1
-&prompt.ardana;openstack router set lb_router1 --external-gateway ext-net
-&prompt.ardana;openstack network list</screen>
+&prompt.user;openstack router create lb_router1
+&prompt.user;openstack router add subnet lb_router1 lb_subnet1
+&prompt.user;openstack router set lb_router1 --external-gateway ext-net
+&prompt.user;openstack network list</screen>
   <procedure>
    <title>Steps to Install &caasp; with Multiple Masters</title>
    <step>
@@ -185,7 +185,7 @@ git clone https://github.com/SUSE/caasp-openstack-heat-templates
      Create a stack in &o_orch; by passing the template, environment file, and
      parameters:
     </para>
-    <screen>&prompt.ardana;openstack stack create -t caasp-multi-master-stack.yaml \
+    <screen>&prompt.user;openstack stack create -t caasp-multi-master-stack.yaml \
 -e caasp-multi-master-environment.yaml --parameter image=CaaSP-3 caasp-multi-master-stack
     </screen>
    </step>
@@ -196,14 +196,14 @@ git clone https://github.com/SUSE/caasp-openstack-heat-templates
     </para>
     <substeps>
      <step>
-      <screen>&prompt.ardana;openstack loadbalancer list --provider</screen>
+      <screen>&prompt.user;openstack loadbalancer list --provider</screen>
      </step>
      <step>
       <para>
        From the output, copy the <literal>id</literal> and enter it in the
        following command as shown in the following example:
       </para>
-      <screen>&prompt.ardana;openstack loadbalancer show id</screen>
+      <screen>&prompt.user;openstack loadbalancer show id</screen>
       <screen>+---------------------+------------------------------------------------+
 | Field               | Value                                          |
 +---------------------+------------------------------------------------+
@@ -228,7 +228,7 @@ git clone https://github.com/SUSE/caasp-openstack-heat-templates
       <para>
        Search the floating IP list for <literal>vip_address</literal>
       </para>
-      <screen>&prompt.ardana;openstack floating ip list | grep 172.28.0.6
+      <screen>&prompt.user;openstack floating ip list | grep 172.28.0.6
 | d636f3...481b0c | fd7ff...deb4c1 | 172.28.0.6  | 10.84.65.37  | 53ad2...373e8b |</screen>
      </step>
      <step>
@@ -347,98 +347,6 @@ git clone https://github.com/SUSE/caasp-openstack-heat-templates
     </imageobject>
    </mediaobject>
   </informalfigure>
- </section>
- <section>
-  <title>Deploy &caasp; Stack Using &o_orch; &caasp; Playbook</title>
-  <procedure>
-   <step>
-    <para>
-     Install the <package>caasp-openstack-heat-templates</package> package on a
-     machine with &productname; repositories:
-    </para>
-    <screen>&prompt.ardana;zypper in caasp-openstack-heat-templates</screen>
-    <para>
-     The installed templates are located in
-     <filename>/usr/share/caasp-openstack-heat-templates</filename>.
-    </para>
-   </step>
-   <step>
-    <para>
-     Run <filename>heat-caasp-deploy.yml</filename> on the &clm; to create a
-     &caasp; cluster with &o_orch; templates from the
-     <literal>caasp-openstack-heat-templates</literal> package.
-    </para>
-    <screen>&prompt.ardana;cd ~/scratch/ansible/next/ardana/ansible
-&prompt.ardana;ansible-playbook -i hosts/localhost heat-caasp-deploy.yml</screen>
-   </step>
-   <step>
-    <para>
-     In a browser, navigate to the &o_dash; UI to determine the floating IP
-     address assigned to the admin node.
-    </para>
-   </step>
-   <step>
-    <para>
-     Go to http://<replaceable>ADMIN-NODE-FLOATING-IP</replaceable>/ to bring
-     up the Velum dashboard.
-    </para>
-   </step>
-   <step>
-    <para>
-     Follow the steps for <literal>bootstrap</literal> and <literal>add nodes
-     to the cluster</literal> to bring up the &caasp; Kubernetes cluster.
-    </para>
-   </step>
-  </procedure>
- </section>
- <section>
-  <title>Deploy &caasp; Cluster with Multiple Masters Using &o_orch; CaasP
-  Playbook</title>
-  <procedure>
-   <step>
-    <para>
-     Install the <package>caasp-openstack-heat-templates</package> package on a
-     machine with &productname; repositories:
-    </para>
-    <screen>&prompt.ardana;zypper in caasp-openstack-heat-templates</screen>
-    <para>
-     The installed templates are located in
-     <filename>/usr/share/caasp-openstack-heat-templates</filename>.
-    </para>
-   </step>
-   <step>
-    <para>
-     On the &clm;, run the <filename>heat-caasp-deploy.yml</filename> playbook
-     and pass parameters for <literal>caasp_stack_name</literal>,
-     <literal>caasp_stack_yaml_file</literal> and
-     <literal>caasp_stack_env_yaml_file</literal>.
-    </para>
-    <screen>&prompt.ardana;ansible-playbook -i hosts/localhost heat-caasp-deploy.yml -e "caasp_stack_name=caasp_multi-master caasp_stack_yaml_file=caasp-multi-master-stack.yaml caasp_stack_env_yaml_file=caasp-multi-master-environment.yaml"</screen>
-   </step>
-  </procedure>
- </section>
- <section>
-  <title>&caasp; &ostack; Image for &o_orch; &caasp; Playbook</title>
-  <para>
-   By default the &o_orch; &caasp; playbook downloads the &caasp; image from <link
-   xlink:href="http://download.suse.de/install/SUSE-CaaSP-3-GM/SUSE-CaaS-Platform-3.0-for-OpenStack-Cloud.x86_64-3.0.0-GM.qcow2"/>. If
-   this URL is not accessible, the &caasp; image can be downloaded from <link
-   xlink:href="https://download.suse.com/Download?buildid=z7ezhywXXRc"/> and
-   copied to the deployer.
-  </para>
-  <para>
-   To create a &caasp; cluster and pass the path to the downloaded image, run the
-   following commands:
-  </para>
-  <screen>&prompt.ardana;cd ~/scratch/ansible/next/ardana/ansible
-&prompt.ardana;ansible-playbook -i hosts/localhost heat-caasp-deploy.yml -e "caasp_image_tmp_path=~/SUSE-CaaS-Platform-3.0-for-OpenStack-Cloud.x86_64-3.0.0-GM.qcow2"</screen>
-  <para>
-   To create a &caasp; cluster with multiple masters and pass the path to the
-   downloaded image, run the following commands:
-  </para>
-  <screen>&prompt.ardana;cd ~/scratch/ansible/next/ardana/ansible
-&prompt.ardana;ansible-playbook -i hosts/localhost heat-caasp-deploy.yml -e "caasp_image_tmp_path=caasp_image_tmp_path=~/SUSE-CaaS-Platform-3.0-for-OpenStack-Cloud.x86_64-3.0.0-GM.qcow2
- caasp_stack_name=caasp_multi-master caasp_stack_yaml_file=caasp-multi-master-stack.yaml caasp_stack_env_yaml_file=caasp-multi-master-environment.yaml"</screen>
  </section>
  <section>
    <title>Enabling the Cloud Provider Integration (CPI) Feature</title>
@@ -570,7 +478,7 @@ git clone https://github.com/SUSE/caasp-openstack-heat-templates
        <para>
         Log in to each node and add the update repository.
        </para>
-       <screen>&prompt.ardana;sudo zypper ar http://nu.novell.com/SUSE/Updates/SUSE-CAASP/3.0/x86_64/update/ caasp_update</screen>
+       <screen>&prompt.sudo;zypper ar http://nu.novell.com/SUSE/Updates/SUSE-CAASP/3.0/x86_64/update/ caasp_update</screen>
       </step>
       <step>
        <para>
@@ -586,7 +494,7 @@ git clone https://github.com/SUSE/caasp-openstack-heat-templates
        <para>
         Verify that the Velum image packages were updated
        </para>
-       <screen>&prompt.ardana;zypper se --detail velum-image
+       <screen>&prompt.user;zypper se --detail velum-image
 i | sles12-velum-image | package    | 3.1.7-3.27.3  | x86_64 | update_caasp</screen>
       </step>
      </substeps>
@@ -596,46 +504,31 @@ i | sles12-velum-image | package    | 3.1.7-3.27.3  | x86_64 | update_caasp</scr
       Upload a valid trust certificate that can validate a certificate
       presented by &o_ident; at the specified
       <literal>keystone_auth_url</literal> in the <literal>system-wide
-      certificate</literal> section of Velum. The certificate must be uploaded
-      to avoid bootstrapping failure with a <literal>x509: certificate signed
-      by unknown authority</literal> error message.
+      certificate</literal> section of Velum. If the SSL certificate provided
+      by &o_ident; cannot be verified, bootstrapping fails with the error
+      message <literal>x509: certificate signed by unknown authority</literal>.
      </para>
-     <para>
-      Get SUSE Root CA certificate with the following steps:
-     </para>
-     <substeps>
-      <step>
-       <para>
-        From the RPM provided in the repos:
-       </para>
-       <substeps>
-        <step>
-         <para>
-          Add a repository for your distribution at
-          <literal>http://download.suse.de/ibs/SUSE:/CA/</literal>. For
-          example, with <literal>openSUSE Leap</literal>, use
-          <literal>http://download.suse.de/ibs/SUSE:/CA/openSUSE_Leap_15.0/SUSE:CA.repo</literal>
-         </para>
-        </step>
-        <step>
-         <para>
-          Install certificates and find the <filename>.pem</filename> file.
-         </para>
-         <screen>&prompt.ardana;sudo zypper in ca-certificates-suse
-&prompt.ardana;rpm -ql ca-certificates-suse</screen>
-         <para>
-          The path to the cert is <filename>/usr/share/pki/trust/anchors/SUSE_Trust_Root.crt.pem</filename>
-         </para>
-        </step>
-       </substeps>
-      </step>
-      <step>
-       <para>
-        In <literal>system wide certificate</literal> during setup in Velum,
-        upload this certificate so you can bootstrap with CPI.
-     </para>
-      </step>
-     </substeps>
+     <note>
+      <para>
+       If your &ostack; endpoints operate on the Internet, or if the SSL
+       certificates in use have been signed by a public authority, no action is
+       needed to enable secure communication with them.
+      </para>
+      <para>
+       If your &ostack; services operate in a private network using SSL
+       certificates signed by an organizational certificate authority, provide
+       that CA certificate as the system-wide certificate.
+      </para>
+      <para>
+       If your &ostack; service SSL infrastructure was self-signed during the
+       installation of &productname; (as is done by default), its CA
+       certificate (with the file extension <literal>.pem</literal>) can be
+       retrieved from the admin node in the
+       <filename>/etc/ssl/certs/</filename> directory. The filename should
+       match the node name of your primary controller node. Download this file
+       and provide it as the system-wide certificate.
+      </para>
+     </note>
     </step>
     <step>
      <para>

--- a/xml/install_caasp_heat_templates.xml
+++ b/xml/install_caasp_heat_templates.xml
@@ -147,7 +147,7 @@ git clone https://github.com/SUSE/caasp-openstack-heat-templates
    checking that the <literal>provisioning_status</literal> changes to
    <literal>Active</literal>.
   </para>
-  <screen>&prompt.ardana;openstack loadbalancer show
+  <screen>$ openstack loadbalancer show
 &lt;<replaceable>LOAD_BALANCER_ID</replaceable>&gt;</screen>
   <para>
    HAProxy is the default load balancer provider in &productname;.
@@ -157,13 +157,13 @@ git clone https://github.com/SUSE/caasp-openstack-heat-templates
    and IPs for a test <literal>lb_net1</literal> network with
    <literal>lb_subnet1</literal> subnet.
   </para>
-  <screen>&prompt.ardana;openstack network create lb_net1
-  &prompt.ardana;openstack subnet create --name lb_subnet1 lb_net1 \
+  <screen>$ openstack network create lb_net1
+  $ openstack subnet create --name lb_subnet1 lb_net1 \
 --subnet-range 172.29.0.0/24 --gateway 172.29.0.2
-&prompt.ardana;openstack router create lb_router1
-&prompt.ardana;openstack router add subnet lb_router1 lb_subnet1
-&prompt.ardana;openstack router set lb_router1 --external-gateway ext-net
-&prompt.ardana;openstack network list</screen>
+$ openstack router create lb_router1
+$ openstack router add subnet lb_router1 lb_subnet1
+$ openstack router set lb_router1 --external-gateway ext-net
+$ openstack network list</screen>
   <procedure>
    <title>Steps to Install &caasp; with Multiple Masters</title>
    <step>
@@ -185,7 +185,7 @@ git clone https://github.com/SUSE/caasp-openstack-heat-templates
      Create a stack in &o_orch; by passing the template, environment file, and
      parameters:
     </para>
-    <screen>&prompt.ardana;openstack stack create -t caasp-multi-master-stack.yaml \
+    <screen>$ openstack stack create -t caasp-multi-master-stack.yaml \
 -e caasp-multi-master-environment.yaml --parameter image=CaaSP-3 caasp-multi-master-stack
     </screen>
    </step>
@@ -196,14 +196,14 @@ git clone https://github.com/SUSE/caasp-openstack-heat-templates
     </para>
     <substeps>
      <step>
-      <screen>&prompt.ardana;openstack loadbalancer list --provider</screen>
+      <screen>$ openstack loadbalancer list --provider</screen>
      </step>
      <step>
       <para>
        From the output, copy the <literal>id</literal> and enter it in the
        following command as shown in the following example:
       </para>
-      <screen>&prompt.ardana;openstack loadbalancer show id</screen>
+      <screen>$ openstack loadbalancer show id</screen>
       <screen>+---------------------+------------------------------------------------+
 | Field               | Value                                          |
 +---------------------+------------------------------------------------+
@@ -228,7 +228,7 @@ git clone https://github.com/SUSE/caasp-openstack-heat-templates
       <para>
        Search the floating IP list for <literal>vip_address</literal>
       </para>
-      <screen>&prompt.ardana;openstack floating ip list | grep 172.28.0.6
+      <screen>$ openstack floating ip list | grep 172.28.0.6
 | d636f3...481b0c | fd7ff...deb4c1 | 172.28.0.6  | 10.84.65.37  | 53ad2...373e8b |</screen>
      </step>
      <step>
@@ -347,98 +347,6 @@ git clone https://github.com/SUSE/caasp-openstack-heat-templates
     </imageobject>
    </mediaobject>
   </informalfigure>
- </section>
- <section>
-  <title>Deploy &caasp; Stack Using &o_orch; &caasp; Playbook</title>
-  <procedure>
-   <step>
-    <para>
-     Install the <package>caasp-openstack-heat-templates</package> package on a
-     machine with &productname; repositories:
-    </para>
-    <screen>&prompt.ardana;zypper in caasp-openstack-heat-templates</screen>
-    <para>
-     The installed templates are located in
-     <filename>/usr/share/caasp-openstack-heat-templates</filename>.
-    </para>
-   </step>
-   <step>
-    <para>
-     Run <filename>heat-caasp-deploy.yml</filename> on the &clm; to create a
-     &caasp; cluster with &o_orch; templates from the
-     <literal>caasp-openstack-heat-templates</literal> package.
-    </para>
-    <screen>&prompt.ardana;cd ~/scratch/ansible/next/ardana/ansible
-&prompt.ardana;ansible-playbook -i hosts/localhost heat-caasp-deploy.yml</screen>
-   </step>
-   <step>
-    <para>
-     In a browser, navigate to the &o_dash; UI to determine the floating IP
-     address assigned to the admin node.
-    </para>
-   </step>
-   <step>
-    <para>
-     Go to http://<replaceable>ADMIN-NODE-FLOATING-IP</replaceable>/ to bring
-     up the Velum dashboard.
-    </para>
-   </step>
-   <step>
-    <para>
-     Follow the steps for <literal>bootstrap</literal> and <literal>add nodes
-     to the cluster</literal> to bring up the &caasp; Kubernetes cluster.
-    </para>
-   </step>
-  </procedure>
- </section>
- <section>
-  <title>Deploy &caasp; Cluster with Multiple Masters Using &o_orch; CaasP
-  Playbook</title>
-  <procedure>
-   <step>
-    <para>
-     Install the <package>caasp-openstack-heat-templates</package> package on a
-     machine with &productname; repositories:
-    </para>
-    <screen>&prompt.ardana;zypper in caasp-openstack-heat-templates</screen>
-    <para>
-     The installed templates are located in
-     <filename>/usr/share/caasp-openstack-heat-templates</filename>.
-    </para>
-   </step>
-   <step>
-    <para>
-     On the &clm;, run the <filename>heat-caasp-deploy.yml</filename> playbook
-     and pass parameters for <literal>caasp_stack_name</literal>,
-     <literal>caasp_stack_yaml_file</literal> and
-     <literal>caasp_stack_env_yaml_file</literal>.
-    </para>
-    <screen>&prompt.ardana;ansible-playbook -i hosts/localhost heat-caasp-deploy.yml -e "caasp_stack_name=caasp_multi-master caasp_stack_yaml_file=caasp-multi-master-stack.yaml caasp_stack_env_yaml_file=caasp-multi-master-environment.yaml"</screen>
-   </step>
-  </procedure>
- </section>
- <section>
-  <title>&caasp; &ostack; Image for &o_orch; &caasp; Playbook</title>
-  <para>
-   By default the &o_orch; &caasp; playbook downloads the &caasp; image from <link
-   xlink:href="http://download.suse.de/install/SUSE-CaaSP-3-GM/SUSE-CaaS-Platform-3.0-for-OpenStack-Cloud.x86_64-3.0.0-GM.qcow2"/>. If
-   this URL is not accessible, the &caasp; image can be downloaded from <link
-   xlink:href="https://download.suse.com/Download?buildid=z7ezhywXXRc"/> and
-   copied to the deployer.
-  </para>
-  <para>
-   To create a &caasp; cluster and pass the path to the downloaded image, run the
-   following commands:
-  </para>
-  <screen>&prompt.ardana;cd ~/scratch/ansible/next/ardana/ansible
-&prompt.ardana;ansible-playbook -i hosts/localhost heat-caasp-deploy.yml -e "caasp_image_tmp_path=~/SUSE-CaaS-Platform-3.0-for-OpenStack-Cloud.x86_64-3.0.0-GM.qcow2"</screen>
-  <para>
-   To create a &caasp; cluster with multiple masters and pass the path to the
-   downloaded image, run the following commands:
-  </para>
-  <screen>&prompt.ardana;cd ~/scratch/ansible/next/ardana/ansible
-&prompt.ardana;ansible-playbook -i hosts/localhost heat-caasp-deploy.yml -e "caasp_image_tmp_path=caasp_image_tmp_path=~/SUSE-CaaS-Platform-3.0-for-OpenStack-Cloud.x86_64-3.0.0-GM.qcow2
- caasp_stack_name=caasp_multi-master caasp_stack_yaml_file=caasp-multi-master-stack.yaml caasp_stack_env_yaml_file=caasp-multi-master-environment.yaml"</screen>
  </section>
  <section>
    <title>Enabling the Cloud Provider Integration (CPI) Feature</title>
@@ -570,7 +478,7 @@ git clone https://github.com/SUSE/caasp-openstack-heat-templates
        <para>
         Log in to each node and add the update repository.
        </para>
-       <screen>&prompt.ardana;sudo zypper ar http://nu.novell.com/SUSE/Updates/SUSE-CAASP/3.0/x86_64/update/ caasp_update</screen>
+       <screen>$ sudo zypper ar http://nu.novell.com/SUSE/Updates/SUSE-CAASP/3.0/x86_64/update/ caasp_update</screen>
       </step>
       <step>
        <para>
@@ -586,7 +494,7 @@ git clone https://github.com/SUSE/caasp-openstack-heat-templates
        <para>
         Verify that the Velum image packages were updated
        </para>
-       <screen>&prompt.ardana;zypper se --detail velum-image
+       <screen>$ zypper se --detail velum-image
 i | sles12-velum-image | package    | 3.1.7-3.27.3  | x86_64 | update_caasp</screen>
       </step>
      </substeps>
@@ -596,46 +504,32 @@ i | sles12-velum-image | package    | 3.1.7-3.27.3  | x86_64 | update_caasp</scr
       Upload a valid trust certificate that can validate a certificate
       presented by &o_ident; at the specified
       <literal>keystone_auth_url</literal> in the <literal>system-wide
-      certificate</literal> section of Velum. The certificate must be uploaded
-      to avoid bootstrapping failure with a <literal>x509: certificate signed
-      by unknown authority</literal> error message.
+      certificate</literal> section of Velum. If the SSL certificate provided
+      by &o_ident; cannot be verified, bootstrapping fails with the error
+      <literal>x509: certificate signed by unknown authority</literal> error
+      message.
      </para>
-     <para>
-      Get SUSE Root CA certificate with the following steps:
-     </para>
-     <substeps>
-      <step>
-       <para>
-        From the RPM provided in the repos:
-       </para>
-       <substeps>
-        <step>
-         <para>
-          Add a repository for your distribution at
-          <literal>http://download.suse.de/ibs/SUSE:/CA/</literal>. For
-          example, with <literal>openSUSE Leap</literal>, use
-          <literal>http://download.suse.de/ibs/SUSE:/CA/openSUSE_Leap_15.0/SUSE:CA.repo</literal>
-         </para>
-        </step>
-        <step>
-         <para>
-          Install certificates and find the <filename>.pem</filename> file.
-         </para>
-         <screen>&prompt.ardana;sudo zypper in ca-certificates-suse
-&prompt.ardana;rpm -ql ca-certificates-suse</screen>
-         <para>
-          The path to the cert is <filename>/usr/share/pki/trust/anchors/SUSE_Trust_Root.crt.pem</filename>
-         </para>
-        </step>
-       </substeps>
-      </step>
-      <step>
-       <para>
-        In <literal>system wide certificate</literal> during setup in Velum,
-        upload this certificate so you can bootstrap with CPI.
-     </para>
-      </step>
-     </substeps>
+     <note>
+      <para>
+       If your &ostack; endpoints operate on the Internet, or if the SSL
+       certificates in use have been signed by a public authority, no action is
+       needed to enable secure communication with them.
+      </para>
+      <para>
+       If your &ostack; services operate in a private network using SSL
+       certificates signed by an organizational certificate authority, provide
+       that CA certificate as the system-wide certificate.
+      </para>
+      <para>
+       If your &ostack; service SSL infrastructure was self-signed during the
+       installation of &productname; (as is done by default), its CA
+       certificate (with the file extension <literal>.pem</literal>) can be
+       retrieved from the admin node in the
+       <filename>/etc/ssl/certs/</filename> directory. The filename should
+       match the node name of your primary controller node. Download this file
+       and provide it as the system-wide certificate.
+      </para>
+     </note>
     </step>
     <step>
      <para>


### PR DESCRIPTION
SUSE ca-certificate instructions are not appropriate for
self-certificate or other certificate providers. Replace
instructions.

remove ardana prompts and CLM instructions (bsc#1136569)
ardana references don't belong in Crowbar documentation.