### PR TITLE
Clarify keyring chown instructions for Ceph (bsc#1111180)

### DIFF
--- a/xml/depl_inst_nodes.xml
+++ b/xml/depl_inst_nodes.xml
@@ -1132,32 +1132,23 @@ chmod 640 /etc/ceph/ceph.client.admin.keyring</screen>
           <screen>scp root@admin:/root/tmp/ceph.client.cinder.keyring /etc/ceph
 chmod 640 /etc/ceph/ceph.client.cinder.keyring</screen>
           <para>
+	    On &contrnode; on which &o_blockstore; will be deployed run the
+	    following command to update file ownership:
+          </para>
+          <screen>chown root.cinder /etc/ceph/ceph.client.cinder.keyring</screen>
+          <para>
+	    On KVM &compnode;s run the following command to update file ownership:
+          </para>
+          <screen>chown root.nova /etc/ceph/ceph.client.cinder.keyring</screen>
+          <para>
            Now copy the &o_img; keyring to the &contrnode; on which &o_img;
            will be deployed:
           </para>
           <screen>scp root@admin:/root/tmp/ceph.client.glance.keyring /etc/ceph
-chmod 640 /etc/ceph/ceph.client.glance.keyring</screen>
+chmod 640 /etc/ceph/ceph.client.glance.keyring
+chown root.glance /etc/ceph/ceph.client.glance.keyring</screen>
          </step>
         </substeps>
-       </step>
-       <step>
-        <para>
-         Adjust the ownership of the keyring file as follows:
-        </para>
-        <simplelist>
-         <member>
-          &o_img;: <command>chown
-          root.cinder /etc/ceph/ceph.client.cinder.keyring</command>
-         </member>
-         <member>
-          &o_blockstore;: <command>chown
-          root.glance /etc/ceph/ceph.client.glance.keyring</command>
-         </member>
-         <member>
-          KVM &compnode;s: <command>chown
-          root.nova /etc/ceph/ceph.volumes.keyring</command>
-         </member>
-        </simplelist>
        </step>
       </substeps>
      </step>


### PR DESCRIPTION
The instructions for changing the ownership of the keyring
files for Ceph were unclear.

Fixed the glance and cinder labels to apply appropriately
Moved the chown step into the previous section just after chmod
Corrected the file reference that referred to a non-existant file