### PR TITLE
Fix extraneous --name parameter (SOC-10975)

### DIFF
--- a/xml/installation-ardana-manila.xml
+++ b/xml/installation-ardana-manila.xml
@@ -442,7 +442,7 @@ cephfs_enable_snapshots = False</screen>
 &prompt.ardana;openstack security group rule list manila-security-group (verify manila security group)
 &prompt.ardana;openstack keypair create --public-key ~/.ssh/id_rsa.pub mykey
 &prompt.ardana;openstack network create n1
-&prompt.ardana;openstack subnet create --name s1 n1 <replaceable>11.11.11.0/24</replaceable>
+&prompt.ardana;openstack subnet create s1 --network n1 <replaceable>--subnet-range 11.11.11.0/24</replaceable>
 &prompt.ardana;openstack router create r1
 &prompt.ardana;openstack router add subnet r1 s1
 &prompt.ardana;openstack router set r1 ext-net
@@ -539,7 +539,7 @@ default_share_type = default1</screen>
      Create a &o_sharefs; share image and verify it
     </para>
 <screen>&prompt.ardana;wget http://tarballs.openstack.org/manila-image-elements/images/manila-service-image-master.qcow2
-&prompt.ardana;. service.osrc;openstack image create --name <literal>manila-service-image-new</literal> \
+&prompt.ardana;. service.osrc;openstack image create <literal>manila-service-image-new</literal> \
 --file manila-service-image-master.qcow2 --disk-format qcow2 \
 --container-format bare --visibility public --progress
 &prompt.ardana;openstack image list (verify a &o_sharefs; image)</screen>


### PR DESCRIPTION
In reviewing these docs for SOC8, feedback was received
that the --name parameter is unnecessary and may be a legacy
from before the "openstack" cli was used. Removed it here

cherry-pick e6f60ac605bc12c62130483ec6a8aeb5eb7f14bb