### PR TITLE
fix instructions for TLS certitificate renewal (SOC-10846)

### DIFF
--- a/xml/security-troubleshooting_tls.xml
+++ b/xml/security-troubleshooting_tls.xml
@@ -104,61 +104,23 @@ ansible-playbook -i hosts/verb_hosts monasca-start.yml</screen>
   <procedure>
    <step>
     <para>
-     Stop &mariadb; with a playbook
+     Regenerate the TLS certificates on the deployer.
     </para>
-    <substeps>
-     <step>
-       <screen>&prompt.ardana;cd ~/scratch/ansible/next/hos/ansible
-&prompt.ardana;ansible-playbook -i hosts/verb_hosts percona-stop.yml</screen>
-     </step>
-     <step>
-      <para>
-       If the playbook failed, use the <literal>systemd</literal> command to
-       shutdown the daemon on each database node.
-      </para>
-      <screen>&prompt.ardana;sudo systemctl stop mysql</screen>
-     </step>
-     <step>
-      <para>
-       If the <literal>mysql</literal> daemon does not go down following the
-       <command>systemctl stop</command>, then kill the daemon using
-       <command>kill -9 mysqld</command> before continuing.
-      </para>
-     </step>
-    </substeps>
+    <screen>&prompt.ardana;cd ~/scratch/ansible/next/hos/ansible
+&prompt.ardana;ansible-playbook -i hosts/verb_hosts tls-reconfigure.yml --limit DEPLOYER_HOST</screen>
    </step>
    <step>
     <para>
-     Verify no mysqld processes are running. The following command should show
-     no entries.
+     Distribute the regenerated TLS certificates to the MySQL Percona clusters.
     </para>
-    <screen>&prompt.ardana;ps -aux | grep mysql</screen>
+    <screen>&prompt.ardana;cd ~/scratch/ansible/next/hos/ansible
+&prompt.ardana;ansible-playbook -i hosts/verb_hosts --extra-vars "mysql_certs_needs_regeneration=true" tls-percona-reconfigure.yml</screen>
    </step>
    <step>
     <para>
-     Commment out all lines with <literal>ssl</literal> in
-     <filename>/etc/mysql/my.cnf</filename> on all nodes.
+     Verify Percona cluster status on a controller node
     </para>
-   </step>
-   <step>
-    <para>
-     Bootstrap the first controller node
-    </para>
-    <screen>&prompt.ardana;cd ~/scratch/ansible/next/ardana/ansible
-&prompt.ardana;ansible-playbook -i hosts/verb_hosts percona-bootstrap.yml</screen>
-   </step>
-   <step>
-    <para>
-     Re-create the SSL certificates
-    </para>
-    <screen>&prompt.ardana;cd ~/scratch/ansible/next/ardana/ansible
-ansible-playbook -i hosts/verb_hosts tls-percona-reconfigure.yml</screen>
-   </step>
-   <step>
-    <para>
-     Verify Percona cluster status
-    </para>
-    <screen>&prompt.ardana;sudo mysql -e show status</screen>
+    <screen>&prompt.ardana;sudo mysql -e 'show status'</screen>
    </step>
   </procedure>
   <para>
@@ -175,11 +137,18 @@ Not After : Nov 6 15:15:38 2018 GMT</screen>
    </step>
    <step>
     <para>
+     Regenerate the TLS certificates on the deployer.
+    </para>
+    <screen>&prompt.ardana;cd ~/scratch/ansible/next/hos/ansible
+&prompt.ardana;ansible-playbook -i hosts/verb_hosts tls-reconfigure.yml --limit DEPLOYER_HOST</screen>
+   </step>
+   <step>
+    <para>
      Reconfigure &rabbit;. Certificate will be re-created if the input model is
      correct.
     </para>
     <screen>&prompt.ardana;cd ~/scratch/ansible/next/ardana/ansible
-&prompt.ardana;ansible-playbook -i hosts/verb_hosts rabbitmq-reconfigure.yml</screen>
+&prompt.ardana;ansible-playbook -i hosts/verb_hosts --extra-vars "rabbitmq_tls_certs_force_regeneration=true" rabbitmq-reconfigure.yml</screen>
    </step>
   </procedure>
  </section>


### PR DESCRIPTION
The instructions for TLS certificate renewal for MySQL replication
and rabbitmq are badly outdated. This PR modernize those instructions.

(cherry picked from commit 999466f18e52a6fe30c3e5f44df2fe68c3ca43c0)