### PR TITLE
MANAGEMENT network group cannot be changed, is required (SOC-10106)

### DIFF
--- a/xml/planning-architecture-input_model-concepts-networkgroups.xml
+++ b/xml/planning-architecture-input_model-concepts-networkgroups.xml
@@ -33,12 +33,13 @@
   isolate Swift traffic, the swift-account, swift-container, and swift-object
   service components are attached to an "Object"
   <guimenu>network-group</guimenu> and all other services are connected to
-  "Management" <guimenu>network-group</guimenu> via the default relationship.
+  "MANAGEMENT" <guimenu>network-group</guimenu> via the default relationship.
  </para>
  <note>
   <para>
-   The name of the "Management" <guimenu>network-group</guimenu> cannot be
-   changed. Doing so may cause failures in some situations.
+   The name of the "MANAGEMENT" <guimenu>network-group</guimenu> cannot be
+   changed. It must be upper case. Every &cloud; requires this network group in
+   order to be valid.
   </para>
  </note>
  <para>

--- a/xml/planning-architecture-input_model-configobj-networkgroups.xml
+++ b/xml/planning-architecture-input_model-configobj-networkgroups.xml
@@ -13,8 +13,9 @@
  </para>
   <note>
   <para>
-   The name of the "Management" <guimenu>network-group</guimenu> cannot be
-   changed. Doing so may cause failures in some situations.
+   The name of the "MANAGEMENT" <guimenu>network-group</guimenu> cannot be
+   changed. It must be upper case. Every &cloud; requires this network group in
+   order to be valid.
   </para>
  </note>
 <screen>---


### PR DESCRIPTION
MANAGEMENT network group name is not just a good idea. Must be in
upper case, cannot be changed.