### PR TITLE
clarify domain and project admin roles (bsc#1145749)

### DIFF
--- a/xml/operations-understanding_identity.xml
+++ b/xml/operations-understanding_identity.xml
@@ -88,7 +88,12 @@
    </listitem>
    <listitem>
     <para>
-     Each domain and project have an assigned admin.
+     Each domain has an assigned "admin".
+    </para>
+   </listitem>
+   <listitem>
+    <para>
+     Each project has an assigned "admin".
     </para>
    </listitem>
    <listitem>
@@ -205,16 +210,31 @@
    <listitem>
     <para>
      A domain administrator can assign a UID from outside of their domain the
-     "domain admin" role but it is assumed that the domain admin would know the
+     "domain admin" role, but it is assumed that the domain admin would know the
      specific UID and would not need to list users from an external domain.
     </para>
    </listitem>
    <listitem>
     <para>
      A domain administrator can assign a UID from outside of their domain the
-     "project admin" role for a specific project within their domain but it is
+     "project admin" role for a specific project within their domain, but it is
      assumed that the domain admin would know the specific UID and would not
      need to list users from an external domain.
+    </para>
+   </listitem>
+   <listitem>
+    <para>
+     Any user that needs the ability to create a user in a project should be
+     granted the "admin" role for the domain where the user and the project
+     reside.
+    </para>
+   </listitem>
+   <listitem>
+    <para>
+     In order for the &o_dash; <menuchoice><guimenu>Compute</guimenu>
+     <guimenu>Images</guimenu></menuchoice> panel to properly fill the "Owner"
+     column, any user that is granted the admin role on a project must also be
+     granted the "member" or "admin" role in the domain.
     </para>
    </listitem>
   </itemizedlist>


### PR DESCRIPTION
admin roles need to be assigned by domain and by project
to ensure the ability to add users to projects and show
Owner information in Horizon Compute-Images panel

(cherry picked from commit b6d004bc5e34cfa357e5fd2e43ad5f335b0d467a)