### PR TITLE
8: Remove (commented) mention of phrases-decl.ent

### DIFF
--- a/xml/entity-decl.ent
+++ b/xml/entity-decl.ent
@@ -368,10 +368,6 @@ vendor='hpe'>HPE-Helion-OpenStack-8</phrase></phrase>">
 <!-- ======================= INCLUDES ============================= -->
 <!ENTITY % network-entities SYSTEM "network-decl.ent">
 %network-entities;
-<!--
-<!ENTITY % phrases-entities SYSTEM "phrases-decl.ent">
-%phrases-entities;
--->
 <!ENTITY % sgml.features "IGNORE">
 <!ENTITY % xml.features "INCLUDE">
 <!ENTITY % dbcent PUBLIC "-//OASIS//ENTITIES DocBook Character Entities V4.5//EN" "http://www.oasis-open.org/docbook/xml/4.5/dbcentx.mod">


### PR DESCRIPTION
It appears daps-auto (old docserv) does not know how to handle comments
in entity files