### PR TITLE
message to add non-admin node for public network (SOC-10658)

### DIFF
--- a/xml/depl_nodes.xml
+++ b/xml/depl_nodes.xml
@@ -163,12 +163,21 @@
     create and propagate zones and records over the network using pools of DNS
     servers. Deployment defaults are in place, so not much is required to
     configure &desig;. &o_netw; needs additional settings for integration with
-    &desig;, which are also present in the <literal>[designate]</literal> section in &o_netw; configuration.
+    &desig;, which are also present in the <literal>[designate]</literal>
+    section in &o_netw; configuration.
   </para>
   <para>
     The &desig; barclamp relies heavily on dns barclamp and expects
     it to be applied without any failures.
   </para>
+  <note>
+   <para>
+    In order to deploy &desig;, at least one node is necessary in the DNS
+    barclamp that is not the admin node. The admin node is not added to the
+    public network. So another node is needed that can be attached to the public
+    network and appear in the designate default pool.
+   </para>
+  </note>
   <variablelist>
     <varlistentry>
       <term>designate-server role</term>


### PR DESCRIPTION
admin node is not added to public network. Yet at least one node
is necessary that can be added to the public network.