### PR TITLE
update designate deployment (SOC-8739)

### DIFF
--- a/xml/depl_nodes.xml
+++ b/xml/depl_nodes.xml
@@ -163,10 +163,7 @@
     create and propagate zones and records over the network using pools of DNS
     servers. Deployment defaults are in place, so not much is required to
     configure &desig;. &o_netw; needs additional settings for integration with
-    &desig;. The &desig; barclamp does not configure these &o_netw; settings; an
-    admin can enable them if necessary. For more information, see the <link
-    xlink:href="https://docs.openstack.org/designate/latest/contributor/integrations.html">OpenStack
-    Integrations</link>.
+    &desig;, which are also present in the <literal>[designate]</literal> section in &o_netw; configuration.
   </para>
   <para>
     The &desig; barclamp relies heavily on dns barclamp and expects
@@ -198,18 +195,25 @@
   </para>
   <para>
     &desig; uses pool(s) over which it can distribute zones and
-    records, these pool(s) are not created by &crow;. Pools can have
-    varied configuration. Any misconfiguration can lead to
+    records. Pools can have varied configuration. Any misconfiguration can lead to
     information leakage.
   </para>
   <para>
-    One possible configuration of pools is created by &crow; on a node
-    with <literal>designate-api</literal> role in
-    <filename>/etc/designate/pools.crowbar.yaml</filename>. Copy
-    this file and edit it according to the requirements. Then provide this
+    The &desig; barclamp creates default Bind9 pool out of the box, which can be
+    modified later as needed. The default Bind9 pool configuration is created by &crow;
+    on a node with <literal>designate-server</literal> role in
+    <filename>/etc/designate/pools.crowbar.yaml</filename>. You can copy
+    this file and edit it according to your requirements. Then provide this
     configuration to &desig; using the command:
   </para>
   <screen>&prompt.ardana;designate-manage pool update --file /etc/designate/pools.crowbar.yaml</screen>
+  <para>
+    The <literal>dns_domain</literal> specified in &o_netw; configuration in <literal>[designate]</literal> section
+    is the default Zone where DNS records for &o_netw; resources will be created via
+    &o_netw;-&desig; integration. If this is desired, you will have to create this zone
+    explicitly using the following command:
+  </para>
+  <screen>&prompt.ardana;openstack zone create &lt; email &gt; &lt; dns_domain &gt;</screen>
   <para>
    Editing the &desig; proposal
   </para>


### PR DESCRIPTION
Modified the designate deployment section for SOC using Crowbar.

We now have the Neutron-Designate integration working out of the
box. We also create default Bind9 server pool. Command to create
the default Zone (dns_domain) for Neutron-Designate integration
is also added.