### PR TITLE
add requirement for dummy entries in servers.yml (bsc#1146206)

### DIFF
--- a/xml/installation-kvm_xpointer.xml
+++ b/xml/installation-kvm_xpointer.xml
@@ -540,6 +540,17 @@
      installing the &clm; from the ISO, and is the same user that is running
      the cobbler-deploy play.
     </para>
+    <note>
+     <para>
+      When imaging servers with your own tooling, it is still necessary to have
+      ILO/IPMI settings for all nodes. Even if you are not using Cobbler, the
+      username and password fields in <filename>servers.yml</filename> need to
+      be filled in with dummy settings. For example, add the following to
+      <filename>servers.yml</filename>:
+     </para>
+     <screen>ilo-user: manual
+ilo-password: deployment</screen>
+    </note>
     <procedure>
      <step>
       <para>

--- a/xml/operations-maintenance-controller-replace_shared_lm.xml
+++ b/xml/operations-maintenance-controller-replace_shared_lm.xml
@@ -35,14 +35,24 @@
   </step>
   <step>
    <para>
-    On the new node, update your cloud model (<literal>servers.yml</literal>)
-    with the new <literal>mac-addr</literal>, <literal>ilo-ip</literal>,
-    <literal>ilo-password</literal>, or <literal>ilo-user</literal> fields
-    where these have changed. Do not change the <literal>id</literal>,
-    <literal>ip-addr</literal>, <literal>role</literal>, or
-    <literal>server-group</literal> settings. (Please follow the procedure for
-    updating your cloud model in the git repo)
+    On the new node, update your cloud model with the new
+    <literal>mac-addr</literal>, <literal>ilo-ip</literal>,
+    <literal>ilo-password</literal>, and <literal>ilo-user</literal> fields to
+    reflect the attributes of the node. Do not change the
+    <literal>id</literal>, <literal>ip-addr</literal>, <literal>role</literal>,
+    or <literal>server-group</literal> settings.
    </para>
+   <note>
+    <para>
+      When imaging servers with your own tooling, it is still necessary to have
+      ILO/IPMI settings for all nodes. Even if you are not using Cobbler, the
+      username and password fields in <filename>servers.yml</filename> need to
+      be filled in with dummy settings. For example, add the following to
+      <filename>servers.yml</filename>:
+     </para>
+     <screen>ilo-user: manual
+ilo-password: deployment</screen>
+   </note>
   </step>
   <step>
    <para>


### PR DESCRIPTION
when servers are imaged with user-provided tooling, dummy entries
must be entered in servers.yml to prevent cobbler-deploy.yml failure

(cherry picked from commit e205cf0b5644c4ef698f37c1e5a93d3c1aa6ead2)

screenshot in https://github.com/SUSE-Cloud/doc-cloud/pull/1124