### PR TITLE
Clarify keyring chown instructions for Ceph (bsc#1111180)

### DIFF
--- a/xml/depl_inst_nodes.xml
+++ b/xml/depl_inst_nodes.xml
@@ -1132,32 +1132,23 @@ chmod 640 /etc/ceph/ceph.client.admin.keyring</screen>
           <screen>scp root@admin:/root/tmp/ceph.client.cinder.keyring /etc/ceph
 chmod 640 /etc/ceph/ceph.client.cinder.keyring</screen>
           <para>
+	    On &contrnode; on which &o_blockstore; will be deployed run the
+	    following command to update file ownership:
+          </para>
+          <screen>chown root.cinder /etc/ceph/ceph.client.cinder.keyring</screen>
+          <para>
+	    On KVM &compnode;s run the following command to update file ownership:
+          </para>
+          <screen>chown root.nova /etc/ceph/ceph.client.cinder.keyring</screen>
+          <para>
            Now copy the &o_img; keyring to the &contrnode; on which &o_img;
            will be deployed:
           </para>
           <screen>scp root@admin:/root/tmp/ceph.client.glance.keyring /etc/ceph
-chmod 640 /etc/ceph/ceph.client.glance.keyring</screen>
+chmod 640 /etc/ceph/ceph.client.glance.keyring
+chown root.glance /etc/ceph/ceph.client.glance.keyring</screen>
          </step>
         </substeps>
-       </step>
-       <step>
-        <para>
-         Adjust the ownership of the keyring file as follows:
-        </para>
-        <simplelist>
-         <member>
-          &o_img;: <command>chown
-          root.cinder /etc/ceph/ceph.client.cinder.keyring</command>
-         </member>
-         <member>
-          &o_blockstore;: <command>chown
-          root.glance /etc/ceph/ceph.client.glance.keyring</command>
-         </member>
-         <member>
-          KVM &compnode;s: <command>chown
-          root.nova /etc/ceph/ceph.volumes.keyring</command>
-         </member>
-        </simplelist>
        </step>
       </substeps>
      </step>


### PR DESCRIPTION
Per https://bugzilla.suse.com/show_bug.cgi?id=1111180 the documentation at https://documentation.suse.com/soc/8/single-html/suse-openstack-cloud-deployment/#sec-depl-inst-nodes-post-ceph-ext-install  refers to a non-existent file /etc/ceph/ceph.volumes.keyring  in step 6.d , additionally the way that step is organized appears tacked on and is a bit confusing. 

Moved chown commands up into step 6.c , splitting by service type, for the sake of clarity.