### PR TITLE
Add a Note to websso integration (SOC-10933)

### DIFF
--- a/xml/operations-configuring-identity-websso.xml
+++ b/xml/operations-configuring-identity-websso.xml
@@ -7,6 +7,12 @@
 ]>
 <section xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="websso">
  <title>Configuring Web Single Sign-On</title>
+ <important>
+   <para>
+   The external-name in ~/openstack/my_cloud/definition/data/network_groups.yml must be set to a valid DNS-resolvable FQDN. 
+   </para>
+ </important>
+
  <para>
   This topic explains how to implement web single sign-on.
  </para>


### PR DESCRIPTION
WebSSO integration requires the public vips to be DNS-resolvable
FQDN. If external-name in network_groups.yml is not set to this,
then IP addresses are used.