### PR TITLE
add qos to neutron not supported (bsc#1151206)

### DIFF
--- a/xml/operations-troubleshooting-ts_heat.xml
+++ b/xml/operations-troubleshooting-ts_heat.xml
@@ -100,4 +100,14 @@ ansible-playbook -i hosts/verb_hosts heat-reconfigure.yml</screen>
    alarm name automatically during heat stack create.
   </para>
  </section>
+ <section>
+  <title>Unable to Retrieve QOS Policies</title>
+  <para>
+   Launching the Orchestration Template Generator may trigger the message:
+   <literal>Unable to retrieve resources Qos Policies</literal>. This is a
+   known <link
+   xlink:href="https://storyboard.openstack.org/#!/story/2003523">upstream
+   bug</link>. This information message can be ignored.
+  </para>
+ </section>
 </section>

--- a/xml/planning-core_non-core_openstack_support.xml
+++ b/xml/planning-core_non-core_openstack_support.xml
@@ -206,7 +206,7 @@
       </row>
       <row>
        <entry><para>VMware ESX Hypervisor</para></entry>
-       <entry><para>  </para></entry>
+       <entry><para>QoS</para></entry>
       </row>
       <row>
        <entry vendor="hpe"><para>&rhla; KVM Hypervisor</para></entry>


### PR DESCRIPTION
QoS should be shown as core-not-supported.

(cherry picked from commit f4bd7f48743c09476a1b3e22e22c6160e53208e7)
retaining hpe profiling