### PR TITLE
Travis/Gitlint: switch config file, allow body-less commits (noref)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,8 @@ matrix:
       if: type = pull_request
       script:
       - pip install gitlint
-      - wget https://raw.githubusercontent.com/SUSE-Cloud/automation/master/scripts/jenkins/gitlint.ini
+      - wget https://raw.githubusercontent.com/openSUSE/doc-ci/develop/gitlint/gitlint.ini
+      - wget https://raw.githubusercontent.com/openSUSE/doc-ci/develop/gitlint/extra-gitlint-rules.py
       - gitlint --commits master..HEAD -C gitlint.ini
     - name: "Validate Documentation"
       before_install:


### PR DESCRIPTION
As discussed among Jeremy, Dima, Alex, me, relax the rules for the gitlint commit message checker in Travis a little. This switches us to a different config file, provided from a doc-team repo (which I hope is fine). We now also have better error messages if there is an issue with the title line's bug reference (i.e. no more regexes thrown in people's face).