### PR TITLE
warning about .j2 file comments (bsc#1142521)

### DIFF
--- a/xml/operations-cloudadmin_cli.xml
+++ b/xml/operations-cloudadmin_cli.xml
@@ -12,10 +12,6 @@
   Cloud admins can use the command line tools to perform domain admin tasks
   such as user and project administration.
  </para>
- <para>
-  Cloud admins can use the command line tools to perform domain admin tasks
-  such as user and project administration.
- </para>
  <section xml:id="idg-all-operations-cloudadmin_cli-xml-4">
   <title>Creating Additional Cloud Admins</title>
   <para>
@@ -43,7 +39,7 @@
  <section xml:id="idg-all-operations-cloudadmin_cli-xml-5">
   <title>Command Line Examples</title>
   <para>
-   For a full list of commands, see
+   For a full list of OpenStackClient commands, see
    <link xlink:href="http://docs.openstack.org/developer/python-openstackclient/command-list.html">OpenStackClient
    Command List</link>.
   </para>
@@ -593,6 +589,13 @@ cinder_admin</screen>
    <literal>~/scratch/ansible/next/ardana/ansible</literal> and run this
    command:
   </para>
-<screen>ls –l | grep reconfigure</screen>
+  <screen>ls –l | grep reconfigure</screen>
+  <note xml:id="note-j2-comments">
+   <para>
+    Comments added to any <filename>*.j2</filename> files (including templates)
+    must follow proper comment syntax. Otherwise you may see errors when
+    running the config-processor or any of the service playbooks.
+   </para>
+  </note>
  </section>
 </chapter>


### PR DESCRIPTION
.j2 comments must follow the format {# comment #}. Incorrectly
formatted comments may cause fatal errors.
remove duplicate content

(cherry picked from commit fc54e48d41aab703c813631b16784796ec39cea9)