### PR TITLE
message to add non-admin node for public network (SOC-10658)

### DIFF
--- a/xml/depl_nodes.xml
+++ b/xml/depl_nodes.xml
@@ -172,6 +172,14 @@
     The &desig; barclamp relies heavily on dns barclamp and expects
     it to be applied without any failures.
   </para>
+  <note>
+   <para>
+    In order to deploy &desig;, at least one node is necessary in the DNS
+    barclamp that is not the admin node. The admin node is not added to the
+    public network. So another node is needed that can be attached to the public
+    network and appear in the designate default pool.
+   </para>
+  </note>
   <variablelist>
     <varlistentry>
       <term>designate-server role</term>


### PR DESCRIPTION
admin node is not added to public network. Yet at least one node
is necessary that can be added to the public network.

(cherry picked from commit ab6bd1366d1aa55a9c13dc15e83dbe1ef47f51e7)