### PR TITLE
Update the port create commands with right parameters (SOC-10962)

### DIFF
--- a/xml/networking-pcipt_sriov_config.xml
+++ b/xml/networking-pcipt_sriov_config.xml
@@ -870,7 +870,7 @@ nic-device-families:
     <para>
      Create a &o_netw; port with <literal>vnic_type = direct</literal>.
     </para>
-<screen>&prompt.ardana;openstack port create $net_id --name sriov_port --binding:vnic_type direct</screen>
+<screen>&prompt.ardana;openstack port create --network $net_id --vnic-type direct sriov_port</screen>
    </step>
    <step>
     <para>
@@ -888,8 +888,8 @@ nic-device-families:
      Create two &o_netw; ports with <literal>vnic_type =
      direct-physical</literal>.
     </para>
-<screen>&prompt.ardana;openstack port create net1 --name pci-port1 --vnic_type=direct-physical
-&prompt.ardana;openstack port create net1 --name pci-port2  --vnic_type=direct-physical</screen>
+<screen>&prompt.ardana;openstack port create --network net1 --vnic-type direct-physical pci-port1
+&prompt.ardana;openstack port create --network net1 --vnic-type direct-physical pci-port2</screen>
    </step>
    <step>
     <para>


### PR DESCRIPTION
Currently the openstack CLI command for port creation in the
document specifies incorrect parameters.
This changes addresses the issue with incorrect parameters.

(cherry picked from commit 5a899d9e6e1178595622dabb76192267b7a1aa90)