### PR TITLE
add swift endpoint steps (bsc#1150957)

### DIFF
--- a/xml/installation-installation-ses_integration.xml
+++ b/xml/installation-installation-ses_integration.xml
@@ -314,7 +314,57 @@ ses_config_file: ses_config.yml
     </step>
    </procedure>
   </section>
-
+  <section>
+   <title>Add Missing Swift Endpoints</title>
+   <para>
+    If you deployed &clm; using the &ses; integration without &swift;, the
+    integration will not be set up properly. Swift object endpoints will be
+    missing. Use the following process to create the necessary endpoints.
+   </para>
+   <procedure>
+    <step>
+     <para>
+      Source the &o_ident; <literal>rc</literal> file to have the correct
+      permissions to create the &swift; service and endpoints.
+     </para>
+     <screen>&prompt.ardana;. ~/keystone.osrc</screen>
+    </step>
+    <step>
+     <para>
+      Create the &swift; service.
+     </para>
+     <screen>&prompt.ardana;openstack service create --name swift object-store --enable</screen>
+    </step>
+    <step>
+     <para>
+      Read the RADOS gateway URL from the <filename>ses_config.yml</filename>
+      file. For example:
+     </para>
+     <screen>&prompt.ardana;grep http ~/ses/ses_config.yml
+https://ses-osd3:8080/swift/v1</screen>
+    </step>
+    <step>
+     <para>
+      Create the three &swift; endpoints.
+     </para>
+     <screen>&prompt.ardana;openstack endpoint create --enable --region region1 swift \
+admin https://ses-osd3:8080/swift/v1
+&prompt.ardana;openstack endpoint create --enable --region region1 swift \
+public  https://ses-osd3:8080/swift/v1
+&prompt.ardana;openstack endpoint create --enable --region region1 swift \
+internal https://ses-osd3:8080/swift/v1</screen>
+    </step>
+    <step>
+     <para>
+      Verify the objects in the endpoint list.
+     </para>
+     <screen>&prompt.ardana;openstack endpoint list | grep object
+5313b...e9412f  region1  swift  object-store  True  public    https://ses-osd3:8080/swift/v1
+83faf...1eb602  region1  swift  object-store  True  internal  https://ses-osd3:8080/swift/v1
+dc698...715b8c  region1  swift  object-store  True  admin     https://ses-osd3:8080/swift/v1</screen>
+    </step>
+   </procedure>
+  </section>
   <section>
    <title>Configuring &ses; for Integration with &rados; Gateway</title>
    <para>


### PR DESCRIPTION
When CLM is deployed using SES integration without swift, endpoints
are not set up properly. These are workaround steps.

(cherry picked from commit 27b12cb73d0cae192743f3b9bc4b4f7aea8852b5)

screenshot in https://github.com/SUSE-Cloud/doc-cloud/pull/1162