### PR TITLE
Updating README with upstream docs build instructions (noref)

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -18,18 +18,20 @@ The following guides are available:
 ** Supplement to Administrator Guide and User Guide
 
 These guides are all maintained and created in this GitHub
-repository .
+repository. Released versions of these guides have been published at
+https://www.suse.com/documentation/.
 
-The folowing guides are available upstream:
+The following guides are built directly from upstream OpenStack sources:
 
 ** Administration Guide
 ** User Guide
 
 These guides are all maintained upstream in the various OpenStack
-project repositories. Released versions of these guides have been
-generated using the `suse_sphinx_theme` and published at
-https://www.suse.com/documentation/. This setup can be found
-here: https://github.com/SUSE-Cloud/doc-cloud-upstream
+project repositories. Released versions of the upstream OpenStack guides
+have been built using the `suse_sphinx_theme`.
+
+Released versions of these guides have also been published at
+https://www.suse.com/documentation/.
 
 Branches
 --------
@@ -129,7 +131,7 @@ Building upstream docs
 
 If you're required to build the upstream Administration and User Guides, you can build and view each individual guide upstream: https://docs.openstack.org/doc-contrib-guide/docs-builds.html 
 
-If you want to build the SUSE version that is published at suse.com/documentation, perform the following:
+If you want to build the SUSE version, equivalent to what is published at at suse.com/documentation, perform the following:
 
 1. Clone https://github.com/SUSE-Cloud/doc-cloud-upstream
 2. Change into the `/scripts/` directory:

--- a/README.adoc
+++ b/README.adoc
@@ -131,19 +131,7 @@ Building upstream docs
 
 If you're required to build the upstream Administration and User Guides, you can build and view each individual guide upstream: https://docs.openstack.org/doc-contrib-guide/docs-builds.html 
 
-If you want to build the SUSE version, equivalent to what is published at at suse.com/documentation, perform the following:
-
-1. Clone https://github.com/SUSE-Cloud/doc-cloud-upstream
-2. Change into the `/scripts/` directory:
-   
-   $ cd scripts
-   
-3. Run `./gen_docs.sh`
-
-   This process clones every repository required, and builds them using the `suse_sphinx_theme`. You need to allocate at
-   least an hour for the process to complete.
-   
-4. You can find the finished product in the `/scripts/build/` folder.
+If you want to build the SUSE version, equivalent to what is published at at suse.com/documentation, see the instructions on how to build here: https://github.com/SUSE-Cloud/doc-cloud-upstream/README
 
 Quick start building the docs
 -----------------------------

--- a/README.adoc
+++ b/README.adoc
@@ -16,11 +16,20 @@ The following guides are available:
 * SUSE OpenStack Cloud, General:
 ** Security Guide
 ** Supplement to Administrator Guide and User Guide
+
+These guides are all maintained and created in this GitHub
+repository .
+
+The folowing guides are available upstream:
+
 ** Administration Guide
 ** User Guide
 
-Released versions of these guides have been published at
-https://www.suse.com/documentation/.
+These guides are all maintained upstream in the various OpenStack
+project repositories. Released versions of these guides have been
+generated using the `suse_sphinx_theme` and published at
+https://www.suse.com/documentation/. This setup can be found
+here: https://github.com/SUSE-Cloud/doc-cloud-upstream
 
 Branches
 --------
@@ -114,6 +123,25 @@ our daps2docker project: https://github.com/openSUSE/daps2docker
 1. Install Docker
 2. Clone the daps2docker repository.
 3. Run  `./daps2docker.sh /PATH/TO/DOC-DIR` or `/daps2docker.sh /PATH/TO/DC-FILE`.
+
+Building upstream docs
+~~~~~~~~~~~~~~~~~~~~~~
+
+If you're required to build the upstream Administration and User Guides, you can build and view each individual guide upstream: https://docs.openstack.org/doc-contrib-guide/docs-builds.html 
+
+If you want to build the SUSE version that is published at suse.com/documentation, perform the following:
+
+1. Clone https://github.com/SUSE-Cloud/doc-cloud-upstream
+2. Change into the `/scripts/` directory:
+   
+   $ cd scripts
+   
+3. Run `./gen_docs.sh`
+
+   This process clones every repository required, and builds them using the `suse_sphinx_theme`. You need to allocate at
+   least an hour for the process to complete.
+   
+4. You can find the finished product in the `/scripts/build/` folder.
 
 Quick start building the docs
 -----------------------------

--- a/README.adoc
+++ b/README.adoc
@@ -131,7 +131,7 @@ Building upstream docs
 
 If you're required to build the upstream Administration and User Guides, you can build and view each individual guide upstream: https://docs.openstack.org/doc-contrib-guide/docs-builds.html 
 
-If you want to build the SUSE version, equivalent to what is published at at suse.com/documentation, see the instructions on how to build here: https://github.com/SUSE-Cloud/doc-cloud-upstream/README
+If you want to build the SUSE version, equivalent to what is published at at suse.com/documentation, see the instructions on how to build here: https://github.com/SUSE-Cloud/doc-cloud-upstream/blob/rocky/README
 
 Quick start building the docs
 -----------------------------


### PR DESCRIPTION
Updating the README with instructions on how to build upstream guides for future ref. I would recommend testing these instructions before merge, please.