### PR TITLE
Update CLM deploy verification steps (SOC-8980)

### DIFF
--- a/xml/installation-installation-cloud_verification.xml
+++ b/xml/installation-installation-cloud_verification.xml
@@ -19,4 +19,7 @@
   </para>
  </important>
  <xi:include href="installation-installation-api_verification.xml"/>
+ <xi:include href="installation-installation-verify_swift.xml"/>
+ <xi:include href="installation-operations-upload_image.xml"/>
+ <xi:include href="installation-operations-create_extnet.xml"/>
 </chapter>

--- a/xml/installation-installation-ui_verification.xml
+++ b/xml/installation-installation-ui_verification.xml
@@ -13,7 +13,4 @@
   installation.
  </para>
  <xi:include href="installation-installation-verify_block_storage.xml"/>
- <xi:include href="installation-installation-verify_swift.xml"/>
- <xi:include href="installation-operations-upload_image.xml"/>
- <xi:include href="installation-operations-create_extnet.xml"/>
 </chapter>


### PR DESCRIPTION
The current placement of the verification steps
were in the incorrect place as they are not ui
verification. This updates the guide correctly.