### PR TITLE
add workaround for partition image resize (bsc#1145498)

### DIFF
--- a/xml/installation-installation-ironic-ironic_troubleshooting.xml
+++ b/xml/installation-installation-ironic-ironic_troubleshooting.xml
@@ -505,11 +505,14 @@ IRN-CND -m copy -b -a 'src=~/undionly.kpxe dest=/tftpboot'
      </para>
     </listitem>
    </itemizedlist>
+   <para>
+    <emphasis role="bold">ISO Image Exceeds Free Space</emphasis>
+   </para>
   <para>
-   When using the <systemitem>agent_ilo</systemitem> driver, provision will
-   fail if the size of the user image exceeds the free space
-   available on the ramdisk partition. This will produce an error in the &o_iron;
-   Conductor logs that may look like as follows
+   When using the <systemitem>agent_ilo</systemitem> driver, provisioning will
+   fail if the size of the user ISO image exceeds the free space available on
+   the ramdisk partition. This will produce an error in the &o_iron; Conductor
+   logs that may look like as follows:
   </para>
 <screen>"ERROR root [-] Command failed: prepare_image, error: Error downloading
 image: Download of image id 0c4d74e4-58f1-4f8d-8c1d-8a49129a2163 failed: Unable
@@ -606,11 +609,52 @@ boot_method=vmedia showopts</screen>
    </step>
    <step>
     <para>
-     Re-create or update the &o_iron; node, if needed. <!-- FIXME: This sentence
-     makes no sense, but devs are unresponsive.
-     If you cannot use the same
-     image ID in the previous step, you must update the &o_iron; node with the
-     same image ID. -->
+     Re-deploy the &o_iron; node.
+    </para>
+   </step>
+  </procedure>
+   <para>
+    <emphasis role="bold">Partition Image Exceeds Free Space</emphasis>
+   </para>
+  <para>
+   The previous procedure applies to ISO images. It does not apply to
+   <literal>partition images</literal>, although there will be a similar error
+   in the &o_iron; logs. However the resolution is different. An option must be
+   added to the <literal>PXE</literal> line in the
+   <filename>main.yml</filename> file to increase the <filename>/tmp</filename>
+   disk size with the following workaround:
+  </para>
+  <procedure>
+   <step>
+    <para>
+     Edit
+     <filename>/openstack/ardana/ansible/roles/ironic-common/defaults/main.yml</filename>.
+    </para>
+   </step>
+   <step>
+    <para>
+     Add <literal>suse.tmpsize=4G</literal> to
+     <literal>pxe_append_params</literal>. Adjust the size of
+     <literal>suse.tmpsize</literal> as needed for the partition image.
+    </para>
+    <screen>pxe_append_params : "nofb nomodeset vga=normal elevator=deadline
+                     security=apparmor crashkernel=256M console=tty0
+                     console=ttyS0 suse.tmpsize=4G"</screen>
+   </step>
+   <step>
+    <para>
+     Update Git and run playbooks:
+    </para>
+    <screen>&prompt.ardana;git add -A
+&prompt.ardana;git commit -m "Add suse.tmpsize variable"
+&prompt.ardana;ansible-playbook -i hosts/localhost config-processor-run.yml
+&prompt.ardana;ansible-playbook -i hosts/localhost ready-deployment.yml
+&prompt.ardana;cd /var/lib/ardana/scratch/ansible/next/ardana/ansible
+&prompt.ardana;ansible-playbook -i hosts/verb_hosts ironic-reconfigure.yml</screen>
+   </step>
+   <step>
+    <para>
+     Re-deploy the &o_iron; node.
     </para>
    </step>
   </procedure>


### PR DESCRIPTION
deployment documentation covers ISO image size exceeding
free space. Add instructions for increasing /tmp size for
partition images.