### PR TITLE
add requirement for dummy entries in servers.yml (bsc#1146206)

### DIFF
--- a/xml/installation-kvm_xpointer.xml
+++ b/xml/installation-kvm_xpointer.xml
@@ -540,6 +540,16 @@
      installing the &clm; from the ISO, and is the same user that is running
      the cobbler-deploy play.
     </para>
+    <note>
+     <para>
+      When imaging servers with your own tooling, it is still necessary to have
+      ILO/IPMI settings for all nodes. Even if you are not using Cobbler, the
+      username and password fields in <filename>servers.yml</filename> need to
+      be filled in with dummy settings. For example, add the following to
+      <filename>servers.yml</filename>:
+     </para>
+     <screen>ilo-user: manual ilo-password: deployment</screen>
+    </note>
     <procedure>
      <step>
       <para>

--- a/xml/operations-maintenance-controller-replace_shared_lm.xml
+++ b/xml/operations-maintenance-controller-replace_shared_lm.xml
@@ -15,10 +15,10 @@
  <procedure>
   <step>
    <para>
-    To ensure that you use the same version of &productname; that you previously had
-    loaded on your &clm;, you will need to download and install the
-    lifecycle management software using the instructions from the installation
-    guide:
+    To ensure that you use the same version of &productname; that you
+    previously had loaded on your &clm;, you will need to download and install
+    the lifecycle management software using the instructions from the
+    installation guide:
    </para>
    <para>
     <xref linkend="sec-depl-adm-inst-add-on"/>
@@ -41,11 +41,22 @@
    <para>
     On the new node, update your cloud model with the new
     <literal>mac-addr</literal>, <literal>ilo-ip</literal>,
-    <literal>ilo-password</literal>, and <literal>ilo-user</literal> fields
-    to reflect the attributes of the node. Do not change the <literal>id</literal>,
-    <literal>ip-addr</literal>, <literal>role</literal>, or
-    <literal>server-group</literal> settings.
+    <literal>ilo-password</literal>, and <literal>ilo-user</literal> fields to
+    reflect the attributes of the node. Do not change the
+    <literal>id</literal>, <literal>ip-addr</literal>, <literal>role</literal>,
+    or <literal>server-group</literal> settings.
    </para>
+   <note>
+    <para>
+      When imaging servers with your own tooling, it is still necessary to have
+      ILO/IPMI settings for all nodes. Even if you are not using Cobbler, the
+      username and password fields in <filename>servers.yml</filename> need to
+      be filled in with dummy settings. For example, add the following to
+      <filename>servers.yml</filename>:
+     </para>
+     <screen>ilo-user: manual
+ilo-password: deployment</screen>
+   </note>
   </step>
   <step>
    <para>


### PR DESCRIPTION
when servers are imaged with user-provided tooling, dummy entries
must be entered in servers.yml to prevent cobbler-deploy.yml failure

(cherry picked from commit e205cf0b5644c4ef698f37c1e5a93d3c1aa6ead2)

screenshot in https://github.com/SUSE-Cloud/doc-cloud/pull/1124