### PR TITLE
Supplement/Upstream Admin: Fix guide grouping on documentation.suse.com

### DIFF
--- a/DC-suse-openstack-cloud-supplement
+++ b/DC-suse-openstack-cloud-supplement
@@ -4,7 +4,7 @@
 ## ----------------------------------------
 
 ## Basics
-MAIN="book_cloud_suppl.xml"
+MAIN="MAIN.suse-openstack-cloud.xml"
 ROOTID=book-supplement
 
 ## Profiling

--- a/DC-suse-openstack-cloud-upstream-admin
+++ b/DC-suse-openstack-cloud-upstream-admin
@@ -4,7 +4,7 @@
 ## ----------------------------------------
 
 ## Basics
-MAIN="bk_openstack-admin-guide.xml"
+MAIN="MAIN.suse-openstack-cloud.xml"
 ROOTID=book-upstream-admin
 
 ## Profiling


### PR DESCRIPTION
On documentation.suse.com/soc/9, the Supplement Guide & Upstream Admin
Guide are currently shown on two lines like this:

Supplement Guide   HTML
Supplement Guide   Single-HTML PDF EPUB

This commit aligns makes sure we use the same MAIN file both when
building with DC-...crowbar-all and with  DC-...supplement/
DC-...upstream-admin. This has the effect of fixing the grouping, so
everything all document formats are on one line on the web page.