### PR TITLE
Supplement: Fix grouping on nav page of documentation.suse.com

### DIFF
--- a/DC-suse-openstack-cloud-supplement
+++ b/DC-suse-openstack-cloud-supplement
@@ -9,7 +9,7 @@ ROOTID=book-supplement
 
 ## Profiling
 PROFOS="sles"
-PROFVENDOR="suse-crow"
+PROFVENDOR="suse"
 
 ## Stylesheet location
 STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2013-ns"


### PR DESCRIPTION
On documentation.suse.com/soc/9, the Supplement Guide is currently shown
on  two lines like this:

Supplement Guide   HTML
Supplement Guide   Single-HTML PDF EPUB

This commit aligns the profiling values of DC-...clm-all and
DC-...supplement. This has the effect of fixing the grouping, so
everything is in one line on the web page.