### PR TITLE
Cloud 9: Use GeekoDoc again

### DIFF
--- a/DC-rhel-installation
+++ b/DC-rhel-installation
@@ -13,6 +13,3 @@ PROFVENDOR="suse"
 
 ## Stylesheet location
 STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2013-ns"
-
-## Validation
-DOCBOOK5_RNG_URI="file:///usr/share/xml/docbook/schema/rng/5.1/docbookxi.rnc"

--- a/DC-suse-openstack-cloud-clm-all
+++ b/DC-suse-openstack-cloud-clm-all
@@ -13,6 +13,3 @@ PROFVENDOR="suse"
 
 ## Stylesheet location
 STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2013-ns"
-
-## Validation
-DOCBOOK5_RNG_URI="file:///usr/share/xml/docbook/schema/rng/5.1/docbookxi.rnc"

--- a/DC-suse-openstack-cloud-crowbar-all
+++ b/DC-suse-openstack-cloud-crowbar-all
@@ -13,6 +13,3 @@ PROFVENDOR="suse-crow"
 
 ## Stylesheet location
 STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2013-ns"
-
-## Validation
-DOCBOOK5_RNG_URI="file:///usr/share/xml/docbook/schema/rng/5.1/docbookxi.rnc"

--- a/DC-suse-openstack-cloud-crowbar-deployment
+++ b/DC-suse-openstack-cloud-crowbar-deployment
@@ -16,6 +16,3 @@ STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2013-ns"
 
 ## Sort the glossary
 XSLTPARAM="--param glossary.sort=1"
-
-## Validation
-DOCBOOK5_RNG_URI="file:///usr/share/xml/docbook/schema/rng/5.1/docbookxi.rnc"

--- a/DC-suse-openstack-cloud-crowbar-operations
+++ b/DC-suse-openstack-cloud-crowbar-operations
@@ -13,6 +13,3 @@ PROFVENDOR="suse-crow"
 
 ## Stylesheet location
 STYLEROOT=/usr/share/xml/docbook/stylesheet/suse2013
-
-## Validation
-DOCBOOK5_RNG_URI="file:///usr/share/xml/docbook/schema/rng/5.1/docbookxi.rnc"

--- a/DC-suse-openstack-cloud-deployment
+++ b/DC-suse-openstack-cloud-deployment
@@ -13,6 +13,3 @@ PROFVENDOR="suse"
 
 ## Stylesheet location
 STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2013-ns"
-
-## Validation
-DOCBOOK5_RNG_URI="file:///usr/share/xml/docbook/schema/rng/5.1/docbookxi.rnc"

--- a/DC-suse-openstack-cloud-operations
+++ b/DC-suse-openstack-cloud-operations
@@ -13,6 +13,3 @@ PROFVENDOR="suse"
 
 ## Stylesheet location
 STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2013-ns"
-
-## Validation
-DOCBOOK5_RNG_URI="file:///usr/share/xml/docbook/schema/rng/5.1/docbookxi.rnc"

--- a/DC-suse-openstack-cloud-poc-crowbar
+++ b/DC-suse-openstack-cloud-poc-crowbar
@@ -13,6 +13,3 @@ PROFVENDOR="suse-crow"
 
 ## Stylesheet location
 STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2013-ns"
-
-## Validation
-DOCBOOK5_RNG_URI="file:///usr/share/xml/docbook/schema/rng/5.1/docbookxi.rnc"

--- a/DC-suse-openstack-cloud-security
+++ b/DC-suse-openstack-cloud-security
@@ -13,6 +13,3 @@ PROFVENDOR="suse"
 
 ## Stylesheet location
 STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2013-ns"
-
-## Validation
-DOCBOOK5_RNG_URI="file:///usr/share/xml/docbook/schema/rng/5.1/docbookxi.rnc"

--- a/DC-suse-openstack-cloud-supplement
+++ b/DC-suse-openstack-cloud-supplement
@@ -13,6 +13,3 @@ PROFVENDOR="suse"
 
 ## Stylesheet location
 STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2013-ns"
-
-## Validation
-DOCBOOK5_RNG_URI="file:///usr/share/xml/docbook/schema/rng/5.1/docbookxi.rnc"

--- a/xml/depl_nodes.xml
+++ b/xml/depl_nodes.xml
@@ -1776,7 +1776,7 @@ and admins can see the available options in the barclamp -->
      <warning>
       <para>
        The name of the Identity Provider must be exactly the same as the
-        <guilabel>identity_provider</guilabel> attribute given when configuring
+        <guimenu>identity_provider</guimenu> attribute given when configuring
         Keystone in the previous section.
       </para>
      </warning>

--- a/xml/installation-installation-configure_lbaas.xml
+++ b/xml/installation-installation-configure_lbaas.xml
@@ -168,10 +168,11 @@
    <step>
     <para>
      The Amphora image is in an RPM package managed by zypper, display the full path to that file with the following command:
-     <screen>&prompt.ardana;find /srv -type f -name "*amphora-image*"</screen>
+    </para>
+    <screen>&prompt.ardana;find /srv -type f -name "*amphora-image*"</screen>
+    <para>
      For example:
-     <filename>/srv/www/suse-12.4/x86_64/repos/Cloud/suse/noarch/openstack-octavia-amphora-image-x86_64-0.1.0-13.157.noarch.rpm</filename>
-
+     <filename>/srv/www/suse-12.4/x86_64/repos/Cloud/suse/noarch/openstack-octavia-amphora-image-x86_64-0.1.0-13.157.noarch.rpm</filename>.
      The Amphora image may be updated via maintenance updates, which will change the filename.
     </para>
     <para>

--- a/xml/soc-operations-self-sign-cert.xml
+++ b/xml/soc-operations-self-sign-cert.xml
@@ -611,7 +611,7 @@
     </step>
     <step>
       <para>
-        Click <guilabel>Apply</guilabel>. Your changes will apply in a
+        Click <guimenu>Apply</guimenu>. Your changes will apply in a
         few minutes.
       </para>
     </step>
@@ -636,7 +636,7 @@
     </step>
     <step>
       <para>
-        Click <guilabel>Apply</guilabel>. Your changes will apply in a
+        Click <guimenu>Apply</guimenu>. Your changes will apply in a
         few minutes.
       </para>
     </step>
@@ -661,7 +661,7 @@
     </step>
     <step>
       <para>
-        Click <guilabel>Apply</guilabel>. Your changes will apply in a
+        Click <guimenu>Apply</guimenu>. Your changes will apply in a
         few minutes.
       </para>
     </step>
@@ -687,7 +687,7 @@
     </step>
     <step>
       <para>
-        Click <guilabel>Apply</guilabel>. Your changes will apply in a
+        Click <guimenu>Apply</guimenu>. Your changes will apply in a
         few minutes.
       </para>
     </step>
@@ -713,7 +713,7 @@
     </step>
     <step>
       <para>
-        Click <guilabel>Apply</guilabel>. Your changes will apply in a
+        Click <guimenu>Apply</guimenu>. Your changes will apply in a
         few minutes.
       </para>
     </step>
@@ -739,7 +739,7 @@
     </step>
     <step>
       <para>
-        Click <guilabel>Apply</guilabel>. Your changes will apply in a
+        Click <guimenu>Apply</guimenu>. Your changes will apply in a
         few minutes.
       </para>
     </step>
@@ -765,7 +765,7 @@
     </step>
     <step>
       <para>
-        Click <guilabel>Apply</guilabel>. Your changes will apply in a
+        Click <guimenu>Apply</guimenu>. Your changes will apply in a
         few minutes.
       </para>
     </step>


### PR DESCRIPTION
This branch fixes the minor issues that made the documents incompatible with GeekoDoc and it removes the DC file settings that made us always validate with DocBook instead of GeekoDoc.

To make sure you validate with GeekoDoc locally:

1. install the `geekodoc` package
2. Set DAPS to use GeekoDoc by default: `echo "DOCBOOK5_RNG_URI=https://github.com/openSUSE/geekodoc/raw/master/geekodoc/rng/geekodoc5-flat.rnc" > ~/.config/daps/dapsrc`
