### PR TITLE
remove NSX references from Crowbar deployment (SOC-10081)

### DIFF
--- a/xml/depl_nodes.xml
+++ b/xml/depl_nodes.xml
@@ -3137,10 +3137,10 @@ host1:/srv/nfs/share1 /mnt/nfs/share1 -o rsize=8192,wsize=8192,timeo=14,intr
   </para>
 
   <para>
-   The <guimenu>vmware</guimenu> option lets you use an existing VMWare NSX
-   installation. Using this plugin is not a prerequisite for the VMWare vSphere
-   hypervisor support. However, it is needed when wanting to have security
-   groups supported on VMWare compute nodes. For all other scenarios, choose
+
+   The <guimenu>vmware</guimenu> option lets you use an existing &vmware;
+   installation. Using this plug-in is not a prerequisite for the &vmware;
+   vSphere hypervisor support. For all other scenarios, choose
    <guimenu>ml2</guimenu>.
   </para>
 
@@ -3161,9 +3161,9 @@ host1:/srv/nfs/share1 /mnt/nfs/share1 -o rsize=8192,wsize=8192,timeo=14,intr
     </term>
     <listitem>
      <para>
-      Select which mechanism driver(s) shall be enabled for the ml2 plugin. It
-      is possible to select more than one driver by holding the
-      <keycap function="control"/> key while clicking. Choices are:
+      Select which mechanism driver(s) shall be enabled for the ml2 plug-in. It
+      is possible to select more than one driver by holding the <keycap
+      function="control"/> key while clicking. Choices are:
      </para>
      <formalpara>
       <title><guimenu>openvswitch</guimenu></title>
@@ -3334,51 +3334,6 @@ host1:/srv/nfs/share1 /mnt/nfs/share1 -o rsize=8192,wsize=8192,timeo=14,intr
       Net mask of the xCAT management interface.
       <remark>
             2016-12-29 - dpopov: DEVS FIXME Please check whether this is correct.</remark>
-     </para>
-    </listitem>
-   </varlistentry>
-  </variablelist>
-
-  <bridgehead renderas="sect2"><guimenu>vmware</guimenu>
-  </bridgehead>
-
-  <para>
-   This plug-in requires to configure access to the VMWare NSX service.
-  </para>
-
-  <variablelist>
-   <varlistentry>
-    <term><guimenu>VMWare NSX User Name/Password</guimenu>
-    </term>
-    <listitem>
-     <para>
-      Login credentials for the VMWare NSX server. The user needs to have
-      administrator permissions on the NSX server.
-     </para>
-    </listitem>
-   </varlistentry>
-   <varlistentry>
-    <term><guimenu>VMWare NSX Controllers</guimenu>
-    </term>
-    <listitem>
-     <para>
-      Enter the IP address and the port number
-      (<replaceable>IP-ADDRESS</replaceable>:<replaceable>PORT</replaceable>)
-      of the controller API endpoint. If the port number is omitted, port 443
-      will be used. You may also enter multiple API endpoints
-      (comma-separated), provided they all belong to the same controller
-      cluster. When multiple API endpoints are specified, the plugin will load
-      balance requests on the various API endpoints.
-     </para>
-    </listitem>
-   </varlistentry>
-   <varlistentry>
-    <term><guimenu>UUID of the NSX Transport Zone/Gateway Service</guimenu>
-    </term>
-    <listitem>
-     <para>
-      The UUIDs for the transport zone and the gateway service can be obtained
-      from the NSX server. They will be used when networks are created.
      </para>
     </listitem>
    </varlistentry>
@@ -4196,7 +4151,7 @@ sudo neutron router-interface-add <replaceable>router2</replaceable> priv-net-su
     <title>vmware_dvs must be enabled</title>
     <para>
       Deploying <guimenu>nova-compute-vmware</guimenu> nodes will not result in
-      a functional cloud setup if the <guimenu>vmware_dvs</guimenu> ML2 plugin
+      a functional cloud setup if the <guimenu>vmware_dvs</guimenu> ML2 plug-in
       is not enabled in the &o_netw; &barcl;.
      </para>
     </warning>
@@ -5425,7 +5380,7 @@ sudo neutron router-interface-add <replaceable>router2</replaceable> priv-net-su
     </listitem>
    </varlistentry>
    <varlistentry>
-    <term><guimenu>Certificate Manager</guimenu>: <guimenu>Plugin</guimenu>
+    <term><guimenu>Certificate Manager</guimenu>: <guimenu>Plug-in</guimenu>
     </term>
     <listitem>
      <para>
@@ -5546,7 +5501,7 @@ sudo neutron router-interface-add <replaceable>router2</replaceable> priv-net-su
     <para>
      <literal>kek</literal> An encryption key (fixed-length 32-byte
      Base64-encoded value) for &secret_store;'s
-     <systemitem>simple_crypto</systemitem> plugin. If left unspecified, the
+     <systemitem>simple_crypto</systemitem> plug-in. If left unspecified, the
      key will be generated automatically.
     </para>
     <note>
@@ -6115,6 +6070,231 @@ monasca-installer on the &crow; node</guimenu>
     <listitem>
      <para>
       Sender address for alarm notifications.
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+
+<bridgehead renderas="sect3"><guimenu>monasca: settings for libvirt and &ceph;
+monitoring</guimenu>
+  </bridgehead>
+  <variablelist>
+   <varlistentry>
+    <term>
+     monitor_libvirt
+    </term>
+    <listitem>
+     <para>
+      The global switch for toggling libvirt monitoring. If set to
+      <parameter>true</parameter>, libvirt metrics will be gathered on all
+      libvirt based &compnode;s. This setting is available in the &crow; UI.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term>
+     monitor_ceph
+    </term>
+    <listitem>
+     <para>
+      The global switch for toggling &ceph; monitoring. If set to
+      <parameter>true</parameter>, &ceph; metrics will be gathered on all
+      &ceph;-based &compnode;s. This setting is available in &crow; UI. If the
+      &ceph; cluster has been set up independently, &crow; ignores this setting.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term>
+     cache_dir
+    </term>
+    <listitem>
+     <para>
+      The directory where monasca-agent will locally cache various metadata
+      about locally running VMs on each &compnode;.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term>
+     customer_metadata
+    </term>
+    <listitem>
+     <para>
+      Specifies the list of instance metadata keys to be included as dimensions
+      with customer metrics. This is useful for providing more information
+      about an instance.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term>
+     disk_collection_period
+    </term>
+    <listitem>
+     <para>
+      Specifies a minimum interval in seconds for collecting disk metrics.
+      Increase this value to reduce I/O load. If the value is lower than the
+      global agent collection period (<option>check_frequency</option>), it
+      will be ignored in favor of the global collection period.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term>
+     max_ping_concurrency
+    </term>
+    <listitem>
+     <para>
+      Specifies the number of ping command processes to run concurrently when
+      determining whether the VM is reachable. This should be set to a value
+      that allows the plug-in to finish within the agent's collection period,
+      even if there is a networking issue. For example, if the expected number
+      of VMs per &compnode; is 40 and each VM has one IP address, then the
+      plug-in will take at least 40 seconds to do the ping checks in the
+      worst-case scenario where all pings fail (assuming the default timeout of
+      1 second). Increasing <option>max_ping_concurrency</option> allows the
+      plug-in to finish faster.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term>
+     metadata
+    </term>
+    <listitem>
+     <para>
+      Specifies the list of &o_comp; side instance metadata keys to be included
+      as dimensions with the cross-tenant metrics for the
+      <guimenu>monasca</guimenu> project. This is useful for providing more
+      information about an instance.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term>
+     nova_refresh
+    </term>
+    <listitem>
+     <para>
+      Specifies the number of seconds between calls to the &o_comp; API to
+      refresh the instance cache. This is helpful for updating VM hostname and
+      pruning deleted instances from the cache. By default, it is set to 14,400
+      seconds (four hours). Set to 0 to refresh every time the Collector runs,
+      or to <parameter>None</parameter> to disable regular refreshes entirely.
+      In this case, the instance cache will only be refreshed when a new
+      instance is detected.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term>
+     ping_check
+    </term>
+    <listitem>
+     <para>
+      Includes the entire ping command (without the IP address, which is
+      automatically appended) to perform a ping check against instances. The
+      <literal>NAMESPACE</literal> keyword is automatically replaced with the
+      appropriate network namespace for the VM being monitored. Set to
+      <parameter>False</parameter> to disable ping checks.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term>
+     vnic_collection_period
+    </term>
+    <listitem>
+     <para>
+      Specifies a minimum interval in seconds for collecting disk metrics.
+      Increase this value to reduce I/O load. If the value is lower than the
+      global agent collection period (<option>check_frequency</option>), it
+      will be ignored in favor of the global collection period.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term>
+     vm_cpu_check_enable
+    </term>
+    <listitem>
+     <para>
+      Toggles the collection of VM CPU metrics. Set to
+      <parameter>true</parameter> to enable.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term>
+     vm_disks_check_enable
+    </term>
+    <listitem>
+     <para>
+      Toggles the collection of VM disk metrics. Set to
+      <parameter>true</parameter> to enable.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term>
+     vm_extended_disks_check_enable
+    </term>
+    <listitem>
+     <para>
+      Toggles the collection of extended disk metrics. Set to
+      <parameter>true</parameter> to enable.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term>
+     vm_network_check_enable
+    </term>
+    <listitem>
+     <para>
+      Toggles the collection of VM network metrics. Set to
+      <parameter>true</parameter> to enable.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term>
+     vm_ping_check_enable
+    </term>
+    <listitem>
+     <para>
+      Toggles ping checks for checking whether a host is alive. Set to
+      <parameter>true</parameter> to enable.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term>
+     vm_probation
+    </term>
+    <listitem>
+     <para>
+      Specifies a period of time (in seconds) in which to suspend metrics from
+      a newly-created VM. This is to prevent quickly-obsolete metrics in an
+      environment with a high amount of instance churn (VMs created and
+      destroyed in rapid succession). The default probation length is 300
+      seconds (5 minutes). Set to 0 to disable VM probation. In this case,
+      metrics are recorded immediately after a VM is created.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term>
+     vnic_collection_period
+    </term>
+    <listitem>
+     <para>
+      Specifies a minimum interval in seconds for collecting VM network
+      metrics. Increase this value to reduce I/O load. If the value is lower
+      than the global agent collection period
+      (<parameter>check_frequency</parameter>), it will be ignored in favor of
+      the global collection period.
      </para>
     </listitem>
    </varlistentry>

--- a/xml/depl_vmware.xml
+++ b/xml/depl_vmware.xml
@@ -65,14 +65,6 @@
      gre</literal> plug-in, a VLAN setup is required.
     </para>
    </listitem>
-   <listitem>
-    <para>
-     Security groups are only supported when running VMWare NSX. You need to
-     deploy &o_netw; with the <guimenu>vmware</guimenu> plug-in to have
-     security group support. This is also a prerequisite for
-     <literal>gre</literal> tunnel support.
-    </para>
-   </listitem>
   </itemizedlist>
  </sect1>
  <sect1 xml:id="app-deploy-vmware-vcenter">


### PR DESCRIPTION
NSX on SOC 7 and 8 Crowbar was not tested or qualified.

make plug-in consistent with hyphen (SOC-10081)
plug-in is the format specified in the Style Guide

(cherry picked from commit 23c491cfb57a5e237b5bf9f80e035137b5fcf876)