### PR TITLE
Update amphora image path for SOC9 to correct path

### DIFF
--- a/xml/installation-installation-configure_lbaas.xml
+++ b/xml/installation-installation-configure_lbaas.xml
@@ -99,6 +99,13 @@
  <section>
   <title>Prerequisite Setup</title>
   <para>
+    <emphasis role="bold">&octavia; Client Installation</emphasis>
+  </para>
+  <para>
+    The Octavia client must be installed in the control plane, see
+    <xref linkend="install-openstack-clients"/>.
+  </para>
+  <para>
    <emphasis role="bold">&octavia; Network and Management Network
    Ports</emphasis>
   </para>
@@ -160,31 +167,36 @@
   <procedure>
    <step>
     <para>
-     The full path and name for the Amphora image is
-     <filename>/srv/www/suse-12.3/x86_64/repos/Cloud/suse/noarch/openstack-octavia-amphora-image-x86_64-0.1.0-1.21.noarch.rpm</filename>
+     The Amphora image is in an RPM package managed by zypper, display the full path to that file with the following command:
+     <screen>&prompt.ardana;find /srv -type f -name "*amphora-image*"</screen>
+     For example:
+     <filename>/srv/www/suse-12.4/x86_64/repos/Cloud/suse/noarch/openstack-octavia-amphora-image-x86_64-0.1.0-13.157.noarch.rpm</filename>
+
+     The Amphora image may be updated via maintenance updates, which will change the filename.
     </para>
     <para>
      Switch to the <filename>ansible</filename> directory and register the
      image by giving the full path and name for the Amphora image as an
-     argument to <literal>service_package</literal>:
+     argument to <literal>service_package</literal>, replacing the filename
+     as needed to reflect an updated amphora image rpm:
     </para>
 <screen><?dbsuse-fo font-size="0.70em"?>&prompt.ardana;cd ~/scratch/ansible/next/ardana/ansible/
 &prompt.ardana;ansible-playbook -i hosts/verb_hosts service-guest-image.yml \
 -e service_package=\
-/srv/www/suse-12.3/x86_64/repos/Cloud/suse/noarch/openstack-octavia-amphora-image-x86_64-0.1.0-1.21.noarch.rpm</screen>
+/srv/www/suse-12.4/x86_64/repos/Cloud/suse/noarch/openstack-octavia-amphora-image-x86_64-0.1.0-13.157.noarch.rpm</screen>
    </step>
    <step>
     <para>
      Source the service user (this can be done on a different computer)
     </para>
-<screen>&prompt.user;source service.osrc</screen>
+<screen>&prompt.ardana;source service.osrc</screen>
    </step>
    <step>
     <para>
      Verify that the image was registered (this can be done on a computer with
      access to the &o_img; CLI client)
     </para>
-<screen>&prompt.user;openstack image list
+<screen>&prompt.ardana;openstack image list
 +--------------------------------------+------------------------+---------
 | ID                                   | Name                   | Status |
 +--------------------------------------+------------------------+--------+
@@ -227,7 +239,7 @@
     <para>
      Create a network.
     </para>
-<screen>&prompt.user;openstack network create lb_net1
+<screen>&prompt.ardana;openstack network create lb_net1
 +---------------------------+--------------------------------------+
 | Field                     | Value                                |
 +---------------------------+--------------------------------------+
@@ -249,7 +261,7 @@
     <para>
      Create a subnet.
     </para>
-<screen><?dbsuse-fo font-size="0.70em"?>&prompt.user;openstack subnet create --network lb_net1 --subnet-range 10.247.94.128/26 \
+<screen><?dbsuse-fo font-size="0.70em"?>&prompt.ardana;openstack subnet create --network lb_net1 --subnet-range 10.247.94.128/26 \
   --gateway 10.247.94.129 lb_subnet1
 +-------------------+----------------------------------------------------+
 | Field             | Value                                              |
@@ -274,7 +286,7 @@
     <para>
      Create a router.
     </para>
-<screen>&prompt.user;openstack router create --centralized lb_router1
+<screen>&prompt.ardana;openstack router create --centralized lb_router1
 +-----------------------+--------------------------------------+
 | Field                 | Value                                |
 +-----------------------+--------------------------------------+
@@ -295,19 +307,19 @@
      <literal>426c5898-f851-4f49-b01f-7a6fe490410c</literal> will be added to
      the router <literal>lb_router1</literal>.
     </para>
-<screen>&prompt.user;openstack router add subnet lb_router1 lb_subnet1</screen>
+<screen>&prompt.ardana;openstack router add subnet lb_router1 lb_subnet1</screen>
    </step>
    <step>
     <para>
      Set gateway for router.
     </para>
-<screen>&prompt.user;openstack router set --external-gateway ext-net lb_router1</screen>
+<screen>&prompt.ardana;openstack router set --external-gateway ext-net lb_router1</screen>
    </step>
    <step>
     <para>
      Check networks.
     </para>
-<screen><?dbsuse-fo font-size="0.70em"?>&prompt.user;openstack network list
+<screen><?dbsuse-fo font-size="0.70em"?>&prompt.ardana;openstack network list
 +-----------------------------+------------------+-----------------------------+
 | id                          | name             | subnets                     |
 +-----------------------------+------------------+-----------------------------+
@@ -325,7 +337,7 @@
     <para>
      Create security group.
     </para>
-<screen><?dbsuse-fo font-size="0.65em"?>&prompt.user;openstack security group create lb_secgroup1
+<screen><?dbsuse-fo font-size="0.65em"?>&prompt.ardana;openstack security group create lb_secgroup1
 +----------------+---------------------------------------------------------------------------+
 | Field          | Value                                                                     |
 +----------------+---------------------------------------------------------------------------+
@@ -347,7 +359,7 @@
     <para>
      Create icmp security group rule.
     </para>
-<screen>&prompt.user;openstack security group rule create --protocol icmp lb_secgroup1
+<screen>&prompt.ardana;openstack security group rule create --protocol icmp lb_secgroup1
 +-------------------+--------------------------------------+
 | Field             | Value                                |
 +-------------------+--------------------------------------+
@@ -367,7 +379,7 @@
     <para>
      Create TCP port 22 rule.
     </para>
-<screen><?dbsuse-fo font-size="0.70em"?>&prompt.user;openstack security group rule create --protocol tcp --dst-port 22 lb_secgroup1
+<screen><?dbsuse-fo font-size="0.70em"?>&prompt.ardana;openstack security group rule create --protocol tcp --dst-port 22 lb_secgroup1
 +-------------------+--------------------------------------+
 | Field             | Value                                |
 +-------------------+--------------------------------------+
@@ -387,7 +399,7 @@
     <para>
      Create TCP port 80 rule.
     </para>
-<screen><?dbsuse-fo font-size="0.70em"?>&prompt.user;openstack security group rule create --protocol tcp --dst-port 80 lb_secgroup1
+<screen><?dbsuse-fo font-size="0.70em"?>&prompt.ardana;openstack security group rule create --protocol tcp --dst-port 80 lb_secgroup1
 +-------------------+--------------------------------------+
 | Field             | Value                                |
 +-------------------+--------------------------------------+
@@ -409,7 +421,7 @@
      <literal>openstack keypair create</literal>. You will use the keypair to boot
      images.
     </para>
-<screen>&prompt.user;openstack keypair create lb_kp1 &gt; lb_kp1.pem
+<screen>&prompt.ardana;openstack keypair create lb_kp1 &gt; lb_kp1.pem
 
 chmod 400 lb_kp1.pem
 
@@ -446,7 +458,7 @@ f9SUiRNruDnH4F4OclsDBlmqWXImuXRfeiDHxM8X03UDZoqyHmGD3RqA53I=
     <para>
      Check and boot images.
     </para>
-<screen><?dbsuse-fo font-size="0.70em"?>&prompt.user;openstack image list
+<screen><?dbsuse-fo font-size="0.70em"?>&prompt.ardana;openstack image list
 +--------------+------------------------+--------+--------+
 | ID           | Name                   | Status | Server |
 +--------------+------------------------+--------+--------+
@@ -456,7 +468,7 @@ f9SUiRNruDnH4F4OclsDBlmqWXImuXRfeiDHxM8X03UDZoqyHmGD3RqA53I=
     <para>
      Boot first VM.
     </para>
-<screen><?dbsuse-fo font-size="0.70em"?>&prompt.user;openstack server create --flavor m1.tiny --image cirros-0.4.0-x86_64 --key-name lb_kp1 \
+<screen><?dbsuse-fo font-size="0.70em"?>&prompt.ardana;openstack server create --flavor m1.tiny --image cirros-0.4.0-x86_64 --key-name lb_kp1 \
   --security-groups lb_secgroup1 --nic net-id=lb_net1 lb_vm1 --wait
 +--------------------------------------+--------------------------------------+
 | Property                             | Value                                |
@@ -497,7 +509,7 @@ f9SUiRNruDnH4F4OclsDBlmqWXImuXRfeiDHxM8X03UDZoqyHmGD3RqA53I=
     <para>
      Boot second VM.
     </para>
-<screen><?dbsuse-fo font-size="0.70em"?>&prompt.user;openstack server create --flavor m1.tiny --image cirros-0.4.0-x86_64 --key-name lb_kp1 \
+<screen><?dbsuse-fo font-size="0.70em"?>&prompt.ardana;openstack server create --flavor m1.tiny --image cirros-0.4.0-x86_64 --key-name lb_kp1 \
   --security-groups lb_secgroup1 --nic net-id=lb_net1 lb_vm2 --wait
 +--------------------------------------+---------------------------------------+
 | Property                             | Value                                 |
@@ -540,7 +552,7 @@ f9SUiRNruDnH4F4OclsDBlmqWXImuXRfeiDHxM8X03UDZoqyHmGD3RqA53I=
     <para>
      List the running VMs with <literal>openstack server list</literal>
     </para>
-<screen><?dbsuse-fo font-size="0.70em"?>&prompt.user;openstack server list
+<screen><?dbsuse-fo font-size="0.70em"?>&prompt.ardana;openstack server list
 +----------------+--------+--------+------------+-------------+-----------------------+
 | ID             | Name   | Status | Task State | Power State | Networks              |
 +----------------+--------+--------+------------+-------------+-----------------------+
@@ -552,7 +564,7 @@ f9SUiRNruDnH4F4OclsDBlmqWXImuXRfeiDHxM8X03UDZoqyHmGD3RqA53I=
     <para>
      Check ports.
     </para>
-<screen><?dbsuse-fo font-size="0.70em"?>&prompt.user;openstack port list
+<screen><?dbsuse-fo font-size="0.70em"?>&prompt.ardana;openstack port list
 +----------------+------+-------------------+--------------------------------+
 | id             | name | mac_address       | fixed_ips                      |
 +----------------+------+-------------------+--------------------------------+
@@ -567,7 +579,7 @@ f9SUiRNruDnH4F4OclsDBlmqWXImuXRfeiDHxM8X03UDZoqyHmGD3RqA53I=
     <para>
      Create the first floating IP.
     </para>
-<screen><?dbsuse-fo font-size="0.70em"?>&prompt.user;openstack floating ip create ext-net --port-id 7e5e0038-88cf-4f97-a366-b58cd836450e
+<screen><?dbsuse-fo font-size="0.70em"?>&prompt.ardana;openstack floating ip create ext-net --port-id 7e5e0038-88cf-4f97-a366-b58cd836450e
 +---------------------+--------------------------------------+
 | Field               | Value                                |
 +---------------------+--------------------------------------+
@@ -585,7 +597,7 @@ f9SUiRNruDnH4F4OclsDBlmqWXImuXRfeiDHxM8X03UDZoqyHmGD3RqA53I=
     <para>
      Create the second floating IP.
     </para>
-<screen><?dbsuse-fo font-size="0.70em"?>&prompt.user;openstack floating ip create ext-net --port-id ca95cc24-4e8f-4415-9156-7b519eb36854
+<screen><?dbsuse-fo font-size="0.70em"?>&prompt.ardana;openstack floating ip create ext-net --port-id ca95cc24-4e8f-4415-9156-7b519eb36854
 +---------------------+--------------------------------------+
 | Field               | Value                                |
 +---------------------+--------------------------------------+
@@ -603,7 +615,7 @@ f9SUiRNruDnH4F4OclsDBlmqWXImuXRfeiDHxM8X03UDZoqyHmGD3RqA53I=
     <para>
      List the floating IP's.
     </para>
-<screen><?dbsuse-fo font-size="0.70em"?>&prompt.user;openstack floating ip list
+<screen><?dbsuse-fo font-size="0.70em"?>&prompt.ardana;openstack floating ip list
 +----------------+------------------+---------------------+---------------+
 | id             | fixed_ip_address | floating_ip_address | port_id       |
 +----------------+------------------+---------------------+---------------+
@@ -615,7 +627,7 @@ f9SUiRNruDnH4F4OclsDBlmqWXImuXRfeiDHxM8X03UDZoqyHmGD3RqA53I=
     <para>
      Show first Floating IP.
     </para>
-<screen>&prompt.user;openstack floating ip show 3ce608bf-8835-4638-871d-0efe8ebf55ef
+<screen>&prompt.ardana;openstack floating ip show 3ce608bf-8835-4638-871d-0efe8ebf55ef
 +---------------------+--------------------------------------+
 | Field               | Value                                |
 +---------------------+--------------------------------------+
@@ -633,7 +645,7 @@ f9SUiRNruDnH4F4OclsDBlmqWXImuXRfeiDHxM8X03UDZoqyHmGD3RqA53I=
     <para>
      Show second Floating IP.
     </para>
-<screen>&prompt.user;openstack floating ip show 680c0375-a179-47cb-a8c5-02b836247444
+<screen>&prompt.ardana;openstack floating ip show 680c0375-a179-47cb-a8c5-02b836247444
 +---------------------+--------------------------------------+
 | Field               | Value                                |
 +---------------------+--------------------------------------+
@@ -651,7 +663,7 @@ f9SUiRNruDnH4F4OclsDBlmqWXImuXRfeiDHxM8X03UDZoqyHmGD3RqA53I=
     <para>
      <command>Ping</command> first Floating IP.
     </para>
-<screen>&prompt.user;ping -c 1 10.247.96.26
+<screen>&prompt.ardana;ping -c 1 10.247.96.26
 PING 10.247.96.26 (10.247.96.26) 56(84) bytes of data.
 64 bytes from 10.247.96.26: icmp_seq=1 ttl=62 time=3.50 ms
 
@@ -663,7 +675,7 @@ rtt min/avg/max/mdev = 3.505/3.505/3.505/0.000 ms</screen>
     <para>
      <command>Ping</command> second Floating IP.
     </para>
-<screen>&prompt.user;ping -c 1 10.247.96.27
+<screen>&prompt.ardana;ping -c 1 10.247.96.27
 PING 10.247.96.27 (10.247.96.27) 56(84) bytes of data.
 64 bytes from 10.247.96.27: icmp_seq=1 ttl=62 time=3.47 ms
 
@@ -676,7 +688,7 @@ rtt min/avg/max/mdev = 3.473/3.473/3.473/0.000 ms</screen>
      Listing the VMs will give you both the fixed and floating IP's for each
      virtual machine.
     </para>
-<screen><?dbsuse-fo font-size="0.65em"?>&prompt.user;openstack server list
+<screen><?dbsuse-fo font-size="0.65em"?>&prompt.ardana;openstack server list
 +---------------+--------+--------+-------+---------+-------------------------------------+
 | ID            | Name   | Status | Task  | Power   | Networks                            |
 |               |        |        | State | State   |                                     |
@@ -689,7 +701,7 @@ rtt min/avg/max/mdev = 3.473/3.473/3.473/0.000 ms</screen>
     <para>
      List Floating IP's.
     </para>
-<screen><?dbsuse-fo font-size="0.70em"?>&prompt.user;openstack floating ip list
+<screen><?dbsuse-fo font-size="0.70em"?>&prompt.ardana;openstack floating ip list
 +---------------+------------------+---------------------+-----------------+
 | id            | fixed_ip_address | floating_ip_address | port_id         |
 +---------------+------------------+---------------------+-----------------+
@@ -714,7 +726,7 @@ rtt min/avg/max/mdev = 3.473/3.473/3.473/0.000 ms</screen>
     <para>
      Create load balancer for subnet
     </para>
-<screen><?dbsuse-fo font-size="0.70em"?>&prompt.user;neutron lbaas-loadbalancer-create --provider octavia \
+<screen><?dbsuse-fo font-size="0.70em"?>&prompt.ardana;neutron lbaas-loadbalancer-create --provider octavia \
   --name lb1 6fc2572c-53b3-41d0-ab63-342d9515f514
 +---------------------+--------------------------------------+
 | Field               | Value                                |
@@ -739,7 +751,7 @@ rtt min/avg/max/mdev = 3.473/3.473/3.473/0.000 ms</screen>
      <literal>provisioning_status</literal>is <literal>ACTIVE</literal> before
      proceeding to the next step.
     </para>
-<screen><?dbsuse-fo font-size="0.70em"?>&prompt.user;neutron lbaas-loadbalancer-list
+<screen><?dbsuse-fo font-size="0.70em"?>&prompt.ardana;neutron lbaas-loadbalancer-list
 +---------------+------+---------------+---------------------+----------+
 | id            | name | vip_address   | provisioning_status | provider |
 +---------------+------+---------------+---------------------+----------+
@@ -751,7 +763,7 @@ rtt min/avg/max/mdev = 3.473/3.473/3.473/0.000 ms</screen>
      Once the load balancer is created, create the listener. This may take some
      time.
     </para>
-<screen>&prompt.user;neutron lbaas-listener-create --loadbalancer lb1 \
+<screen>&prompt.ardana;neutron lbaas-listener-create --loadbalancer lb1 \
   --protocol HTTP --protocol-port=80 --name lb1_listener
 +---------------------------+------------------------------------------------+
 | Field                     | Value                                          |
@@ -779,7 +791,7 @@ rtt min/avg/max/mdev = 3.473/3.473/3.473/0.000 ms</screen>
      <literal>ACTIVE</literal>. Once the load balancer returns to
      <literal>ACTIVE</literal>, proceed with the next step.
     </para>
-<screen>&prompt.user;neutron lbaas-pool-create --lb-algorithm ROUND_ROBIN \
+<screen>&prompt.ardana;neutron lbaas-pool-create --lb-algorithm ROUND_ROBIN \
   --listener lb1_listener --protocol HTTP --name lb1_pool
 +---------------------+------------------------------------------------+
 | Field               | Value                                          |
@@ -801,7 +813,7 @@ rtt min/avg/max/mdev = 3.473/3.473/3.473/0.000 ms</screen>
     <para>
      Create first member of the load balancing pool.
     </para>
-<screen>&prompt.user;neutron lbaas-member-create --subnet 6fc2572c-53b3-41d0-ab63-342d9515f514 \
+<screen>&prompt.ardana;neutron lbaas-member-create --subnet 6fc2572c-53b3-41d0-ab63-342d9515f514 \
   --address 10.247.94.132 --protocol-port 80 lb1_pool
 +----------------+--------------------------------------+
 | Field          | Value                                |
@@ -819,7 +831,7 @@ rtt min/avg/max/mdev = 3.473/3.473/3.473/0.000 ms</screen>
     <para>
      Create the second member.
     </para>
-<screen>&prompt.user;neutron lbaas-member-create --subnet 6fc2572c-53b3-41d0-ab63-342d9515f514 \
+<screen>&prompt.ardana;neutron lbaas-member-create --subnet 6fc2572c-53b3-41d0-ab63-342d9515f514 \
   --address 10.247.94.133 --protocol-port 80 lb1_pool
 +----------------+--------------------------------------+
 | Field          | Value                                |
@@ -838,7 +850,7 @@ rtt min/avg/max/mdev = 3.473/3.473/3.473/0.000 ms</screen>
      Check to make sure the load balancer is active and check the
      pool members.
     </para>
-<screen><?dbsuse-fo font-size="0.70em"?>&prompt.user;neutron lbaas-loadbalancer-list
+<screen><?dbsuse-fo font-size="0.70em"?>&prompt.ardana;neutron lbaas-loadbalancer-list
 +----------------+------+---------------+---------------------+----------+
 | id             | name | vip_address   | provisioning_status | provider |
 +----------------+------+---------------+---------------------+----------+
@@ -857,7 +869,7 @@ neutron lbaas-member-list lb1_pool
     <para>
      You can view the details of the load balancer, listener and pool.
     </para>
-<screen><?dbsuse-fo font-size="0.70em"?>&prompt.user;neutron lbaas-loadbalancer-show 3d9170a1-8605-43e6-9255-e14a8b4aae53
+<screen><?dbsuse-fo font-size="0.70em"?>&prompt.ardana;neutron lbaas-loadbalancer-show 3d9170a1-8605-43e6-9255-e14a8b4aae53
 +---------------------+------------------------------------------------+
 | Field               | Value                                          |
 +---------------------+------------------------------------------------+
@@ -903,7 +915,7 @@ neutron lbaas-pool-list
     <para>
      List the current ports.
     </para>
-<screen><?dbsuse-fo font-size="0.65em"?>&prompt.user;openstack port list
+<screen><?dbsuse-fo font-size="0.65em"?>&prompt.ardana;openstack port list
 +--------------+---------------+-------------------+-----------------------------------------+
 | id           | name          | mac_address       | fixed_ips                               |
 +--------------+---------------+-------------------+-----------------------------------------+
@@ -926,7 +938,7 @@ neutron lbaas-pool-list
     <para>
      Create the floating IP for the load balancer.
     </para>
-<screen><?dbsuse-fo font-size="0.70em"?>&prompt.user;openstack floating ip create --port da28aed3-0eb4-4139-afcf-2d8fd3fc3c51 ext-net
+<screen><?dbsuse-fo font-size="0.70em"?>&prompt.ardana;openstack floating ip create --port da28aed3-0eb4-4139-afcf-2d8fd3fc3c51 ext-net
 Created a new floatingip:
 +---------------------+--------------------------------------+
 | Field               | Value                                |
@@ -957,7 +969,7 @@ Created a new floatingip:
      <filename>webserver.sh</filename> script with below contents. In this
      example, the port is 80.
     </para>
-<screen><?dbsuse-fo font-size="0.70em"?>&prompt.user;vi webserver.sh
+<screen><?dbsuse-fo font-size="0.70em"?>&prompt.ardana;vi webserver.sh
 
 #!/bin/sh
 
@@ -986,7 +998,7 @@ ssh -o StrictHostKeyChecking=no -i lb_kp1.pem cirros@10.247.96.26 ./webserver.sh
     <para>
      Test the first web server.
     </para>
-<screen>&prompt.user;curl 10.247.96.26
+<screen>&prompt.ardana;curl 10.247.96.26
  Welcome to 10.247.94.132</screen>
    </step>
    <step>
@@ -995,7 +1007,7 @@ ssh -o StrictHostKeyChecking=no -i lb_kp1.pem cirros@10.247.96.26 ./webserver.sh
      in the previous steps. Once the second web server is running, list the
      floating IPs.
     </para>
-<screen>&prompt.user;openstack floating ip list
+<screen>&prompt.ardana;openstack floating ip list
 +----------------+------------------+---------------------+---------------+
 | id             | fixed_ip_address | floating_ip_address | port_id       |
 +----------------+------------------+---------------------+---------------+
@@ -1008,7 +1020,7 @@ ssh -o StrictHostKeyChecking=no -i lb_kp1.pem cirros@10.247.96.26 ./webserver.sh
     <para>
      Display the floating IP for the load balancer.
     </para>
-<screen>&prompt.user;openstack floating ip show 9a3629bd-b0a6-474c-abe9-89c6ecb2b22c
+<screen>&prompt.ardana;openstack floating ip show 9a3629bd-b0a6-474c-abe9-89c6ecb2b22c
 +---------------------+--------------------------------------+
 | Field               | Value                                |
 +---------------------+--------------------------------------+
@@ -1026,22 +1038,22 @@ ssh -o StrictHostKeyChecking=no -i lb_kp1.pem cirros@10.247.96.26 ./webserver.sh
     <para>
      Test the load balancing.
     </para>
-<screen>&prompt.user;curl 10.247.96.28
+<screen>&prompt.ardana;curl 10.247.96.28
 Welcome to 10.247.94.132
 
-&prompt.user;curl 10.247.96.28
+&prompt.ardana;curl 10.247.96.28
 Welcome to 10.247.94.133
 
-&prompt.user;curl 10.247.96.28
+&prompt.ardana;curl 10.247.96.28
 Welcome to 10.247.94.132
 
-&prompt.user;curl 10.247.96.28
+&prompt.ardana;curl 10.247.96.28
 Welcome to 10.247.94.133
 
-&prompt.user;curl 10.247.96.28
+&prompt.ardana;curl 10.247.96.28
 Welcome to 10.247.94.132
 
-&prompt.user;curl 10.247.96.28
+&prompt.ardana;curl 10.247.96.28
 Welcome to 10.247.94.133</screen>
    </step>
   </procedure>


### PR DESCRIPTION
The amphora image path in the Cloud 9 documentation refers to the wrong path. Currently the Cloud 9 docs refer to the Cloud 8 path, despite the image location and name changing in Cloud 9.