### PR TITLE
put ADFS config artifacts under revision control (SOC-11005)

### DIFF
--- a/xml/operations-configuring-identity-websso.xml
+++ b/xml/operations-configuring-identity-websso.xml
@@ -322,9 +322,15 @@
    </listitem>
    <listitem>
     <para>
-     Copy adfs_metadata.xml to the &clm; node in your preferred
-     location. Here it is /tmp.
+     Copy adfs_metadata.xml to the &clm; node and place it into
+     <filename>/var/lib/ardana/openstack/my_cloud/config/keystone/</filename>
+     directory and put it under revision control.
     </para>
+<screen>&prompt.ardana;cd ~/openstack
+&prompt.ardana;git checkout site
+&prompt.ardana;git add my_cloud/config/keystone/adfs_metadata.xml
+&prompt.ardana;git commit -m "Add ADFS metadata file for WebSSO authentication"
+</screen>
    </listitem>
   </orderedlist>
  </section>
@@ -332,12 +338,13 @@
   <title>Setting Up WebSSO</title>
   <para>
    Start by creating a config file <filename>adfs_config.yml</filename> with the
-   following parameters and place it in any directory on your &clm;,
-   such as <filename>/tmp</filename>.
+   following parameters and place it in the
+   <filename>/var/lib/ardana/openstack/my_cloud/config/keystone/</filename>
+   directory on your &clm; node.
   </para>
 <screen>keystone_trusted_idp: adfs
 keystone_sp_conf:
-    idp_metadata_file: /tmp/adfs_metadata.xml
+    idp_metadata_file: /var/lib/ardana/openstack/my_cloud/config/keystone/adfs_metadata.xml
     shib_sso_application_entity_id: http://sp_uri_entityId
     shib_sso_idp_entity_id: http://default_idp_uri_entityId
     target_domain:
@@ -356,7 +363,7 @@ keystone_sp_conf:
         description: This is the ADFS identity provider.
     mapping:
         id: mapping1
-        rules_file: adfs_mapping.json
+        rules_file: /var/lib/ardana/openstack/my_cloud/config/keystone/adfs_mapping.json
     protocol:
         id: saml2
     attribute_map:
@@ -402,16 +409,14 @@ keystone_sp_conf:
   <orderedlist>
    <listitem>
     <para>
-     In the preceding config file, /tmp/adfs_config.yml, make sure the
-     idp_metadata_file references the previously generated ADFS metadata file.
-     In this case:
+     Create a mapping file, <filename>adfs_mapping.json</filename>, that is
+     referenced from the preceding config file in
+     <filename>/var/lib/ardana/openstack/my_cloud/config/keystone/</filename>.
     </para>
-<screen>idp_metadata_file: /tmp/adfs_metadata.xml</screen>
-   </listitem>
-   <listitem>
+<screen>
+     rules_file: /var/lib/ardana/openstack/my_cloud/config/keystone/adfs_mapping.json.
+</screen>
     <para>
-     Create a mapping file that is referenced from the preceding config file,
-     such as /tmp/adfs_sp_mapping.json. rules_file: /tmp/adfs_sp_mapping.json.
      The following is an example of the mapping file, existing in
      roles/KEY-API/files/samples/websso/adfs_sp_mapping.json:
     </para>
@@ -448,10 +453,22 @@ keystone_sp_conf:
    </listitem>
    <listitem>
     <para>
+     Add <filename>adfs_config.yml</filename> and
+     <filename>adfs_mapping.json</filename> to revision control.
+    </para>
+<screen>&prompt.ardana;cd ~/openstack
+&prompt.ardana;git checkout site
+&prompt.ardana;git add my_cloud/config/keystone/adfs_config.yml
+&prompt.ardana;git add my_cloud/config/keystone/adfs_mapping.json
+&prompt.ardana;git commit -m "Add ADFS config and mapping."
+</screen>
+   </listitem>
+   <listitem>
+    <para>
      Go to ~/scratch/ansible/next/ardana/ansible and run the following
      playbook to enable WebSSO in the keystone identity service:
     </para>
-<screen>ansible-playbook -i hosts/verb_hosts keystone-reconfigure.yml -e@/tmp/adfs_config.yml</screen>
+<screen>ansible-playbook -i hosts/verb_hosts keystone-reconfigure.yml -e@/var/lib/ardana/openstack/my_cloud/config/keystone/adfs_config.yml</screen>
    </listitem>
    <listitem>
     <para>
@@ -595,7 +612,7 @@ keystone_sp_conf:
     identity_provider:
         id: adfs_idp1
         description: This is the ADFS identity provider.
-    idp_metadata_file: /opt/stack/adfs_metadata.xml
+    idp_metadata_file: /var/lib/ardana/openstack/my_cloud/config/keystone/adfs_metadata.xml
 
     shib_sso_application_entity_id: http://blabla
     shib_sso_idp_entity_id: http://WIN-CAICP35LF2I.vlan44.domain/adfs/services/trust
@@ -617,7 +634,7 @@ keystone_sp_conf:
 
     mapping:
         id: mapping1
-        rules_file: /opt/stack/adfs_sp_mapping_multiple_groups.json
+        rules_file: /var/lib/ardana/openstack/my_cloud/config/keystone/adfs_sp_mapping_multiple_groups.json
 
     protocol:
         id: saml2


### PR DESCRIPTION
We should advise customers to put adfs_config.yaml, adfs_medatada.xml,
and adfs_mappings.json under revision control, just like other Ardana
configuration files so that we can sanely keep track of them.