### PR TITLE
Update incorrect Manila install/setup instructions (SOC-10975)

### DIFF
--- a/xml/installation-ardana-manila.xml
+++ b/xml/installation-ardana-manila.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!DOCTYPE chapter [
- <!ENTITY % entities SYSTEM "entities.ent"> %entities;
+ <!ENTITY % entities SYSTEM "entity-decl.ent"> %entities;
 ]>
 <chapter xml:id="install-ardana-manila"
  xmlns="http://docbook.org/ns/docbook" version="5.1"
@@ -14,14 +14,53 @@
    to a virtual machine. The Shared File Systems service provides a storage
    provisioning control plane for shared or distributed file systems. The
    service enables management of share types and share snapshots if you have a
-   driver supports them.
+   driver that supports them.
   </para>
   <para>
-   The &o_sharefs; service consists of the following components: manila-api,
-   manila-data, manila-scheduler, manila-share, and messaging queue.
+   The &o_sharefs; service consists of the following components:
+  </para>
+  <itemizedlist>
+   <listitem>
+    <para>
+     manila-api
+    </para>
+   </listitem>
+   <listitem>
+    <para>
+     manila-data
+    </para>
+   </listitem>
+   <listitem>
+    <para>
+     manila-scheduler
+    </para>
+   </listitem>
+   <listitem>
+    <para>
+     manila-share
+    </para>
+   </listitem>
+   <listitem>
+    <para>
+     messaging queue
+    </para>
+   </listitem>
+  </itemizedlist>
+  <para>
+   These &o_sharefs; components are included in example &productname; models
+   based on &o_comp; KVM, such as <literal>entry-scale-kvm</literal>,
+   <literal>entry-scale-kvm-mml</literal>, and
+   <literal>mid-scale-kvm</literal>. General installation instructions are
+   available at <xref linkend="install-kvm"/>.
   </para>
   <para>
-   The following steps will install &o_sharefs;:
+   If you modify one of these cloud models to set up a dedicated &clm;, add
+   <literal>manila-client</literal> item to the list of service components for
+   the &clm; cluster.
+  </para>
+  <para>
+   The following steps install &o_sharefs; if it is not already present in your
+   cloud data model:
   </para>
   <procedure>
    <step>
@@ -46,7 +85,7 @@
     </para>
 <screen>&prompt.ardana;cd ~/openstack
 &prompt.ardana;git add -A
-&prompt.ardana;git commit -m "Manila config"
+&prompt.ardana;git commit -m "manila config"
 &prompt.ardana;cd ~/openstack/ardana/ansible/
 &prompt.ardana;ansible-playbook -i hosts/localhost config-processor-run.yml
 &prompt.ardana;ansible-playbook -i hosts/localhost ready-deployment.yml</screen>
@@ -58,17 +97,12 @@
 <screen>&prompt.ardana;cd ~/scratch/ansible/next/ardana/ansible
 &prompt.ardana;ansible-playbook -i hosts/verb_hosts percona-deploy.yml
 &prompt.ardana;ansible-playbook -i hosts/verb_hosts manila-deploy.yml</screen>
-   </step>
-   <step>
-    <para>
-     Configure &o_sharefs;
-    </para>
 <screen>&prompt.ardana;cd ~/scratch/ansible/next/ardana/ansible
 &prompt.ardana;ansible-playbook -i hosts/verb_hosts ardana-gen-hosts-file.yml
 &prompt.ardana;ansible-playbook -i hosts/verb_hosts ardana-reconfigure.yml
 &prompt.ardana;ansible-playbook -i hosts/verb_hosts clients-deploy.yml</screen>
     <para>
-     If &o_sharefs; has already been installed but is being reconfigured, run
+     If &o_sharefs; has already been installed and is being reconfigured, run
      the following for the changes to take effect:
     </para>
 <screen>&prompt.ardana;ansible-playbook -i hosts/verb_hosts manila-stop.yml
@@ -76,34 +110,60 @@
    </step>
    <step>
     <para>
-     Workaround to fix <filename>manila-manage.log</filename> ownership problem
-     &o_sharefs;
-    </para>
-<screen>on controller1:
-&prompt.ardana;cd /var/log/manila
-&prompt.ardana;sudo chown manila:manila manila-manage.log
-on &clm;:
-&prompt.ardana;ansible-playbook -i hosts/verb_hosts manila-stop.yml
-&prompt.ardana;ansible-playbook -i hosts/verb_hosts manila-start.yml</screen>
-   </step>
-   <step>
-    <para>
      Verify the &o_sharefs; installation
     </para>
 <screen>&prompt.ardana;cd
-&prompt.ardana;. manila.osrc; . service.osrc; manila api-version; manila service-list</screen>
+&prompt.ardana;. manila.osrc
+&prompt.ardana;. service.osrc
+&prompt.ardana;manila api-version
+&prompt.ardana;manila service-list</screen>
     <para>
      The &o_sharefs; CLI can be run from &clm; or controller nodes.
     </para>
    </step>
   </procedure>
+  <note>
+   <para>
+    The <literal>manila-share</literal> service component is not started by the
+    <filename>manila-deploy.yml</filename> playbook when run under default
+    conditions. This component requires that a valid backend be configured,
+    which is described in <xref linkend="configure-manila-backend"/>.
+   </para>
+  </note>
  </section>
  <section>
-  <title>Configure &o_sharefs; backend</title>
+  <title>Adding &o_sharefs; to an Existing &productname; Environment</title>
+  <para>
+   Add &o_sharefs; to an existing &productname; installation or as part of an
+   upgrade with the following steps:
+  </para>
   <procedure>
    <step>
     <para>
-     Add back-end to manila.conf.j2
+     Add the items listed below to the list of service components in
+     <filename>~/openstack/my_cloud/definition/data/control_plane.yml</filename>.
+     Add them to clusters that have <literal>server-role</literal> set to
+     <literal>CONTROLLER-ROLE</literal> (applies to entry-scale models).
+    </para>
+    <itemizedlist>
+     <listitem>
+      <para>
+       manila-client
+      </para>
+     </listitem>
+     <listitem>
+      <para>
+       manila-api
+      </para>
+     </listitem>
+    </itemizedlist>
+   </step>
+   <step>
+    <para>
+     If your environment uses a dedicated &clm;, add
+     <literal>magnum-client</literal> to the list of service components for the
+     &clm; in
+     <filename>~/openstack/my_cloud/definition/data/control_plane.yml</filename>.
     </para>
    </step>
    <step>
@@ -130,20 +190,225 @@ on &clm;:
    </step>
    <step>
     <para>
-     Run reconfiguration playbook.
+     Deploy &o_sharefs;.
     </para>
 <screen>&prompt.ardana;cd ~/scratch/ansible/next/ardana/ansible
-&prompt.ardana;ansible-playbook -i hosts/verb_hosts manila-reconfigure.yml</screen>
+&prompt.ardana;ansible-playbook -i hosts/verb_hosts percona-deploy.yml
+&prompt.ardana;ansible-playbook -i hosts/verb_hosts manila-deploy.yml
+&prompt.ardana;ansible-playbook -i hosts/verb_hosts ardana-gen-hosts-file.yml
+&prompt.ardana;ansible-playbook -i hosts/verb_hosts ardana-reconfigure.yml
+&prompt.ardana;ansible-playbook -i hosts/verb_hosts clients-deploy.yml</screen>
    </step>
    <step>
     <para>
-     Restart &o_sharefs; services.
+     Verify the &o_sharefs; installation.
     </para>
+<screen>&prompt.ardana;cd
+&prompt.ardana;. manila.osrc
+&prompt.ardana;. service.osrc
+&prompt.ardana;manila api-version
+&prompt.ardana;manila service-list</screen>
+   </step>
+  </procedure>
+  <para>
+   The &o_sharefs; CLI can be run from the &clm; or controller nodes.
+  </para>
+  <para>
+   Proceed to <xref linkend="configure-manila-backend"/>.
+  </para>
+ </section>
+ <section xml:id="configure-manila-backend">
+  <title>Configure &o_sharefs; Backend</title>
+  <section>
+   <title>Configure NetaApp &o_sharefs; Back-end</title>
+   <note>
+    <para>
+     An account with cluster administrator privileges must be used with the
+     <literal>netapp_login</literal> option when using Share Server management.
+     Share Server management creates Storage Virtual Machines (SVM), thus SVM
+     administrator privileges are insufficient.
+    </para>
+    <para>
+     There are two modes for the NetApp &o_sharefs; back-end:
+    </para>
+    <itemizedlist>
+     <listitem>
+      <para>
+       <literal>driver_handles_share_servers = True</literal>
+      </para>
+     </listitem>
+     <listitem>
+      <para>
+       <literal>driver_handles_share_servers = False</literal> This value must
+       be set to <literal>False</literal> if you want the driver to operate
+       without managing share servers.
+      </para>
+     </listitem>
+    </itemizedlist>
+    <para>
+     More information is available from
+     <link
+     xlink:href="https://netapp-openstack-dev.github.io/openstack-docs/rocky/manila/configuration/manila_config_files/section_unified-driver-without-share-server.html">NetApp
+     OpenStack</link>
+    </para>
+   </note>
+   <para>
+    The steps to configure a NetApp &o_sharefs; back-end are:
+   </para>
+   <procedure>
+    <step>
+     <para>
+      Configure a back-end in the &o_sharefs; configuration file, following the
+      directions and comments in the file.
+     </para>
+<screen>&prompt.ardana;cd ~/openstack/my_cloud
+&prompt.ardana;vi config/manila/manila.conf.j2</screen>
+    </step>
+    <step>
+     <para>
+      Commit your configuration to the local Git repo.
+     </para>
+<screen>&prompt.ardana;cd ~/openstack/ardana/ansible
+&prompt.ardana;git add -A
+&prompt.ardana;git commit -m "My config or other commit message"</screen>
+    </step>
+    <step>
+     <para>
+      Run the configuration processor.
+     </para>
+<screen>&prompt.ardana;cd ~/openstack/ardana/ansible
+&prompt.ardana;ansible-playbook -i hosts/localhost config-processor-run.yml</screen>
+    </step>
+    <step>
+     <para>
+      Update deployment directory.
+     </para>
+<screen>&prompt.ardana;cd ~/openstack/ardana/ansible
+&prompt.ardana;ansible-playbook -i hosts/localhost ready-deployment.yml</screen>
+    </step>
+    <step>
+     <para>
+      Run reconfiguration playbook.
+     </para>
+<screen>&prompt.ardana;cd ~/scratch/ansible/next/ardana/ansible
+&prompt.ardana;ansible-playbook -i hosts/verb_hosts manila-reconfigure.yml</screen>
+    </step>
+    <step>
+     <para>
+      Restart &o_sharefs; services.
+     </para>
 <screen>&prompt.ardana;cd ~/scratch/ansible/next/ardana/ansible
 &prompt.ardana;ansible-playbook -i hosts/verb_hosts manila-stop.yml
 &prompt.ardana;ansible-playbook -i hosts/verb_hosts manila-start.yml</screen>
-   </step>
-  </procedure>
+    </step>
+   </procedure>
+   <note>
+    <para>
+     After the <literal>manila-share</literal> service has been initialized
+     with a backend, it can be controlled independently of
+     <literal>manila-api</literal> by using the playbooks
+     <filename>manila-share-start.yml</filename>,
+     <filename>manila-share-stop.yml</filename>, and
+     <filename>manila-share-status.yml</filename>.
+    </para>
+   </note>
+  </section>
+  <section>
+   <title>Configure CephFS &o_sharefs; Backend</title>
+   <para>
+    Configure a back-end in the &o_sharefs; configuration file,
+    <filename>~/openstack/my_cloud vi config/manila/manila.conf.j2</filename>.
+   </para>
+   <procedure>
+    <step>
+     <para>
+      To define a CephFS native back-end, create a section like the following:
+     </para>
+<screen>[cephfsnative1]
+driver_handles_share_servers = False
+share_backend_name = CEPHFSNATIVE1
+share_driver = manila.share.drivers.cephfs.driver.CephFSDriver
+cephfs_conf_path = /etc/ceph/ceph.conf
+cephfs_protocol_helper_type = CEPHFS
+cephfs_auth_id = manila
+cephfs_cluster_name = ceph
+cephfs_enable_snapshots = False</screen>
+    </step>
+    <step>
+     <para>
+      Add CephFS to <literal>enabled_share_protocols</literal>:
+     </para>
+<screen>enabled_share_protocols = NFS,CIFS,CEPHFS</screen>
+    </step>
+    <step>
+     <para>
+      Edit the <literal>enabled_share_backends</literal> option in the
+      <literal>DEFAULT</literal> section to point to the driver’s back-end
+      section name.
+     </para>
+    </step>
+    <step>
+     <para>
+      According to the environment, modify back-end specific lines in
+      <filename>~/openstack/my_cloud vi
+      config/manila/manila.conf.j2</filename>.
+     </para>
+    </step>
+    <step>
+     <para>
+      Commit your configuration to the local Git repo.
+     </para>
+<screen>&prompt.ardana;cd ~/openstack/ardana/ansible
+&prompt.ardana;git add -A
+&prompt.ardana;git commit -m "My config or other commit message"</screen>
+    </step>
+    <step>
+     <para>
+      Run the configuration processor.
+     </para>
+<screen>&prompt.ardana;cd ~/openstack/ardana/ansible
+&prompt.ardana;ansible-playbook -i hosts/localhost config-processor-run.yml</screen>
+    </step>
+    <step>
+     <para>
+      Update deployment directory.
+     </para>
+<screen>&prompt.ardana;cd ~/openstack/ardana/ansible
+&prompt.ardana;ansible-playbook -i hosts/localhost ready-deployment.yml</screen>
+    </step>
+    <step>
+     <para>
+      Run reconfiguration playbook.
+     </para>
+<screen>&prompt.ardana;cd ~/scratch/ansible/next/ardana/ansible
+&prompt.ardana;ansible-playbook -i hosts/verb_hosts manila-reconfigure.yml</screen>
+    </step>
+    <step>
+     <para>
+      Restart &o_sharefs; services.
+     </para>
+<screen>&prompt.ardana;cd ~/scratch/ansible/next/ardana/ansible
+&prompt.ardana;ansible-playbook -i hosts/verb_hosts manila-stop.yml
+&prompt.ardana;ansible-playbook -i hosts/verb_hosts manila-start.yml</screen>
+    </step>
+   </procedure>
+   <note>
+    <para>
+     After the <literal>manila-share</literal> service has been initialized
+     with a back-end, it can be controlled independently of
+     <literal>manila-api</literal> by using the playbooks
+     <filename>manila-share-start.yml</filename>,
+     <filename>manila-share-stop.yml</filename>, and
+     <filename>manila-share-status.yml</filename>.
+    </para>
+   </note>
+   <para>
+    For more details of the CephFS &o_sharefs; back-end, see
+    <link
+    xlink:href="https://docs.openstack.org/manila/rocky/admin/cephfs_driver.html">OpenStack
+    CephFS driver</link>.
+   </para>
+  </section>
  </section>
  <section>
   <title>Creating &o_sharefs; Shares</title>
@@ -159,7 +424,7 @@ on &clm;:
   <procedure>
    <step>
 <screen>&prompt.ardana;wget http://tarballs.openstack.org/manila-image-elements/images/manila-service-image-master.qcow2
-&prompt.ardana;. service.osrc;glance image-create --name
+&prompt.ardana;. service.osrc;openstack image create --name
 "manila-service-image-new" \
 --file manila-service-image-master.qcow2 --disk-format qcow2 \
 --container-format bare --visibility public --progress
@@ -176,11 +441,11 @@ on &clm;:
 --protocol icmp
 &prompt.ardana;openstack security group rule list manila-security-group (verify manila security group)
 &prompt.ardana;openstack keypair create --public-key ~/.ssh/id_rsa.pub mykey
-&prompt.ardana;neutron net-create n1
-&prompt.ardana;neutron subnet-create --name s1 n1 <replaceable>11.11.11.0/24</replaceable>
-&prompt.ardana;neutron router-create r1
-&prompt.ardana;neutron router-interface-add r1 s1
-&prompt.ardana;neutron router-gateway-set r1 ext-net
+&prompt.ardana;openstack network create n1
+&prompt.ardana;openstack subnet create s1 --network n1 <replaceable>--subnet-range 11.11.11.0/24</replaceable>
+&prompt.ardana;openstack router create r1
+&prompt.ardana;openstack router add subnet r1 s1
+&prompt.ardana;openstack router set r1 ext-net
 &prompt.ardana;openstack network list
 &prompt.ardana;openstack server create manila-vm --flavor m1.small \
 --image IMAGE_ID --nic net-id=N1_ID --security-group manila-security-group \
@@ -212,7 +477,7 @@ tenant_net_name_or_ip = <replaceable>MANILA_VM_FLOATING_IP</replaceable></screen
     <para>
      Create a share type. OpenStack docs has
      <link
-     xlink:href="https://docs.openstack.org/manila/pike/install/post-install.html">detailed
+     xlink:href="https://docs.openstack.org/manila/rocky/install/post-install.html">detailed
      instructions</link>. Use the instructions for <literal>manila type-create
      default_share_type False</literal>
     </para>
@@ -245,6 +510,7 @@ openstack-manila-share openstack-manila-scheduler
   <para>
    Mode 2: The back-end is <literal>NetApp</literal>,
    <literal>driver_handles_share_servers = True</literal> (DHSS is enabled).
+   Procedure for driver_handles_share_servers = False is similar to Mode 1.
   </para>
   <procedure>
    <step>
@@ -273,7 +539,7 @@ default_share_type = default1</screen>
      Create a &o_sharefs; share image and verify it
     </para>
 <screen>&prompt.ardana;wget http://tarballs.openstack.org/manila-image-elements/images/manila-service-image-master.qcow2
-&prompt.ardana;. service.osrc;glance image-create --name <literal>manila-service-image-new</literal> \
+&prompt.ardana;. service.osrc;openstack image create <literal>manila-service-image-new</literal> \
 --file manila-service-image-master.qcow2 --disk-format qcow2 \
 --container-format bare --visibility public --progress
 &prompt.ardana;openstack image list (verify a &o_sharefs; image)</screen>
@@ -282,7 +548,7 @@ default_share_type = default1</screen>
     <para>
      Create a share type. OpenStack docs has
      <link
-     xlink:href="https://docs.openstack.org/manila/pike/install/post-install.html">detailed
+     xlink:href="https://docs.openstack.org/manila/rocky/install/post-install.html">detailed
      instructions</link>. Use the instructions for <literal>manila type-create
      default_share_type True</literal> .
     </para>
@@ -307,42 +573,19 @@ default_share_type = default1</screen>
  </section>
  <section>
   <title>Troubleshooting</title>
-<!-- As of 2018-10-31 there has not been a successful demo of Manila with
-       NetApp back-end. Thus this Troubleshooting section may be changed.  -->
   <para>
    If manila-list shows share status in error, use <literal>storage aggregate
-   show</literal> to list available aggregates. Different errors that may be
-   shown in <filename>/var/log/manila/manila-share.log</filename>
+   show</literal> to list available aggregates. Errors may be found in
+   <filename>/var/log/manila/manila-share.log</filename>
   </para>
-  <variablelist>
-   <varlistentry>
-    <term>NaApiError: NetApp API failed.</term>
-    <listitem>
-     <para>
-      Reason - 15675:Cannot provision volume <literal>root</literal> on root
-      aggregate. Provisioning a volume on a root aggregate is not supported.
-     </para>
-    </listitem>
-   </varlistentry>
-   <varlistentry>
-    <term>If aggregate = <replaceable>NODE1_data</replaceable></term>
-    <listitem>
-     <para>
-      Exception during message handling: NetAppException: Failed to create VLAN
-      on <replaceable>PORT</replaceable>
-     </para>
-    </listitem>
-   </varlistentry>
-   <varlistentry>
-    <term>If aggregate = <replaceable>NODE2_data</replaceable></term>
-    <listitem>
-     <para>
-      NetAppException: Failed to create a route to 0.0.0.0/0 via gateway None:
-      Invalid value specified for <literal>gateway</literal> element within
-      <literal>net-routes-create</literal>
-     </para>
-    </listitem>
-   </varlistentry>
-  </variablelist>
+  <para>
+   if the compute nodes do not have access to &o_sharefs; back-end server, use
+   the <literal>manila-share</literal> service on controller nodes instead. You
+   can do so by either running <literal>sudo systemctl stop
+   openstack-manila-share</literal> on compute to turn off its share service or
+   skipping adding "manila-share" to compute hosts in the input-model
+   (<filename>control_plane.yml</filename> in
+   <filename>/var/lib/ardana/openstack/my_cloud/definition/data</filename>).
+  </para>
  </section>
 </chapter>


### PR DESCRIPTION
Per https://bugzilla.suse.com/show_bug.cgi?id=1149860  (also https://jira.suse.com/browse/SOC-10975 ), the Cloud 8 documentation for Manila is wrong. Using the Cloud 9 documentation (which is correct) is the present workaround. This change copies the Cloud 9 Manila docs into Cloud 8. The only change from the Cloud 9 content is a replacement of &product; with &productname; as the former does not exist in Cloud 8.