### PR TITLE
Ensuring SOC docs are validated using docbook only (noref)

### DIFF
--- a/DC-rhel-installation
+++ b/DC-rhel-installation
@@ -13,3 +13,6 @@ PROFVENDOR="suse"
 
 ## Stylesheet location
 STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2013-ns"
+
+## Validation
+DOCBOOK5_RNG_URI="file:///usr/share/xml/docbook/schema/rng/5.1/docbookxi.rnc"

--- a/DC-suse-openstack-cloud-clm-all
+++ b/DC-suse-openstack-cloud-clm-all
@@ -13,3 +13,6 @@ PROFVENDOR="suse"
 
 ## Stylesheet location
 STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2013-ns"
+
+## Validation
+DOCBOOK5_RNG_URI="file:///usr/share/xml/docbook/schema/rng/5.1/docbookxi.rnc"

--- a/DC-suse-openstack-cloud-crowbar-all
+++ b/DC-suse-openstack-cloud-crowbar-all
@@ -13,3 +13,6 @@ PROFVENDOR="suse-crow"
 
 ## Stylesheet location
 STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2013-ns"
+
+## Validation
+DOCBOOK5_RNG_URI="file:///usr/share/xml/docbook/schema/rng/5.1/docbookxi.rnc"

--- a/DC-suse-openstack-cloud-crowbar-deployment
+++ b/DC-suse-openstack-cloud-crowbar-deployment
@@ -16,3 +16,6 @@ STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2013-ns"
 
 ## Sort the glossary
 XSLTPARAM="--param glossary.sort=1"
+
+## Validation
+DOCBOOK5_RNG_URI="file:///usr/share/xml/docbook/schema/rng/5.1/docbookxi.rnc"

--- a/DC-suse-openstack-cloud-crowbar-operations
+++ b/DC-suse-openstack-cloud-crowbar-operations
@@ -13,3 +13,6 @@ PROFVENDOR="suse-crow"
 
 ## Stylesheet location
 STYLEROOT=/usr/share/xml/docbook/stylesheet/suse2013
+
+## Validation
+DOCBOOK5_RNG_URI="file:///usr/share/xml/docbook/schema/rng/5.1/docbookxi.rnc"

--- a/DC-suse-openstack-cloud-deployment
+++ b/DC-suse-openstack-cloud-deployment
@@ -13,3 +13,6 @@ PROFVENDOR="suse"
 
 ## Stylesheet location
 STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2013-ns"
+
+## Validation
+DOCBOOK5_RNG_URI="file:///usr/share/xml/docbook/schema/rng/5.1/docbookxi.rnc"

--- a/DC-suse-openstack-cloud-operations
+++ b/DC-suse-openstack-cloud-operations
@@ -13,3 +13,6 @@ PROFVENDOR="suse"
 
 ## Stylesheet location
 STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2013-ns"
+
+## Validation
+DOCBOOK5_RNG_URI="file:///usr/share/xml/docbook/schema/rng/5.1/docbookxi.rnc"

--- a/DC-suse-openstack-cloud-poc-crowbar
+++ b/DC-suse-openstack-cloud-poc-crowbar
@@ -13,3 +13,6 @@ PROFVENDOR="suse-crow"
 
 ## Stylesheet location
 STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2013-ns"
+
+## Validation
+DOCBOOK5_RNG_URI="file:///usr/share/xml/docbook/schema/rng/5.1/docbookxi.rnc"

--- a/DC-suse-openstack-cloud-security
+++ b/DC-suse-openstack-cloud-security
@@ -13,3 +13,6 @@ PROFVENDOR="suse"
 
 ## Stylesheet location
 STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2013-ns"
+
+## Validation
+DOCBOOK5_RNG_URI="file:///usr/share/xml/docbook/schema/rng/5.1/docbookxi.rnc"

--- a/DC-suse-openstack-cloud-supplement
+++ b/DC-suse-openstack-cloud-supplement
@@ -13,3 +13,6 @@ PROFVENDOR="suse-crow"
 
 ## Stylesheet location
 STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2013-ns"
+
+## Validation
+DOCBOOK5_RNG_URI="file:///usr/share/xml/docbook/schema/rng/5.1/docbookxi.rnc"


### PR DESCRIPTION
The current docs are validated mostly using docbook and not
geekodoc. To ensure this sticks, updating validation tag in
DC files.