### PR TITLE
Specify that manila-share be installed on the control node (SOC-10938)

### DIFF
--- a/xml/installation-ardana-manila.xml
+++ b/xml/installation-ardana-manila.xml
@@ -75,8 +75,8 @@
 <screen>&prompt.ardana;cd /var/lib/ardana/openstack/my_cloud/definition/data/</screen>
     <para>
      Add <literal>manila-client</literal> to the list of service components for
-     &clm;, <literal>manila-api</literal> to the &contrnode;, and
-     <literal>manila-share</literal> to &slsa; &compnode;
+     &clm;, and both <literal>manila-api</literal> and <literal>manila-share</literal>
+     to the &contrnode;.
     </para>
    </step>
    <step>


### PR DESCRIPTION
Instructions currently incorrectly state that manila-share should be
installed on compute nodes. Updated to correctly specify control
node

note that this is different from the change at
https://github.com/SUSE-Cloud/doc-cloud/pull/1229
because SOC 9 ignores the manila-share config and installs
it where manila-api is installed