### PR TITLE
Remove deprecated manila-share instruction step from Cloud 9 doc (SOC-10938)

### DIFF
--- a/xml/installation-ardana-manila.xml
+++ b/xml/installation-ardana-manila.xml
@@ -75,8 +75,7 @@
 <screen>&prompt.ardana;cd /var/lib/ardana/openstack/my_cloud/definition/data/</screen>
     <para>
      Add <literal>manila-client</literal> to the list of service components for
-     &clm;, <literal>manila-api</literal> to the &contrnode;, and
-     <literal>manila-share</literal> to &slsa; &compnode;
+     &clm;, and <literal>manila-api</literal> to the &contrnode;.
     </para>
    </step>
    <step>


### PR DESCRIPTION
manila-share 's are installed on the same hosts as manila-api in Cloud 9, remove the extraneous instruction