### PR TITLE
Correcting para and screen tag placement (noref)

### DIFF
--- a/xml/poc-install-deployer-node.xml
+++ b/xml/poc-install-deployer-node.xml
@@ -81,10 +81,10 @@
        <step>
          <para>
          Install the SMT Server pattern.
+         </para>
          <screen>
            $ sudo zypper in -t pattern smt
          </screen>
-         </para>
        </step>
        <step>
          <para>


### PR DESCRIPTION
While this is related to geekodoc build, and not docbook, this
is the best practice to use when including screen tags in a
procedure list. Fixed after reported from @csymons-suse