### PR TITLE
MANAGEMENT network group name cannot be changed (bsc#1142686)

### DIFF
--- a/xml/planning-architecture-input_model-concepts-networkgroups.xml
+++ b/xml/planning-architecture-input_model-concepts-networkgroups.xml
@@ -25,7 +25,7 @@
  </para>
  <para>
   In terms of <guimenu>service</guimenu> connectivity, all that has to be
-  captured in the <guimenu>network-groups</guimenu> definition is the same
+  captured in the <guimenu>network-groups</guimenu> definition are the same
   service-component names that are used when defining
   <guimenu>control-planes</guimenu>. &kw-hos; also allows a default attachment
   to be used to specify "all service-components" that are not explicitly
@@ -35,6 +35,12 @@
   <guimenu>network-group</guimenu> and all other services are connected to
   "Management" <guimenu>network-group</guimenu> via the default relationship.
  </para>
+ <note>
+  <para>
+   The name of the "Management" <guimenu>network-group</guimenu> cannot be
+   changed. Doing so may cause failures in some situations.
+  </para>
+ </note>
  <para>
   The details of how each service connects, such as what port it uses, if it
   should be behind a load balancer, if and how it should be registered in

--- a/xml/planning-architecture-input_model-configobj-networkgroups.xml
+++ b/xml/planning-architecture-input_model-configobj-networkgroups.xml
@@ -11,6 +11,12 @@
   connections use TLS, and network routing. They also provide the data needed
   to map Neutron's network configuration to the physical networking.
  </para>
+  <note>
+  <para>
+   The name of the "Management" <guimenu>network-group</guimenu> cannot be
+   changed. Doing so may cause failures in some situations.
+  </para>
+ </note>
 <screen>---
   product:
      version: 2


### PR DESCRIPTION
In some likely situations, changing the name of the MANAGEMENT
network group will cause failure. Not catastrophic, but
identifying root cause is difficult.

(cherry picked from commit ac26fea2bf33c54463956dd21eeab60ab08629de)