### PR TITLE
Refactor script steps into separate script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,26 +15,10 @@ matrix:
       language: python
       if: type = pull_request
       script:
-      - pip install gitlint
-      - wget https://raw.githubusercontent.com/openSUSE/doc-ci/develop/gitlint/gitlint.ini
-      - wget https://raw.githubusercontent.com/openSUSE/doc-ci/develop/gitlint/extra-gitlint-rules.py
-      - gitlint --commits master..HEAD -C gitlint.ini
+        - ./travis-linter.sh
     - name: "Validate Documentation"
-      before_install:
-        - echo "TRAVIS_PULL_REQUEST=$TRAVIS_PULL_REQUEST" >> env.list
-        - echo "TRAVIS_BRANCH=$TRAVIS_BRANCH" >> env.list
-        - echo "SOURCE_BRANCH=$SOURCE_BRANCH" >> env.list
-        - echo "TRAVIS_REPO_SLUG=$TRAVIS_REPO_SLUG" >> env.list
-        - echo "LIST_PACKAGES=$LIST_PACKAGES" >> env.list
-        - echo "PUBLISH_PRODUCTS=\"$PUBLISH_PRODUCTS\"" >> env.list
-        - echo "ENCRYPTED_PRIVKEY_SECRET=$ENCRYPTED_PRIVKEY_SECRET" >> env.list
-        - echo "TRAVIS_COMMIT=$TRAVIS_COMMIT" >> env.list
-        - wget https://raw.githubusercontent.com/openSUSE/doc-ci/develop/travis/travis.sh
-        - ls
-        - echo "Building docker image"
-        - docker build -t sle-doc-image .
       script:
-        - docker run --rm -it sle-doc-image /bin/bash -c '/bin/bash travis.sh'
+        - ./travis-validate.sh
 
 notifications:
   email:

--- a/README.adoc
+++ b/README.adoc
@@ -139,6 +139,12 @@ our daps2docker project: https://github.com/openSUSE/daps2docker
 2. Clone the daps2docker repository.
 3. Run  `./daps2docker.sh /PATH/TO/DOC-DIR` or `/daps2docker.sh /PATH/TO/DC-FILE`.
 
+Running Travis-CI tests locally
+-------------------------------
+
+You can run the Travis-CI validation tests locally using the
+`travis-validate.sh` script. Note that Docker is required.
+
 Building upstream docs
 ~~~~~~~~~~~~~~~~~~~~~~
 

--- a/travis-linter.sh
+++ b/travis-linter.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+set -x -u
+
+pip install gitlint
+wget https://raw.githubusercontent.com/openSUSE/doc-ci/develop/gitlint/gitlint.ini
+wget https://raw.githubusercontent.com/openSUSE/doc-ci/develop/gitlint/extra-gitlint-rules.py
+gitlint --commits master..HEAD -C gitlint.ini

--- a/travis-validate.sh
+++ b/travis-validate.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+set -x
+
+echo "TRAVIS_PULL_REQUEST=$TRAVIS_PULL_REQUEST" >> env.list
+echo "TRAVIS_BRANCH=$TRAVIS_BRANCH" >> env.list
+echo "SOURCE_BRANCH=$SOURCE_BRANCH" >> env.list
+echo "TRAVIS_REPO_SLUG=$TRAVIS_REPO_SLUG" >> env.list
+echo "LIST_PACKAGES=$LIST_PACKAGES" >> env.list
+echo "PUBLISH_PRODUCTS=\"$PUBLISH_PRODUCTS\"" >> env.list
+echo "ENCRYPTED_PRIVKEY_SECRET=$ENCRYPTED_PRIVKEY_SECRET" >> env.list
+echo "TRAVIS_COMMIT=$TRAVIS_COMMIT" >> env.list
+
+if [[ ! -f travis.sh ]]; then
+  wget https://raw.githubusercontent.com/openSUSE/doc-ci/develop/travis/travis.sh
+fi
+
+docker run --rm -it \
+  --volume ${PWD}:/usr/src/app \
+  --workdir /usr/src/app \
+  susedoc/ci:openSUSE-42.3 \
+  /bin/bash -c '/bin/bash travis.sh'


### PR DESCRIPTION
Consolidation all `before_install` steps into a separate script makes
it easier to run the CI tests locally.

Signed-off-by: Nicolas Bock <nicolas.bock@suse.com>