### PR TITLE
remove zvm references, only in SOC6 (noref)

### DIFF
--- a/xml/depl_crowbar_extra-features.xml
+++ b/xml/depl_crowbar_extra-features.xml
@@ -54,7 +54,6 @@ skip_unready_nodes:
 - nova-compute-qemu
 - nova-compute-vmware
 - nova-compute-xen
-- nova-compute-zvm
 - ntp-client
 - provisioner-base
 - suse-manager-client

--- a/xml/depl_nodes.xml
+++ b/xml/depl_nodes.xml
@@ -3694,7 +3694,6 @@ neutron router-interface-add <replaceable>router2</replaceable> priv-net-sub</sc
     <guimenu>nova-compute-qemu</guimenu> /
     <guimenu>nova-compute-vmware</guimenu> /
     <guimenu>nova-compute-xen</guimenu> /
-    <guimenu>nova-compute-zvm</guimenu>
     </term>
     <listitem>
      <para>


### PR DESCRIPTION
requested in email 19-09-20 from T.R. Bosworth

(cherry picked from commit c3cd9a331d1dc46218754a02b4865ba1dc858ea9)