### PR TITLE
master: Use GeekoDoc again

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,8 +33,7 @@ matrix:
         - echo "Building docker image"
         - docker build -t sle-doc-image .
       script:
-        - export DOCBOOK5_RNG_URI="file:///usr/share/xml/docbook/schema/rng/5.1/docbookxi.rnc"
-        - docker run -e DOCBOOK5_RNG_URI --rm -it sle-doc-image /bin/bash -c '/bin/bash travis.sh'
+        - docker run --rm -it sle-doc-image /bin/bash -c '/bin/bash travis.sh'
 
 notifications:
   email:

--- a/DC-rhel-installation
+++ b/DC-rhel-installation
@@ -13,6 +13,3 @@ PROFVENDOR="suse"
 
 ## Stylesheet location
 STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2013-ns"
-
-## Validation
-DOCBOOK5_RNG_URI="file:///usr/share/xml/docbook/schema/rng/5.1/docbookxi.rnc"

--- a/DC-suse-openstack-cloud-clm-all
+++ b/DC-suse-openstack-cloud-clm-all
@@ -13,6 +13,3 @@ PROFVENDOR="suse"
 
 ## Stylesheet location
 STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2013-ns"
-
-## Validation
-DOCBOOK5_RNG_URI="file:///usr/share/xml/docbook/schema/rng/5.1/docbookxi.rnc"

--- a/DC-suse-openstack-cloud-crowbar-all
+++ b/DC-suse-openstack-cloud-crowbar-all
@@ -13,6 +13,3 @@ PROFVENDOR="suse-crow"
 
 ## Stylesheet location
 STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2013-ns"
-
-## Validation
-DOCBOOK5_RNG_URI="file:///usr/share/xml/docbook/schema/rng/5.1/docbookxi.rnc"

--- a/DC-suse-openstack-cloud-crowbar-deployment
+++ b/DC-suse-openstack-cloud-crowbar-deployment
@@ -16,6 +16,3 @@ STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2013-ns"
 
 ## Sort the glossary
 XSLTPARAM="--param glossary.sort=1"
-
-## Validation
-DOCBOOK5_RNG_URI="file:///usr/share/xml/docbook/schema/rng/5.1/docbookxi.rnc"

--- a/DC-suse-openstack-cloud-crowbar-operations
+++ b/DC-suse-openstack-cloud-crowbar-operations
@@ -13,6 +13,3 @@ PROFVENDOR="suse-crow"
 
 ## Stylesheet location
 STYLEROOT=/usr/share/xml/docbook/stylesheet/suse2013
-
-## Validation
-DOCBOOK5_RNG_URI="file:///usr/share/xml/docbook/schema/rng/5.1/docbookxi.rnc"

--- a/DC-suse-openstack-cloud-deployment
+++ b/DC-suse-openstack-cloud-deployment
@@ -13,6 +13,3 @@ PROFVENDOR="suse"
 
 ## Stylesheet location
 STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2013-ns"
-
-## Validation
-DOCBOOK5_RNG_URI="file:///usr/share/xml/docbook/schema/rng/5.1/docbookxi.rnc"

--- a/DC-suse-openstack-cloud-operations
+++ b/DC-suse-openstack-cloud-operations
@@ -13,6 +13,3 @@ PROFVENDOR="suse"
 
 ## Stylesheet location
 STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2013-ns"
-
-## Validation
-DOCBOOK5_RNG_URI="file:///usr/share/xml/docbook/schema/rng/5.1/docbookxi.rnc"

--- a/DC-suse-openstack-cloud-poc
+++ b/DC-suse-openstack-cloud-poc
@@ -16,6 +16,3 @@ HTMLROOT="suse-openstack-cloud"
 
 ## stylesheet location
 STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2013-ns"
-
-## Validation
-DOCBOOK5_RNG_URI="file:///usr/share/xml/docbook/schema/rng/5.1/docbookxi.rnc"

--- a/DC-suse-openstack-cloud-poc-crowbar
+++ b/DC-suse-openstack-cloud-poc-crowbar
@@ -13,6 +13,3 @@ PROFVENDOR="suse-crow"
 
 ## Stylesheet location
 STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2013-ns"
-
-## Validation
-DOCBOOK5_RNG_URI="file:///usr/share/xml/docbook/schema/rng/5.1/docbookxi.rnc"

--- a/DC-suse-openstack-cloud-security
+++ b/DC-suse-openstack-cloud-security
@@ -13,6 +13,3 @@ PROFVENDOR="suse"
 
 ## Stylesheet location
 STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2013-ns"
-
-## Validation
-DOCBOOK5_RNG_URI="file:///usr/share/xml/docbook/schema/rng/5.1/docbookxi.rnc"

--- a/DC-suse-openstack-cloud-supplement
+++ b/DC-suse-openstack-cloud-supplement
@@ -13,6 +13,3 @@ PROFVENDOR="suse-crow"
 
 ## Stylesheet location
 STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2013-ns"
-
-## Validation
-DOCBOOK5_RNG_URI="file:///usr/share/xml/docbook/schema/rng/5.1/docbookxi.rnc"

--- a/xml/depl_nodes.xml
+++ b/xml/depl_nodes.xml
@@ -1781,7 +1781,7 @@ and admins can see the available options in the barclamp -->
      <warning>
       <para>
        The name of the Identity Provider must be exactly the same as the
-        <guilabel>identity_provider</guilabel> attribute given when configuring
+        <guimenu>identity_provider</guimenu> attribute given when configuring
         Keystone in the previous section.
       </para>
      </warning>

--- a/xml/installation-installation-configure_lbaas.xml
+++ b/xml/installation-installation-configure_lbaas.xml
@@ -168,10 +168,11 @@
    <step>
     <para>
      The Amphora image is in an RPM package managed by zypper, display the full path to that file with the following command:
-     <screen>&prompt.ardana;find /srv -type f -name "*amphora-image*"</screen>
+    </para>
+    <screen>&prompt.ardana;find /srv -type f -name "*amphora-image*"</screen>
+    <para>
      For example:
-     <filename>/srv/www/suse-12.4/x86_64/repos/Cloud/suse/noarch/openstack-octavia-amphora-image-x86_64-0.1.0-13.157.noarch.rpm</filename>
-
+     <filename>/srv/www/suse-12.4/x86_64/repos/Cloud/suse/noarch/openstack-octavia-amphora-image-x86_64-0.1.0-13.157.noarch.rpm</filename>.
      The Amphora image may be updated via maintenance updates, which will change the filename.
     </para>
     <para>

--- a/xml/poc-ceph-config.xml
+++ b/xml/poc-ceph-config.xml
@@ -8,7 +8,7 @@
 <chapter xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude"
  xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="ceph-config-clm">
 <title>Create Ceph Configuration for CLM</title>
-  <para>In this chapter you create the Ceph users, pools and RBDs that are required for
+  <para>In this chapter you create the Ceph users, pools, and RBDs that are required for
     OpenStack.</para>
     <section xml:id="config-ceph-cluster">
       <title>Configure Ceph Cluster for OpenStack Integration</title>
@@ -19,8 +19,8 @@
             as the <literal>root</literal> user.
           </para>
           <screen>
-            ssh root@192.168.200.30
-            (password: linux)
+ssh root@192.168.200.30
+(password: linux)
           </screen>
         </step>
         <step>
@@ -28,22 +28,18 @@
             Open a terminal and enter the following command to create the
             required Ceph users, pools and RBDs:
           </para>
-          <screen>
-            salt-run --out=yaml openstack.integrate prefix=mycloud
-          </screen>
+          <screen>salt-run --out=yaml openstack.integrate prefix=mycloud</screen>
           <para>
             When the commend has completed you should see YAML output
             displayed on the screen.
-            <note>
-              <para>If the salt-run command above returns errors, enter the
-                following command to force a resync of the nodes and then
-                rerun the previous salt-run command:
-                <screen>
-                  salt '*' saltutil.sync_all
-                </screen>
-              </para>
-            </note>
           </para>
+          <note>
+            <para>If the salt-run command above returns errors, enter the
+              following command to force a resync of the nodes and then
+              rerun the previous salt-run command:
+            </para>
+            <screen>salt '*' saltutil.sync_all</screen>
+          </note>
           <para>
             Copy the YAML output into a new text file named <literal>ses_config.yml</literal>.
           </para>
@@ -52,9 +48,7 @@
           <para>
             Enter the following command to SCP the file to the deployer node:
           </para>
-          <screen>
-            scp ses_config.yml ardana@192.168.200.10:~
-          </screen>
+          <screen>scp ses_config.yml ardana@192.168.200.10:~</screen>
           <para>
             The file should have been copied to the deployer node.
           </para>
@@ -81,19 +75,17 @@
           <para>
             Enter the following command to generate a new UUID:
           </para>
-          <screen>
-            uuidgen
-          </screen>
+          <screen>uuidgen</screen>
         </step>
         <step>
           <para>
-            In the installer web UI, on the <guilabel>Review configuration files</guilabel>
-            screen, select the <guilabel>Model</guilabel> tab.
+            In the installer web UI, on the <guimenu>Review configuration files</guimenu>
+            screen, select the <guimenu>Model</guimenu> tab.
           </para>
         </step>
         <step>
           <para>
-            On the <guilabel>Model</guilabel> tab select <guilabel>Control Plane</guilabel>.
+            On the <guimenu>Model</guimenu> tab select <guimenu>Control Plane</guimenu>.
             A file opens for editing.
           </para>
         </step>
@@ -103,23 +95,23 @@
             match the following:
           </para>
           <screen>
-            - glance-api:
-                glance_default_store: 'rbd'
+- glance-api:
+    glance_default_store: 'rbd'
           </screen>
         </step>
         <step>
           <para>
-            Click <guilabel>Save</guilabel> to save the file and close the editor.
+            Click <guimenu>Save</guimenu> to save the file and close the editor.
           </para>
         </step>
         <step>
           <para>
-            Select the <guilabel>Templates and services</guilabel> tab.
+            Select the <guimenu>Templates and services</guimenu> tab.
           </para>
         </step>
         <step>
           <para>
-            From the list of services, expand <guilabel>SES</guilabel> and
+            From the list of services, expand <guimenu>SES</guimenu> and
             select <literal>settings.yml</literal>.
             The <literal>settings.yml</literal> file opens for editing.
           </para>
@@ -130,30 +122,24 @@
             it to match the following (it is a single line with no line wrap
             in the file):
           </para>
-          <screen>
-            ses_config_path: /var/lib/ardana/
-          </screen>
+          <screen>ses_config_path: /var/lib/ardana/</screen>
         </step>
         <step>
           <para>
             Verify the SES config file name:
           </para>
-          <screen>
-            ses_config_file: ses_config.yml
-          </screen>
+          <screen>ses_config_file: ses_config.yml</screen>
         </step>
         <step>
           <para>
             Replace the value of the <literal>ses_secret_id:</literal> with the
             UUID you generated above:
           </para>
-          <screen>
-            ses_secret_id: SES_SECRET_ID
-          </screen>
+          <screen>ses_secret_id: SES_SECRET_ID</screen>
         </step>
         <step>
           <para>
-            Click <guilabel>Save</guilabel> to save the file and close the editor.
+            Click <guimenu>Save</guimenu> to save the file and close the editor.
           </para>
         </step>
      </procedure>
@@ -166,14 +152,14 @@
            Gateway certs to the deployer:
          </para>
          <screen>
-           mkdir -p /tmp/ardana_tls_certs
-           cd /tmp/ardana_tls_certs
-           scp tux@192.168.200.1:~/course_files/SOC312/ses_integration/rgw.crt ./
+mkdir -p /tmp/ardana_tls_certs
+cd /tmp/ardana_tls_certs
+scp tux@192.168.200.1:~/course_files/SOC312/ses_integration/rgw.crt ./
 
-           mkdir -p /tmp/ardana_tls_cacerts
-           cd /tmp/ardana_tls_cacerts
-           scp tux@192.168.200.1:~/course_files/SOC312/ses_integration/yast_ca.crt
-           ./
+mkdir -p /tmp/ardana_tls_cacerts
+cd /tmp/ardana_tls_cacerts
+scp tux@192.168.200.1:~/course_files/SOC312/ses_integration/yast_ca.crt
+./
          </screen>
          <para>
            The certificates have been copied.
@@ -194,9 +180,7 @@
            ardana user, enter the following command to display the
            keystone Endpoint URL:
          </para>
-         <screen>
-           grep OS_AUTH_URL ~/service.osrc | cut -d = -f 2
-         </screen>
+         <screen>grep OS_AUTH_URL ~/service.osrc | cut -d = -f 2</screen>
          <para>
           This is the <literal>KEYSTONE_ENDPOINT</literal>.
          </para>
@@ -205,9 +189,7 @@
          <para>
            Enter the following command to display the keystone Admin user:
          </para>
-         <screen>
-           grep OS_USERNAME ~/service.osrc | cut -d = -f 2
-         </screen>
+         <screen>grep OS_USERNAME ~/service.osrc | cut -d = -f 2</screen>
          <para>
            This is the <literal>KEYSTONE_ADMIN_USER</literal>.
          </para>
@@ -216,9 +198,7 @@
          <para>
            Enter the following command to display the keystone Admin user:
          </para>
-         <screen>
-           grep OS_PASSWORD ~/service.osrc | cut -d = -f 2
-         </screen>
+         <screen>grep OS_PASSWORD ~/service.osrc | cut -d = -f 2</screen>
          <para>
            This is the <literal>KEYSTONE_ADMIN_PASSWORD</literal>.
          </para>
@@ -227,9 +207,7 @@
          <para>
           Enter the following command to display the keystone Admin user:
          </para>
-         <screen>
-           grep OS_PROJECT_NAME ~/service.osrc | cut -d = -f 2
-         </screen>
+         <screen>grep OS_PROJECT_NAME ~/service.osrc | cut -d = -f 2</screen>
          <para>
            This is the <literal>KEYSTONE_ADMIN_PROJECT</literal>.
          </para>
@@ -238,9 +216,7 @@
          <para>
           Enter the following command to display the keystone Admin user:
          </para>
-         <screen>
-           grep OS_USER_DOMAIN ~/service.osrc | cut -d = -f 2
-         </screen>
+         <screen>grep OS_USER_DOMAIN ~/service.osrc | cut -d = -f 2</screen>
          <para>
            This is the <literal>KEYSTONE_ADMIN_DOMAIN</literal>.
          </para>
@@ -258,29 +234,29 @@
         <para>
           Add the following to the end of the file, replacing the lab variables
           with the values retrieved above:
-          <note>
-            <para>
-              Each line of the <literal>[client.rgw.storage01]</literal> section
-              should begin with <literal>rgw</literal>.
-            </para>
-          </note>
         </para>
         <screen>
-          [client.rgw.storage01]
-          rgw frontends = "civetweb port=80+443s
-          ssl_certificate=/etc/ceph/rgw.pem"
-          rgw enable usage log = true
-          rgw keystone url = KEYSTONE_ENDPOINT
-          rgw keystone admin user = KEYSTONE_ADMIN_USER
-          rgw keystone admin password = KEYSTONE_ADMIN_PASSWORD
-          rgw keystone admin project = KEYSTONE_ADMIN_PROJECT
-          rgw keystone admin domain = KEYSTONE_ADMIN_DOMAIN
-          rgw keystone api version = 3
-          rgw keystone accepted roles = admin,Member,_member_
-          rgw keystone accepted admin roles = admin
-          rgw keystone revocation interval = 0
-          rgw keystone verify ssl = false
+[client.rgw.storage01]
+rgw frontends = "civetweb port=80+443s
+ssl_certificate=/etc/ceph/rgw.pem"
+rgw enable usage log = true
+rgw keystone url = KEYSTONE_ENDPOINT
+rgw keystone admin user = KEYSTONE_ADMIN_USER
+rgw keystone admin password = KEYSTONE_ADMIN_PASSWORD
+rgw keystone admin project = KEYSTONE_ADMIN_PROJECT
+rgw keystone admin domain = KEYSTONE_ADMIN_DOMAIN
+rgw keystone api version = 3
+rgw keystone accepted roles = admin,Member,_member_
+rgw keystone accepted admin roles = admin
+rgw keystone revocation interval = 0
+rgw keystone verify ssl = false
         </screen>
+        <note>
+          <para>
+            Each line of the <literal>[client.rgw.storage01]</literal> section
+            should begin with <literal>rgw</literal>.
+          </para>
+        </note>
       </step>
       <step>
         <para>
@@ -295,8 +271,8 @@
           Enter the following commands to apply the updated configuration to the cluster:
         </para>
         <screen>
-          deepsea stage run ceph.stage.2
-          deepsea stage run ceph.stage.4
+deepsea stage run ceph.stage.2
+deepsea stage run ceph.stage.4
         </screen>
         <para>
           The services should be reconfigured.
@@ -306,9 +282,7 @@
         <para>
           Enter the following command to view the status of the Ceph cluster:
         </para>
-        <screen>
-          ceph -s
-        </screen>
+        <screen>ceph -s</screen>
         <para>
           You should see the rgw daemon is running (along with the other
           Ceph services).

--- a/xml/poc-finalise-env.xml
+++ b/xml/poc-finalise-env.xml
@@ -18,17 +18,13 @@
     <para>
       From the deployer node, SSH to the <literal>controller01</literal> node:
     </para>
-    <screen>
-      $ ssh 192.168.200.11
-    </screen>
+    <screen>ssh 192.168.200.11</screen>
   </step>
   <step>
     <para>
       Enter the following command to become root:
     </para>
-    <screen>
-      sudo -i
-    </screen>
+    <screen>sudo -i</screen>
     <para>
       You should now be logged in as the root user.
     </para>
@@ -37,44 +33,40 @@
     <para>
       Enter the following to launch the YaST NFS Client module:
     </para>
-    <screen>
-      yast nfs-client
-    </screen>
+    <screen>yast nfs-client</screen>
     <para>
-      If prompted that packages need to be installed, select <guilabel>Install</guilabel>
+      If prompted that packages need to be installed, select <guimenu>Install</guimenu>
       <literal>(Alt+i)</literal>.
     </para>
   </step>
   <step>
     <para>
-      On the <guilabel>NFS Client Configuration</guilabel> screen select
-    <guilabel>Add</guilabel> <literal>(Alt+a)</literal>.
+      On the <guimenu>NFS Client Configuration</guimenu> screen select
+    <guimenu>Add</guimenu> <literal>(Alt+a)</literal>.
     Enter the following:
     </para>
     <screen>
-      NFS Server: 192.168.200.10
-      Remote Directory: /export/glance
-      NFSv4 Share: (checked)
-      pNFS: (unchecked)
-      Mount Point (local): /var/lib/glance/images
-      Options: defaults
+NFS Server: 192.168.200.10
+Remote Directory: /export/glance
+NFSv4 Share: (checked)
+pNFS: (unchecked)
+Mount Point (local): /var/lib/glance/images
+Options: defaults
     </screen>
   </step>
   <step>
     <para>
-      Select <guilabel>OK</guilabel> <literal>(Alt+o)</literal>
+      Select <guimenu>OK</guimenu> <literal>(Alt+o)</literal>
       to apply the changes.
-      If prompted that packages need to be installed, select <guilabel>Install</guilabel>
-      <literal>(Alt+i)</literal>.
+      If prompted that packages need to be installed, select <guimenu>Install</guimenu>
+      (<keycombo><keycap function="alt"/><keycap>I</keycap></keycombo>).
     </para>
   </step>
   <step>
     <para>
       Enter the following command to verify that the share is mounted:
     </para>
-    <screen>
-      mount | grep glance
-    </screen>
+    <screen>mount | grep glance</screen>
     <para>
       You should see the mount entry listed.
     </para>
@@ -89,14 +81,14 @@
   <procedure><title>Select the Correct Network Interface Models for NFS Shared Storage</title>
     <step>
       <para>
-        On the seventh screen (<guilabel>Review configuration files</guilabel>),
-        select the <guilabel>Model</guilabel> tab.
+        On the seventh screen (<guimenu>Review configuration files</guimenu>),
+        select the <guimenu>Model</guimenu> tab.
       </para>
     </step>
     <step>
       <para>
-        On the <guilabel>Model</guilabel> tab select
-        <guilabel>Disks</guilabel> (1TB Controller). The file should be
+        On the <guimenu>Model</guimenu> tab select
+        <guimenu>Disks</guimenu> (1TB Controller). The file should be
         opened for editing.
       </para>
     </step>
@@ -106,17 +98,17 @@
         indented 2 spaces):
       </para>
       <screen>
-        device-groups:
-          - name: cinder-volumes
-            devices:
-              - name: /dev/sdb
-            consumer:
-              name: cinder
+device-groups:
+  - name: cinder-volumes
+    devices:
+      - name: /dev/sdb
+    consumer:
+      name: cinder
       </screen>
     </step>
     <step>
       <para>
-        Click <guilabel>Save</guilabel> and close the editor.
+        Click <guimenu>Save</guimenu> and close the editor.
       </para>
     </step>
   </procedure>

--- a/xml/poc-install-deployer-node.xml
+++ b/xml/poc-install-deployer-node.xml
@@ -30,38 +30,38 @@
       SUSE Linux Enterprise Server installation process.
      </para>
    </note>
-    <screen>
-     IP Addressing:
-      Create a bond0 interface with eth0 and eth1 as the bond slaves
-      Hostname: deployer.example.com
-      bond0 IP: 192.168.200.10/24
-      Gateway: 192.168.200.1
-      DNS: 192.168.200.1 , 8.8.8.8
-     Partitioning:
-      /dev/sda1
-      Size: 250GB
-      Filesystem: ext4
-      Mount Point: /boot
-      /dev/sda2
-      Size: 250GB
-      Filesystem: vfat
-      Mount Point: /boot/efi
-      /dev/sda3
-      Size: (remaining space)
-      Type: LVM
-      LVM VG:
-      Name: ardana-vg
-      Disks: /dev/sda3
-      LVM LV:
-      Name: root
-      Size: 50GB
-      Filesystem: ext4
-     Users:
-      Username: root
-      Password: [PASSWORD]
-      Username: [USERNAME]
-      Password: [PASSWORD]
-    </screen>
+  <screen>
+IP Addressing:
+  Create a bond0 interface with eth0 and eth1 as the bond slaves
+  Hostname: deployer.example.com
+  bond0 IP: 192.168.200.10/24
+  Gateway: 192.168.200.1
+  DNS: 192.168.200.1 , 8.8.8.8
+Partitioning:
+  /dev/sda1
+  Size: 250GB
+  Filesystem: ext4
+  Mount Point: /boot
+  /dev/sda2
+  Size: 250GB
+  Filesystem: vfat
+  Mount Point: /boot/efi
+  /dev/sda3
+  Size: (remaining space)
+  Type: LVM
+  LVM VG:
+  Name: ardana-vg
+  Disks: /dev/sda3
+  LVM LV:
+  Name: root
+  Size: 50GB
+  Filesystem: ext4
+Users:
+  Username: root
+  Password: [PASSWORD]
+  Username: [USERNAME]
+  Password: [PASSWORD]
+  </screen>
  </section>
 
  <section xml:id="install-configure-SMT">
@@ -82,9 +82,7 @@
          <para>
          Install the SMT Server pattern.
          </para>
-         <screen>
-           $ sudo zypper in -t pattern smt
-         </screen>
+         <screen>sudo zypper in -t pattern smt</screen>
        </step>
        <step>
          <para>
@@ -100,6 +98,7 @@
        <step>
          <para>
          Mirror the following repositories:
+         </para>
          <itemizedlist>
            <listitem>
              <para>
@@ -122,7 +121,6 @@
              </para>
            </listitem>
          </itemizedlist>
-         </para>
        </step>
      </procedure>
  </section>
@@ -133,8 +131,8 @@
     <step>
       <para>As the root user, open a terminal and enter
         the following to create the required directory:
-        <screen>mkdir -p /srv/www/suse-12.4/x86_64/repos/Cloud</screen>
       </para>
+      <screen>mkdir -p /srv/www/suse-12.4/x86_64/repos/Cloud</screen>
     </step>
     <step>
       <para>Copy the contents of the Cloud 9 installation media to
@@ -144,26 +142,24 @@
       <para>Enter the following command to add the installation media and
         the Cloud install and update repositories from the SMT server
         to Libzypp:
-        <screen>
-          zypper ar dir:///srv/www/suse-12.4/x86_64/repos/Cloud SOC9-Install
-          zypper ar dir:///srv/www/htdocs/repo/SUSE/Products/OpenStackCloud/9/x86_64/product SOC9-Pool
-          zypper ar dir:///srv/www/htdocs/repo/SUSE/Updates/OpenStackCloud/9/x86_64/update SOC9-Updates
-       </screen>
-     </para>
+      </para>
+      <screen>
+zypper ar dir:///srv/www/suse-12.4/x86_64/repos/Cloud SOC9-Install
+zypper ar dir:///srv/www/htdocs/repo/SUSE/Products/OpenStackCloud/9/x86_64/product SOC9-Pool
+zypper ar dir:///srv/www/htdocs/repo/SUSE/Updates/OpenStackCloud/9/x86_64/update SOC9-Updates
+      </screen>
    </step>
    <step>
      <para>Enter the following commands to update the server:</para>
      <screen>
-       zypper ref
-       zypper -n patch
+zypper ref
+zypper -n patch
      </screen>
    </step>
    <step>
      <para>Enter the following command to install the required pattern:
-       <screen>
-         zypper -n in -t pattern cloud_user
-       </screen>
      </para>
+     <screen>zypper -n in -t pattern cloud_user</screen>
    </step>
  </procedure>
  <para>The Ardana pattern should now be installed.</para>
@@ -174,14 +170,14 @@
    <procedure>
      <step>
        <para>Use the following command to set the ardana user's password:
-         <screen>passwd ardana</screen>
        </para>
+       <screen>passwd ardana</screen>
        <para>When prompted, set the password.</para>
      </step>
      <step>
        <para>Use the following command to switch to the ardana user:
-         <screen>su - ardana</screen>
        </para>
+       <screen>su - ardana</screen>
      </step>
    </procedure>
    <para>You should now be logged in as the ardana user.</para>

--- a/xml/poc-map-ui-steps.xml
+++ b/xml/poc-map-ui-steps.xml
@@ -20,10 +20,8 @@
         <emphasis>ardana</emphasis> user and from the ardana user's home
         directory, enter the following command to initialize the installer
         environment:
-        <screen>
-          ARDANA_INIT_AUTO=1 /usr/bin/ardana-init
-        </screen>
       </para>
+      <screen>ARDANA_INIT_AUTO=1 /usr/bin/ardana-init</screen>
       <para>You should see some Ansible playbooks run resulting in green
            <literal>ok=</literal> messages and yellow <literal>changed=</literal>
            messages. If there are any red <literal>failed=</literal> messages,
@@ -32,7 +30,9 @@
     <step>
       <para>
         On the<literal>deployer01</literal> node, open a web browser and point to:
-        <screen>http://localhost:9085</screen>
+       </para>
+       <screen>http://localhost:9085</screen>
+       <para>
         You should see the SUSE OpenStack Cloud Deployer screen.
       </para>
     </step>
@@ -46,7 +46,7 @@
       <step>
         <para>
           On the welcome screen of the SUSE OpenStack Cloud
-          Deployer, click <guilabel>Next</guilabel>.
+          Deployer, click <guimenu>Next</guimenu>.
         </para>
       </step>
       <step>
@@ -55,36 +55,36 @@
           We recommend using the Entry-Scale Cloud. For more information,
           see <link xlink:href="https://www.suse.com/documentation/suse-openstack-cloud-9/singlehtml/book-deployment/book-deployment.html#entry-scale-kvm"><citetitle>Entry-Scale Cloud</citetitle></link>
           in the Deployment Guide.
-          Click <guilabel>Next</guilabel>.
+          Click <guimenu>Next</guimenu>.
         </para>
       </step>
       <step>
         <para>
-          On the left, under <guilabel>Mandatory Components</guilabel>, select
-          <guilabel>Lifecycle Manager Nodes</guilabel>.
-          On the right, in the <guilabel>Edit number of nodes</guilabel> text
+          On the left, under <guimenu>Mandatory Components</guimenu>, select
+          <guimenu>Lifecycle Manager Nodes</guimenu>.
+          On the right, in the <guimenu>Edit number of nodes</guimenu> text
           box enter: <literal>1</literal>.
         </para>
       </step>
       <step>
         <para>
-          Under <guilabel>Mandatory Components</guilabel>, select
-          <guilabel>Controller Nodes</guilabel>.
-          On the right, in the <guilabel>Edit number of nodes</guilabel> text
+          Under <guimenu>Mandatory Components</guimenu>, select
+          <guimenu>Controller Nodes</guimenu>.
+          On the right, in the <guimenu>Edit number of nodes</guimenu> text
           box enter: <literal>1</literal>.
         </para>
       </step>
       <step>
         <para>
-          On the left, under <guilabel>Additional Components</guilabel>, select
-          <guilabel>Compute Nodes</guilabel>.
-          On the right, in the <guilabel>Edit minimum number of nodes</guilabel> text
+          On the left, under <guimenu>Additional Components</guimenu>, select
+          <guimenu>Compute Nodes</guimenu>.
+          On the right, in the <guimenu>Edit minimum number of nodes</guimenu> text
           box enter: <literal>1</literal>.
         </para>
       </step>
       <step>
         <para>
-          Click <guilabel>Next</guilabel>.
+          Click <guimenu>Next</guimenu>.
         </para>
       </step>
     </procedure>
@@ -95,15 +95,15 @@
     <procedure><title>Configure Cloud DNS, Hostnames and NTP</title>
       <step>
         <para>
-          On the next screen (<guilabel>Add Servers and Assign
-          Server Roles</guilabel>), in the top right, click
-          <guilabel>Manage Cloud Settings</guilabel>.
+          On the next screen (<guimenu>Add Servers and Assign
+          Server Roles</guimenu>), in the top right, click
+          <guimenu>Manage Cloud Settings</guimenu>.
         </para>
       </step>
       <step>
         <para>
-          On the <guilabel>Manage Cloud Settings</guilabel> window select
-          the <guilabel>Cloud Configuration tab</guilabel>.
+          On the <guimenu>Manage Cloud Settings</guimenu> window select
+          the <guimenu>Cloud Configuration tab</guimenu>.
         </para>
       </step>
       <step>
@@ -111,20 +111,20 @@
           Enter the following:
         </para>
         <screen>
-          Host Name Prefix: ardana
-          Host Member Prefix: -m
-          DNS Name Servers: 192.168.200.1
-          NTP Servers: 192.168.200.1
+Host Name Prefix: ardana
+Host Member Prefix: -m
+DNS Name Servers: 192.168.200.1
+NTP Servers: 192.168.200.1
         </screen>
       </step>
       <step>
         <para>
-          Click <guilabel>Save</guilabel>.
+          Click <guimenu>Save</guimenu>.
         </para>
       </step>
       <step>
         <para>
-          Close the <guilabel>Manage Cloud Settings</guilabel> window.
+          Close the <guimenu>Manage Cloud Settings</guimenu> window.
         </para>
       </step>
     </procedure>
@@ -132,26 +132,26 @@
     <procedure><title>Configure Disk Models</title>
       <step>
         <para>
-          On the top right, click <guilabel>Manage Cloud Settings</guilabel>.
+          On the top right, click <guimenu>Manage Cloud Settings</guimenu>.
         </para>
       </step>
       <step>
         <para>
-          On the <guilabel>Manage Cloud Settings</guilabel> window select
-          the <guilabel>Disk Models</guilabel> tab.
+          On the <guimenu>Manage Cloud Settings</guimenu> window select
+          the <guimenu>Disk Models</guimenu> tab.
         </para>
       </step>
       <step>
         <para>
-          On the <guilabel>Manage Cloud Settings</guilabel> window select
-          the <guilabel>Disk Models</guilabel> tab.
+          On the <guimenu>Manage Cloud Settings</guimenu> window select
+          the <guimenu>Disk Models</guimenu> tab.
           You should see the following disk models listed:
         </para>
         <screen>
-          COMPUTE-DISKS
-          CONTROLLER-1TB-DISKS
-          CONTROLLER-600GB-DISKS
-          LIFECYCLE-MANAGER-DISKS
+COMPUTE-DISKS
+CONTROLLER-1TB-DISKS
+CONTROLLER-600GB-DISKS
+LIFECYCLE-MANAGER-DISKS
         </screen>
       </step>
       <step>
@@ -174,73 +174,71 @@
     </note>
       <step>
         <para>
-          Click <guilabel>Add disk model</guilabel>.
+          Click <guimenu>Add disk model</guimenu>.
         </para>
       </step>
       <step>
         <para>
           On the right hand side, in the Disk model name field enter:
         </para>
-        <screen>
-          LIFECYCLE-MANAGER-DISKS
-        </screen>
+        <screen>LIFECYCLE-MANAGER-DISKS</screen>
       </step>
       <step>
         <para>
-          Click <guilabel>Add volume group</guilabel>.
-          Under <guilabel>Add volume group</guilabel>, enter the following:
+          Click <guimenu>Add volume group</guimenu>.
+          Under <guimenu>Add volume group</guimenu>, enter the following:
         </para>
         <screen>
-          Volume group name: ardana-vg
-          Physical volume: /dev/sda_root
+Volume group name: ardana-vg
+Physical volume: /dev/sda_root
         </screen>
         <para>
-          To add a new logical volume, click: <guilabel>Add logical volume</guilabel>.
+          To add a new logical volume, click: <guimenu>Add logical volume</guimenu>.
         </para>
       </step>
       <step>
         <para>
-          Under <guilabel>Add logical volume</guilabel>, enter the following:
+          Under <guimenu>Add logical volume</guimenu>, enter the following:
         </para>
         <screen>
-          Logical volume name: root
-          Size: 80
-          Mount: /
-          File system type: ext4
-          mkfs command options: (leave empty)
+Logical volume name: root
+Size: 80
+Mount: /
+File system type: ext4
+mkfs command options: (leave empty)
         </screen>
         <para>
-          To save the logical volume configuration, click <guilabel>Save</guilabel>.
-          Back under <guilabel>Logical volume</guilabel>
-          (under <guilabel>Add volume group</guilabel>) you should see the
+          To save the logical volume configuration, click <guimenu>Save</guimenu>.
+          Back under <guimenu>Logical volume</guimenu>
+          (under <guimenu>Add volume group</guimenu>) you should see the
           new logical volume listed.</para>
       </step>
       <step>
         <para>
-          To add another logical volume, click <guilabel>Add logical volume</guilabel>.
-          Under <guilabel>Add logical volume</guilabel>, enter the following:
+          To add another logical volume, click <guimenu>Add logical volume</guimenu>.
+          Under <guimenu>Add logical volume</guimenu>, enter the following:
         </para>
         <screen>
-          Logical volume name: crash
-          Size: 15
-          Mount: /var/crash
-          File system type: ext4
-          mkfs command options: -O large_file
+Logical volume name: crash
+Size: 15
+Mount: /var/crash
+File system type: ext4
+mkfs command options: -O large_file
         </screen>
         <para>
-          To save the logical volume configuration, click <guilabel>Save</guilabel>.
+          To save the logical volume configuration, click <guimenu>Save</guimenu>.
           You should see the new logical volume listed.
         </para>
       </step>
       <step>
         <para>
-          To save the volume group configuration, click <guilabel>Save</guilabel>.
+          To save the volume group configuration, click <guimenu>Save</guimenu>.
           You should see the new volume group listed.
         </para>
       </step>
       <step>
         <para>
-          To save the disk model configuration, click <guilabel>Save</guilabel>.
+          To save the disk model configuration, click <guimenu>Save</guimenu>.
           You should see the new disk model listed.
         </para>
       </step>
@@ -249,21 +247,21 @@
     <procedure><title>Configure NIC Mappings</title>
       <step>
         <para>
-          On the screen <guilabel>Server and Server Role
-          Summary</guilabel>, in the top right, click
-          <guilabel>Manage Cloud Settings</guilabel>.
+          On the screen <guimenu>Server and Server Role
+          Summary</guimenu>, in the top right, click
+          <guimenu>Manage Cloud Settings</guimenu>.
         </para>
       </step>
       <step>
         <para>
-          On the <guilabel>Manage Cloud Settings</guilabel> window select
-          the <guilabel>NIC mappings</guilabel> tab.
+          On the <guimenu>Manage Cloud Settings</guimenu> window select
+          the <guimenu>NIC mappings</guimenu> tab.
           You should see the following disk models listed:
         </para>
         <screen>
-          COMPUTE-6PORT
-          CONTROLLER-6PORT
-          LIFECYCLE-MANAGER-2PORT
+COMPUTE-6PORT
+CONTROLLER-6PORT
+LIFECYCLE-MANAGER-2PORT
         </screen>
       </step>
       <step>
@@ -285,8 +283,8 @@
     </note>
       <step>
         <para>
-          On the <guilabel>Manage Cloud Settings – NIC Mapping</guilabel>
-          window click <guilabel>Add NIC Mapping</guilabel>.
+          On the <guimenu>Manage Cloud Settings – NIC Mapping</guimenu>
+          window click <guimenu>Add NIC Mapping</guimenu>.
         </para>
       </step>
       <step>
@@ -295,69 +293,69 @@
           the controller nodes, enter the following:
         </para>
         <screen>
-          NIC Mapping Name: CONTROLLER-6PORT
-          Port Logical Name: eth0
-          PCI Address: 0000:00:03.0
+NIC Mapping Name: CONTROLLER-6PORT
+Port Logical Name: eth0
+PCI Address: 0000:00:03.0
         </screen>
       </step>
       <step>
         <para>
-          Click the <guilabel>+</guilabel> on the right of the
+          Click the <guimenu>+</guimenu> on the right of the
           port/PCI address line to add a second line.
           Enter the following on the second line:
         </para>
         <screen>
-          Port Logical Name: eth1
-          PCI Address: 0000:00:07.0
+Port Logical Name: eth1
+PCI Address: 0000:00:07.0
         </screen>
       </step>
       <step>
         <para>
-          Click the <guilabel>+</guilabel> on the right of the
+          Click the <guimenu>+</guimenu> on the right of the
           port/PCI address line to add a third line.
           Enter the following on the third line:
         </para>
         <screen>
-          Port Logical Name: eth2
-          PCI Address: 0000:00:08.0
+Port Logical Name: eth2
+PCI Address: 0000:00:08.0
         </screen>
       </step>
       <step>
         <para>
-          Click the <guilabel>+</guilabel> on the right of the
+          Click the <guimenu>+</guimenu> on the right of the
           port/PCI address line to add a forth line.
           Enter the following on the forth line:
         </para>
         <screen>
-          Port Logical Name: eth3
-          PCI Address: 0000:00:10.0
+Port Logical Name: eth3
+PCI Address: 0000:00:10.0
         </screen>
       </step>
       <step>
         <para>
-          Click the <guilabel>+</guilabel> on the right of the
+          Click the <guimenu>+</guimenu> on the right of the
           port/PCI address line to add a fifth line.
           Enter the following on the fifth line:
         </para>
         <screen>
-          Port Logical Name: eth4
-          PCI Address: 0000:00:11.0
+Port Logical Name: eth4
+PCI Address: 0000:00:11.0
         </screen>
       </step>
       <step>
         <para>
-          Click the <guilabel>+</guilabel> on the right of the
+          Click the <guimenu>+</guimenu> on the right of the
           port/PCI address line to add a fifth line.
           Enter the following on the fifth line:
         </para>
         <screen>
-          Port Logical Name: eth5
-          PCI Address: 0000:00:12.0
+Port Logical Name: eth5
+PCI Address: 0000:00:12.0
         </screen>
       </step>
       <step>
         <para>
-          Click <guilabel>Save</guilabel>.
+          Click <guimenu>Save</guimenu>.
         </para>
       </step>
     </procedure>
@@ -376,8 +374,8 @@
     <procedure><title>Configure Lifecycle Manager NIC Mappings</title>
       <step>
         <para>
-          On the <guilabel>Manage Cloud Settings – NIC Mapping</guilabel>
-          window click <guilabel>Add NIC Mapping</guilabel>.
+          On the <guimenu>Manage Cloud Settings – NIC Mapping</guimenu>
+          window click <guimenu>Add NIC Mapping</guimenu>.
         </para>
       </step>
       <step>
@@ -386,14 +384,14 @@
           the controller nodes, enter the following:
         </para>
         <screen>
-          NIC Mapping Name: LIFECYCLE-MANAGER-1PORT
-          Port Logical Name: eth0
-          PCI Address: 0000:00:03.0
+NIC Mapping Name: LIFECYCLE-MANAGER-1PORT
+Port Logical Name: eth0
+PCI Address: 0000:00:03.0
         </screen>
       </step>
       <step>
         <para>
-          Click <guilabel>Save</guilabel>.
+          Click <guimenu>Save</guimenu>.
         </para>
       </step>
     </procedure>
@@ -401,21 +399,21 @@
     <procedure><title>Configure Interface Models</title>
       <step>
         <para>
-          On the <guilabel>Server and Server Role
-          Summary</guilabel> window, in the top right, click
-          <guilabel>Manage Cloud Settings</guilabel>.
+          On the <guimenu>Server and Server Role
+          Summary</guimenu> window, in the top right, click
+          <guimenu>Manage Cloud Settings</guimenu>.
         </para>
       </step>
       <step>
         <para>
-          On the <guilabel>Manage Cloud Settings</guilabel> window select
-          the <guilabel>Interface Models</guilabel> tab.
+          On the <guimenu>Manage Cloud Settings</guimenu> window select
+          the <guimenu>Interface Models</guimenu> tab.
           You should see the following disk models listed:
         </para>
         <screen>
-          COMPUTE-INTERFACES-3-BONDS
-          CONTROLLER-INTERFACES-3-BONDS
-          LIFECYCLE-MANAGER-INTERFACES-1-BOND
+COMPUTE-INTERFACES-3-BONDS
+CONTROLLER-INTERFACES-3-BONDS
+LIFECYCLE-MANAGER-INTERFACES-1-BOND
         </screen>
       </step>
       <step>
@@ -432,34 +430,32 @@
     <procedure><title>Configure the Lifecycle Manager Interface Model</title>
       <step>
         <para>
-          Click <guilabel>Add interface model</guilabel>.
+          Click <guimenu>Add interface model</guimenu>.
           In the Interface model field enter:
         </para>
-        <screen>
-          LIFECYCLE-MANAGER-INTERFACES-1-BOND
-        </screen>
+        <screen>LIFECYCLE-MANAGER-INTERFACES-1-BOND</screen>
       </step>
       <step>
         <para>
-          Under <guilabel>Interfaces</guilabel>, click
-          <guilabel>Add Network Interface</guilabel>.
+          Under <guimenu>Interfaces</guimenu>, click
+          <guimenu>Add Network Interface</guimenu>.
           Enter the following:
         </para>
         <screen>
-          Network Interface Name: BOND0
-          Network Devices: eth0
-          Network Devices: eth1
-          Forced Network Groups: None
-          Network Groups: MANAGEMENT
-          Bond device name: bond0
-          Bond options: miimon: 200
-                        mode: active-backup
-                        primary: eth0
+Network Interface Name: BOND0
+Network Devices: eth0
+Network Devices: eth1
+Forced Network Groups: None
+Network Groups: MANAGEMENT
+Bond device name: bond0
+Bond options: miimon: 200
+              mode: active-backup
+              primary: eth0
         </screen>
       </step>
       <step>
         <para>
-          Click <guilabel>Save</guilabel>.
+          Click <guimenu>Save</guimenu>.
         </para>
       </step>
     </procedure>
@@ -468,81 +464,81 @@
       <step>
         <para>
           On the right side of the <literal>COMPUTE-INTERFACES</literal>
-          network click the <guilabel>edit</guilabel> button.
+          network click the <guimenu>edit</guimenu> button.
         </para>
       </step>
       <step>
         <para>
-          On the right, in the <guilabel>Edit Interface Model</guilabel>
-          section, under <guilabel>Interfaces</guilabel>, delete any existing
+          On the right, in the <guimenu>Edit Interface Model</guimenu>
+          section, under <guimenu>Interfaces</guimenu>, delete any existing
           interfaces by clicking the trash can icon on their right.
-          When asked if you are sure, click <guilabel>Yes</guilabel>.</para>
+          When asked if you are sure, click <guimenu>Yes</guimenu>.</para>
       </step>
       <step>
         <para>
-          Click <guilabel>Add Network Interface</guilabel>.
+          Click <guimenu>Add Network Interface</guimenu>.
           Enter the following:
         </para>
         <screen>
-          Network Interface Name: BOND0
-          Network Devices: eth0
-          Network Devices: eth1
-          Forced Network Groups: None
-          Network Groups: MANAGEMENT
-          Network Groups: GUEST
-          Bond device name: bond0
-          Bond options: miimon: 200
-                        mode: active-backup
-                        primary: eth0
+Network Interface Name: BOND0
+Network Devices: eth0
+Network Devices: eth1
+Forced Network Groups: None
+Network Groups: MANAGEMENT
+Network Groups: GUEST
+Bond device name: bond0
+Bond options: miimon: 200
+              mode: active-backup
+              primary: eth0
         </screen>
       </step>
       <step>
         <para>
-          Click <guilabel>Save</guilabel>.
+          Click <guimenu>Save</guimenu>.
         </para>
       </step>
       <step>
         <para>
-          Click <guilabel>Add Network Interface</guilabel>.
+          Click <guimenu>Add Network Interface</guimenu>.
           Enter the following:
         </para>
         <screen>
-          Network Interface Name: BOND1
-          Network Devices: eth2
-          Network Devices: eth3
-          Forced Network Groups: None
-          Network Groups: EXTERNAL-VM
-          Bond device name: bond1
-          Bond options: miimon: 200
-                        mode: active-backup
-                        primary: eth0
+Network Interface Name: BOND1
+Network Devices: eth2
+Network Devices: eth3
+Forced Network Groups: None
+Network Groups: EXTERNAL-VM
+Bond device name: bond1
+Bond options: miimon: 200
+              mode: active-backup
+              primary: eth0
         </screen>
       </step>
       <step>
         <para>
-          Click <guilabel>Add Network Interface</guilabel>.
+          Click <guimenu>Add Network Interface</guimenu>.
           Enter the following:
         </para>
         <screen>
-          Network Interface Name: BOND2
-          Network Devices: eth4
-          Network Devices: eth5
-          Forced Network Groups: None
-          Network Groups: STORAGE
-          Bond device name: bond2
-          Bond options: miimon: 200
-                        mode: active-backup
-                        primary: eth0
+Network Interface Name: BOND2
+Network Devices: eth4
+Network Devices: eth5
+Forced Network Groups: None
+Network Groups: STORAGE
+Bond device name: bond2
+Bond options: miimon: 200
+              mode: active-backup
+              primary: eth0
         </screen>
       </step>
       <step>
         <para>
-          Click <guilabel>Save</guilabel>.
+          Click <guimenu>Save</guimenu>.
         </para>
       </step>
       <step>
         <para>
-          To save the Interface Model, click <guilabel>Save</guilabel>.
+          To save the Interface Model, click <guimenu>Save</guimenu>.
         </para>
       </step>
     </procedure>
@@ -551,83 +547,83 @@
     <step>
       <para>
         On the right side of the <literal>CONTROLLER-INTERFACES</literal>
-        network click the <guilabel>edit</guilabel> button.
+        network click the <guimenu>edit</guimenu> button.
       </para>
     </step>
     <step>
       <para>
-        On the right, in the <guilabel>Edit Interface Model</guilabel>
-        section, under <guilabel>Interfaces</guilabel>, delete any existing
+        On the right, in the <guimenu>Edit Interface Model</guimenu>
+        section, under <guimenu>Interfaces</guimenu>, delete any existing
         interfaces by clicking the trash can icon on their right.
-        When asked if you are sure, click <guilabel>Yes</guilabel>.
+        When asked if you are sure, click <guimenu>Yes</guimenu>.
       </para>
     </step>
     <step>
       <para>
-        Click <guilabel>Add Network Interface</guilabel>.
+        Click <guimenu>Add Network Interface</guimenu>.
         Enter the following:
       </para>
       <screen>
-        Network Interface Name: BOND0
-        Network Devices: eth0
-        Network Devices: eth1
-        Forced Network Groups: None
-        Network Groups: MANAGEMENT
-        Network Groups: GUEST
-        Bond device name: bond0
-        Bond options: miimon: 200
-                      mode: active-backup
-                      primary: eth0
+Network Interface Name: BOND0
+Network Devices: eth0
+Network Devices: eth1
+Forced Network Groups: None
+Network Groups: MANAGEMENT
+Network Groups: GUEST
+Bond device name: bond0
+Bond options: miimon: 200
+              mode: active-backup
+              primary: eth0
       </screen>
      </step>
       <step>
         <para>
-          Click <guilabel>Save</guilabel>.
+          Click <guimenu>Save</guimenu>.
         </para>
       </step>
       <step>
         <para>
-          Click <guilabel>Add Network Interface</guilabel>.
+          Click <guimenu>Add Network Interface</guimenu>.
           Enter the following:
         </para>
         <screen>
-          Network Interface Name: BOND1
-          Network Devices: eth2
-          Network Devices: eth3
-          Forced Network Groups: None
-          Network Groups: EXTERNAL-API
-          Network Groups: EXTERNAL-VM
-          Bond device name: bond1
-          Bond options: miimon: 200
-                        mode: active-backup
-                        primary: eth0
+Network Interface Name: BOND1
+Network Devices: eth2
+Network Devices: eth3
+Forced Network Groups: None
+Network Groups: EXTERNAL-API
+Network Groups: EXTERNAL-VM
+Bond device name: bond1
+Bond options: miimon: 200
+              mode: active-backup
+              primary: eth0
         </screen>
         </step>
         <step>
           <para>
-            Click <guilabel>Add Network Interface</guilabel>.
+            Click <guimenu>Add Network Interface</guimenu>.
             Enter the following:
           </para>
           <screen>
-            Network Interface Name: BOND2
-            Network Devices: eth4
-            Network Devices: eth5
-            Forced Network Groups: None
-            Network Groups: STORAGE
-            Bond device name: bond2
-            Bond options: miimon: 200
-                          mode: active-backup
-                          primary: eth0
+Network Interface Name: BOND2
+Network Devices: eth4
+Network Devices: eth5
+Forced Network Groups: None
+Network Groups: STORAGE
+Bond device name: bond2
+Bond options: miimon: 200
+              mode: active-backup
+              primary: eth0
           </screen>
           </step>
         <step>
           <para>
-            Click <guilabel>Save</guilabel>.
+            Click <guimenu>Save</guimenu>.
           </para>
         </step>
         <step>
           <para>
-            To save the Interface Model, click <guilabel>Save</guilabel>.
+            To save the Interface Model, click <guimenu>Save</guimenu>.
           </para>
         </step>
     </procedure>
@@ -635,145 +631,145 @@
     <procedure><title>Configure Networks</title>
     <step>
       <para>
-        On the <guilabel>Server and Server Role
-        Summary</guilabel> window, in the top right, click
-        <guilabel>Manage Cloud Settings</guilabel>.
+        On the <guimenu>Server and Server Role
+        Summary</guimenu> window, in the top right, click
+        <guimenu>Manage Cloud Settings</guimenu>.
       </para>
     </step>
     <step>
       <para>
-        On the <guilabel>Manage Cloud Settings</guilabel> window select
-        the <guilabel>Networks</guilabel> tab.
+        On the <guimenu>Manage Cloud Settings</guimenu> window select
+        the <guimenu>Networks</guimenu> tab.
       </para>
     </step>
     <step>
       <para>
         On the right side of the <literal>MANAGEMENT-NET</literal>
-        network click the <guilabel>edit</guilabel> button.
+        network click the <guimenu>edit</guimenu> button.
       </para>
     </step>
       <step>
         <para>
-          On the right, in the <guilabel>Edit Network</guilabel> area,
+          On the right, in the <guimenu>Edit Network</guimenu> area,
           enter the following:
         </para>
        <screen>
-         VLAN ID: (accept default)
-         CIDR: 192.168.200.0/24
-         Addresses: (leave empty)
-         Gateway IP: 192.168.200.1
-         Network Groups: MANAGEMENT
-         Tagged VLAN: (unchecked)
+VLAN ID: (accept default)
+CIDR: 192.168.200.0/24
+Addresses: (leave empty)
+Gateway IP: 192.168.200.1
+Network Groups: MANAGEMENT
+Tagged VLAN: (unchecked)
        </screen>
       </step>
       <step>
         <para>
-          Click <guilabel>Save</guilabel>.
+          Click <guimenu>Save</guimenu>.
         </para>
       </step>
       <step>
         <para>
           On the right side of the <literal>EXTERNAL-API-NET</literal>
-          network click the <guilabel>edit</guilabel> button.
+          network click the <guimenu>edit</guimenu> button.
         </para>
       </step>
         <step>
           <para>
-            On the right, in the <guilabel>Edit Network</guilabel> area,
+            On the right, in the <guimenu>Edit Network</guimenu> area,
             enter the following:
           </para>
          <screen>
-           VLAN ID: (accept default)
-           CIDR: 192.168.201.0/24
-           Addresses: (leave empty)
-           Gateway IP: 192.168.201.1
-           Network Groups: EXTERNAL-API
-           Tagged VLAN: (unchecked)
+VLAN ID: (accept default)
+CIDR: 192.168.201.0/24
+Addresses: (leave empty)
+Gateway IP: 192.168.201.1
+Network Groups: EXTERNAL-API
+Tagged VLAN: (unchecked)
          </screen>
         </step>
         <step>
           <para>
-            Click <guilabel>Save</guilabel>.
+            Click <guimenu>Save</guimenu>.
           </para>
         </step>
         <step>
           <para>
             On the right side of the <literal>EXTERNAL-VM-NET</literal>
-            network click the <guilabel>edit</guilabel> button.
+            network click the <guimenu>edit</guimenu> button.
           </para>
         </step>
           <step>
             <para>
-              On the right, in the <guilabel>Edit Network</guilabel> area,
+              On the right, in the <guimenu>Edit Network</guimenu> area,
               enter the following:
             </para>
            <screen>
-             VLAN ID: (accept default)
-             CIDR: (leave empty)
-             Addresses: (leave empty)
-             Gateway IP: (leave empty)
-             Network Groups: EXTERNAL-VM
-             Tagged VLAN: (unchecked)
+VLAN ID: (accept default)
+CIDR: (leave empty)
+Addresses: (leave empty)
+Gateway IP: (leave empty)
+Network Groups: EXTERNAL-VM
+Tagged VLAN: (unchecked)
            </screen>
           </step>
           <step>
             <para>
-              Click <guilabel>Save</guilabel>.
+              Click <guimenu>Save</guimenu>.
             </para>
           </step>
           <step>
             <para>
               On the right side of the <literal>GUEST-NET</literal>
-              network click the <guilabel>edit</guilabel> button.
+              network click the <guimenu>edit</guimenu> button.
             </para>
           </step>
             <step>
               <para>
-                On the right, in the <guilabel>Edit Network</guilabel> area,
+                On the right, in the <guimenu>Edit Network</guimenu> area,
                 enter the following:
               </para>
              <screen>
-               VLAN ID: (accept default)
-               CIDR: 192.168.203.0/24
-               Addresses: (leave empty)
-               Gateway IP: 192.168.203.1
-               Network Groups: GUEST
-               Tagged VLAN: (unchecked)
+VLAN ID: (accept default)
+CIDR: 192.168.203.0/24
+Addresses: (leave empty)
+Gateway IP: 192.168.203.1
+Network Groups: GUEST
+Tagged VLAN: (unchecked)
              </screen>
             </step>
             <step>
               <para>
-                Click <guilabel>Save</guilabel>.
+                Click <guimenu>Save</guimenu>.
               </para>
             </step>
             <step>
               <para>
                 On the right side of the <literal>STORAGE-NET</literal>
-                network click the <guilabel>edit</guilabel> button.
+                network click the <guimenu>edit</guimenu> button.
               </para>
             </step>
               <step>
                 <para>
-                  On the right, in the <guilabel>Edit Network</guilabel> area,
+                  On the right, in the <guimenu>Edit Network</guimenu> area,
                   enter the following:
                 </para>
                <screen>
-                 VLAN ID: (accept default)
-                 CIDR: 192.168.204.0/24
-                 Addresses: (leave empty)
-                 Gateway IP: 192.168.204.1
-                 Network Groups: STORAGE
-                 Tagged VLAN: (unchecked)
+VLAN ID: (accept default)
+CIDR: 192.168.204.0/24
+Addresses: (leave empty)
+Gateway IP: 192.168.204.1
+Network Groups: STORAGE
+Tagged VLAN: (unchecked)
                </screen>
               </step>
               <step>
                 <para>
-                  Click <guilabel>Save</guilabel>.
+                  Click <guimenu>Save</guimenu>.
                 </para>
               </step>
             <step>
               <para>
-                Close the <guilabel>Manage Cloud Settings</guilabel> window.
+                Close the <guimenu>Manage Cloud Settings</guimenu> window.
               </para>
             </step>
     </procedure>
@@ -788,24 +784,24 @@
  <procedure><title>Manage Subnet and Netmask</title>
    <step>
      <para>
-       On the <guilabel>Add Servers and Assign
-       Server Roles</guilabel> window, in the top right, click
-       <guilabel>Manage Subnet and Netmask</guilabel>.
+       On the <guimenu>Add Servers and Assign
+       Server Roles</guimenu> window, in the top right, click
+       <guimenu>Manage Subnet and Netmask</guimenu>.
      </para>
    </step>
    <step>
      <para>
-       On the <guilabel>Manage Subnet and Netmask</guilabel> screen enter
+       On the <guimenu>Manage Subnet and Netmask</guimenu> screen enter
        the values for the management network:
      </para>
      <screen>
-       Subnet: 192.168.200.0
-       Netmask: 255.255.255.0
+Subnet: 192.168.200.0
+Netmask: 255.255.255.0
      </screen>
    </step>
    <step>
      <para>
-       Click <guilabel>Save</guilabel>.
+       Click <guimenu>Save</guimenu>.
      </para>
    </step>
  </procedure>
@@ -825,25 +821,25 @@
    </step>
    <step>
      <para>
-       On the <guilabel>Edit Server Details</guilabel> window for the deloyer
+       On the <guimenu>Edit Server Details</guimenu> window for the deloyer
        node, enter the following:
      </para>
      <screen>
-       ID: deployer
+ID: deployer
 
-       IP Address: 192.168.200.10
-       Server Group: RACK1
-       NIC Mapping: LIFECYCLE-MANAGER-2PORT
+IP Address: 192.168.200.10
+Server Group: RACK1
+NIC Mapping: LIFECYCLE-MANAGER-2PORT
 
-       MAC Address: 52:54:00:00:01:01
-       IPMI IP Address: (leave empty)
-       IPMI Username: (leave empty)
-       IPMI Password: (leave empty)
+MAC Address: 52:54:00:00:01:01
+IPMI IP Address: (leave empty)
+IPMI Username: (leave empty)
+IPMI Password: (leave empty)
      </screen>
    </step>
    <step>
      <para>
-       Click <guilabel>Done</guilabel>.
+       Click <guimenu>Done</guimenu>.
      </para>
    </step>
  </procedure>
@@ -851,8 +847,8 @@
  <procedure><title>Edit the Controller Servers</title>
    <step>
      <para>
-       On the <guilabel>Add Servers and Assign
-       Server Roles</guilabel> window if the list of servers in <literal>cluster1</literal>
+       On the <guimenu>Add Servers and Assign
+       Server Roles</guimenu> window if the list of servers in <literal>cluster1</literal>
        is not displayed, click on the <literal>cluster1</literal> bar on the right to
        expand the list of servers.
     </para>
@@ -864,25 +860,25 @@
    </step>
    <step>
      <para>
-       On the <guilabel>Edit Server Details</guilabel> window for the first
+       On the <guimenu>Edit Server Details</guimenu> window for the first
        controller02 node, enter the following:
      </para>
      <screen>
-       ID: controller02
+ID: controller02
 
-       IP Address: 192.168.200.12
-       Server Group: RACK1
-       NIC Mapping: CONTROLLER-6PORT
+IP Address: 192.168.200.12
+Server Group: RACK1
+NIC Mapping: CONTROLLER-6PORT
 
-       MAC Address: 52:54:00:00:a2:01
-       IPMI IP Address: 192.168.199.12
-       IPMI Username: admin
-       IPMI Password: password
+MAC Address: 52:54:00:00:a2:01
+IPMI IP Address: 192.168.199.12
+IPMI Username: admin
+IPMI Password: password
      </screen>
    </step>
    <step>
      <para>
-       Click <guilabel>Done</guilabel>.
+       Click <guimenu>Done</guimenu>.
      </para>
    </step>
    <step>
@@ -890,7 +886,7 @@
        If there are any additional controller nodes listed, delete the
        additional controller nodes from the list by clicking on the
        trash can icon on their right.
-       Click <guilabel>Yes</guilabel> when asked if you are sure you want
+       Click <guimenu>Yes</guimenu> when asked if you are sure you want
        to delete them.
      </para>
    </step>
@@ -899,8 +895,8 @@
  <procedure><title>Edit the Compute Servers</title>
    <step>
      <para>
-       On the <guilabel>Add Servers and Assign
-       Server Roles</guilabel> if the list of servers in <literal>compute</literal>
+       On the <guimenu>Add Servers and Assign
+       Server Roles</guimenu> if the list of servers in <literal>compute</literal>
        is not displayed, click on the <literal>compute</literal> bar on the right to
        expand the list of servers.
      </para>
@@ -912,25 +908,25 @@
    </step>
    <step>
      <para>
-       On the <guilabel>Edit Server Details</guilabel> window for the first
+       On the <guimenu>Edit Server Details</guimenu> window for the first
        compute node, enter the following:
      </para>
      <screen>
-       ID: compute03
+ID: compute03
 
-       IP Address: 192.168.200.23
-       Server Group: RACK1
-       NIC Mapping: COMPUTE-6PORT
+IP Address: 192.168.200.23
+Server Group: RACK1
+NIC Mapping: COMPUTE-6PORT
 
-       MAC Address: 52:54:00:00:c3:01
-       IPMI IP Address: 192.168.199.23
-       IPMI Username: admin
-       IPMI Password: password
+MAC Address: 52:54:00:00:c3:01
+IPMI IP Address: 192.168.199.23
+IPMI Username: admin
+IPMI Password: password
      </screen>
    </step>
    <step>
      <para>
-       Click <guilabel>Done</guilabel>.
+       Click <guimenu>Done</guimenu>.
      </para>
    </step>
    <step>
@@ -938,13 +934,13 @@
        If there are any additional compute nodes listed, delete the
        additional compute nodes from the list by clicking on the
        trash can icon on their right.
-       Click <guilabel>Yes</guilabel> when asked if you are sure you want
+       Click <guimenu>Yes</guimenu> when asked if you are sure you want
        to delete them.
      </para>
    </step>
    <step>
      <para>
-       Click <guilabel>Next</guilabel>.
+       Click <guimenu>Next</guimenu>.
      </para>
    </step>
  </procedure>
@@ -952,19 +948,17 @@
  <procedure><title>Install SLES on the Cloud Servers</title>
    <step>
      <para>
-       On the <guilabel>Choose servers on which SLES will be installed</guilabel>
+       On the <guimenu>Choose servers on which SLES will be installed</guimenu>
        window, enter the following:
      </para>
-     <screen>
-       Password: linux
-     </screen>
+     <screen>Password: linux</screen>
    </step>
    <step>
      <para>
        To move the controller and compute severs displayed in the
-       <guilabel>Available Servers</guilabel> box on the left to the
-       <guilabel>Selected Servers</guilabel> box on the right, click the
-       <guilabel>></guilabel> icon between the boxes.
+       <guimenu>Available Servers</guimenu> box on the left to the
+       <guimenu>Selected Servers</guimenu> box on the right, click the
+       <guimenu>></guimenu> icon between the boxes.
 
        You should see the controller and computer servers in the right
        box now instead of the left box.
@@ -975,25 +969,25 @@
    </step>
    <step>
      <para>
-       Click <guilabel>Install</guilabel>.
-       When asked if you want to continue, click <guilabel>Yes</guilabel>.
+       Click <guimenu>Install</guimenu>.
+       When asked if you want to continue, click <guimenu>Yes</guimenu>.
      </para>
    </step>
    <step>
      <para>
-       When the servers finish installing, click <guilabel>Next</guilabel>.
+       When the servers finish installing, click <guimenu>Next</guimenu>.
      </para>
    </step>
    <step>
      <para>
-       On the <guilabel>Server and server role summary</guilabel> window,
-       in the upper right hand side, click <guilabel>Expand all</guilabel> to
+       On the <guimenu>Server and server role summary</guimenu> window,
+       in the upper right hand side, click <guimenu>Expand all</guimenu> to
        review the configuration proposals for the servers.
      </para>
    </step>
    <step>
      <para>
-       Click <guilabel>Next</guilabel>.
+       Click <guimenu>Next</guimenu>.
      </para>
    </step>
  </procedure>
@@ -1001,8 +995,8 @@
  <procedure><title>Verify Server Configuration Parameters</title>
    <step>
      <para>
-       On the <guilabel>Server and server role summary</guilabel> window,
-       click <guilabel>Expand all</guilabel>.
+       On the <guimenu>Server and server role summary</guimenu> window,
+       click <guimenu>Expand all</guimenu>.
        You should see all of the servers, their roles, IDs, IP addresses,
        Server groups, NIC Mappings and MAC Addresses.
      </para>
@@ -1015,7 +1009,7 @@
    <step>
      <para>
        When all server configuration parameters have been verified or
-       fixed click <guilabel>Next</guilabel>.
+       fixed click <guimenu>Next</guimenu>.
      </para>
    </step>
  </procedure>

--- a/xml/poc-next-steps.xml
+++ b/xml/poc-next-steps.xml
@@ -14,15 +14,15 @@
   <procedure><title>Validate Cloud Configuration and Deploy the Cloud</title>
     <step>
       <para>
-        On the <guilabel>Review Configuration Files</guilabel> screen,
-        click <guilabel>Validate</guilabel>.
+        On the <guimenu>Review Configuration Files</guimenu> screen,
+        click <guimenu>Validate</guimenu>.
         You should get a successful validation
       </para>
     </step>
     <step>
       <para>
-        To deploy the cloud from this configuration, click <guilabel>Deploy</guilabel>.
-        You can click on the <guilabel>Show Log</guilabel> link in the bottom
+        To deploy the cloud from this configuration, click <guimenu>Deploy</guimenu>.
+        You can click on the <guimenu>Show Log</guimenu> link in the bottom
         left corner of the SUSE OpenStack Cloud Deployer screen to see the
         progress of the cloud deployment.
       </para>
@@ -32,13 +32,13 @@
   <procedure><title>Finish the Deployment</title>
     <step>
       <para>
-        On the <guilabel>Cloud Deployment In Progress</guilabel> screen,
-        when the cloud deployment is finished successfully, click <guilabel>Next</guilabel>.
+        On the <guimenu>Cloud Deployment In Progress</guimenu> screen,
+        when the cloud deployment is finished successfully, click <guimenu>Next</guimenu>.
       </para>
     </step>
     <step>
       <para>
-        On the final screen you should see <guilabel>Cloud deployment successful</guilabel>.
+        On the final screen you should see <guimenu>Cloud deployment successful</guimenu>.
         This final screen should also include links to useful tools including
         OpenStack Horizon UI, the CLM Admin Console and the SUSE Documentation.
       </para>
@@ -58,9 +58,7 @@
       ardana user, at a terminal, enter the following command to display a
       list of openrc files that were created during the cloud deployment:
      </para>
-     <screen>
-       ls -l ~/*.osrc
-     </screen>
+     <screen>ls -l ~/*.osrc</screen>
      <para>
        You should see the <literal>service.osrc</literal>, <literal>keystone.osrc</literal>
        and the <literal>barbican.osrc</literal> files listed.
@@ -71,9 +69,7 @@
        Enter the following command to view the contents of the
        <literal>service.osrc</literal> file:
      </para>
-     <screen>
-       cat ~/service.osrc
-     </screen>
+     <screen>cat ~/service.osrc</screen>
      <para>
        Locate the <literal>OS_USERNAME</literal> and <literal>OS_PASSWORD</literal>
        variables to determine the admin username and password and the
@@ -89,8 +85,8 @@
        CLM Admin Console URL and port:
      </para>
      <screen>
-       source ~/service.osrc
-       openstack endpoint list --service ardana
+source ~/service.osrc
+openstack endpoint list --service ardana
      </screen>
      <para>
        You should see the internal, public and admin API endpoints listed.
@@ -117,9 +113,7 @@
      Enter the following commands to use the openstack client to list the
      horizon Dashboard URL and port:
    </para>
-   <screen>
-     openstack endpoint list --service horizon
-   </screen>
+   <screen>openstack endpoint list --service horizon</screen>
    <para>
      You should see the internal, public and admin API endpoints listed.
      Notice that the endpoints are all using port 443 (HTTPS).

--- a/xml/poc-prerequisites.xml
+++ b/xml/poc-prerequisites.xml
@@ -73,10 +73,11 @@
     <emphasis role="bold">SUSE Customer Center (SCC)</emphasis>: Before you create a local mirror of the
     required repositories, you need appropriate organization credentials. You
     can obtain the credentials from SCC. To get the credentials from the SCC, visit
-    the SUSE Customer Center at http://scc.suse.com and log in.
+    the SUSE Customer Center at <link xlink:href="https://scc.suse.com"/> and log in.
   </para>
   <para>
     Mirror the following repositories:
+  </para>
     <itemizedlist>
       <listitem>
         <para>
@@ -99,7 +100,6 @@
         </para>
       </listitem>
     </itemizedlist>
-  </para>
   <para>
     Network File System (NFS)
   </para>

--- a/xml/soc-operations-self-sign-cert.xml
+++ b/xml/soc-operations-self-sign-cert.xml
@@ -611,7 +611,7 @@
     </step>
     <step>
       <para>
-        Click <guilabel>Apply</guilabel>. Your changes will apply in a
+        Click <guimenu>Apply</guimenu>. Your changes will apply in a
         few minutes.
       </para>
     </step>
@@ -636,7 +636,7 @@
     </step>
     <step>
       <para>
-        Click <guilabel>Apply</guilabel>. Your changes will apply in a
+        Click <guimenu>Apply</guimenu>. Your changes will apply in a
         few minutes.
       </para>
     </step>
@@ -661,7 +661,7 @@
     </step>
     <step>
       <para>
-        Click <guilabel>Apply</guilabel>. Your changes will apply in a
+        Click <guimenu>Apply</guimenu>. Your changes will apply in a
         few minutes.
       </para>
     </step>
@@ -687,7 +687,7 @@
     </step>
     <step>
       <para>
-        Click <guilabel>Apply</guilabel>. Your changes will apply in a
+        Click <guimenu>Apply</guimenu>. Your changes will apply in a
         few minutes.
       </para>
     </step>
@@ -713,7 +713,7 @@
     </step>
     <step>
       <para>
-        Click <guilabel>Apply</guilabel>. Your changes will apply in a
+        Click <guimenu>Apply</guimenu>. Your changes will apply in a
         few minutes.
       </para>
     </step>
@@ -739,7 +739,7 @@
     </step>
     <step>
       <para>
-        Click <guilabel>Apply</guilabel>. Your changes will apply in a
+        Click <guimenu>Apply</guimenu>. Your changes will apply in a
         few minutes.
       </para>
     </step>
@@ -765,7 +765,7 @@
     </step>
     <step>
       <para>
-        Click <guilabel>Apply</guilabel>. Your changes will apply in a
+        Click <guimenu>Apply</guimenu>. Your changes will apply in a
         few minutes.
       </para>
     </step>


### PR DESCRIPTION
This branch fixes the minor issues that made the documents incompatible with GeekoDoc and it removes the DC file settings that made us always validate with DocBook instead of GeekoDoc.

To make sure you validate with GeekoDoc locally:

1. install the `geekodoc` package
2. Set DAPS to use GeekoDoc by default: `echo "DOCBOOK5_RNG_URI=https://github.com/openSUSE/geekodoc/raw/master/geekodoc/rng/geekodoc5-flat.rnc" > ~/.config/daps/dapsrc`