### PR TITLE
Fixing links from suse.com/doc to new URL (noref)

### DIFF
--- a/xml/book_cloud_suppl.xml
+++ b/xml/book_cloud_suppl.xml
@@ -16,7 +16,6 @@
  </info>
  <xi:include href="suppl_intro.xml"/>
  <chapter xml:id="cha-suppl-horizon-theme">
-<!--https://bugzilla.suse.com/show_bug.cgi?id=917622-->
   <title>Changing the &cloud; &dash; Theme</title>
   <para>
    The &cloud; &dash; theme can now be customized. The default &productname;
@@ -172,7 +171,7 @@
     <para>
      For a list of supported VM guests, refer to the &slsreg; &virtual;,
      section <citetitle>Supported VM Guests</citetitle>. It is available at
-     <link xlink:href="https://www.suse.com/documentation/sles-12/book_virt/data/virt_support_guests.html"/>.
+     <link xlink:href="https://documentation.suse.com/sles/15-SP1/single-html/SLES-virtualization/#virt-support-guests"/>.
     </para>
     <para>
      Depending on the virtualization platform on which you want to use the
@@ -189,7 +188,6 @@
        </para>
       </listitem>
      </varlistentry>
-<!--https://bugzilla.suse.com/show_bug.cgi?id=863876-->
      <varlistentry>
       <term>&xen;</term>
       <listitem>
@@ -344,18 +342,9 @@
      </para>
     </step>
    </procedure>
-
-   <para>
-    For more detailed information on how to build appliance images, refer to
-    the &suseonsite; documentation, available at
-    <link xlink:href="http://www.suse.com/documentation/suse_studio/"/>.
-   </para>
   </sect1>
   <sect1 xml:id="sec-adm-cli-img-props">
    <title>Image Properties</title>
-
-<!-- taroth 2013-08-29: fix for https://bugzilla.suse.com/show_bug.cgi?id=828862-->
-
    <para>
     Images have both contents and metadata. The latter are also called
     properties. The following properties can be attached to an image in
@@ -495,8 +484,6 @@
          HVM image import use <option>vm_mode=hvm</option>.
         </para>
        </note>
-<!--taroth 2013-10-17: Xen:
-        http://docserv.nue.suse.com/documents/SLES/SLES-xen/single-html/#sec.xen.config.disk-->
       </listitem>
       <listitem>
        <para>
@@ -508,8 +495,6 @@
   --property vmware_disktype="preallocated" \
   --property hypervisor_type=vmware \
   --disk-format vmdk&nbsp;--file&nbsp;<replaceable>PATH_TO_IMAGE_FILE</replaceable>.vmdk</screen>
-<!--taroth 2014-02-05: fix for https://bugzilla.suse.com/show_bug.cgi?id=862165#c3,
-        as discussed with mjura-->
        <note>
         <title>Value of <literal>vmware_disktype</literal></title>
         <para>
@@ -912,8 +897,7 @@
        For more details and a list of default flavors available, refer to the
        &cloudadmin;, chapter <citetitle>Dashboard</citetitle> or
        chapter <citetitle>OpenStack command-line clients</citetitle>, section
-       <citetitle>Manage Flavors</citetitle>. The guide is available from
-       &suse-onlinedoc;.
+       <citetitle>Manage Flavors</citetitle>.
       </para>
      </listitem>
     </varlistentry>
@@ -935,7 +919,7 @@
        For details, refer to the &clouduser;, chapter <citetitle>OpenStack
        dashboard</citetitle> or chapter <citetitle>OpenStack command-line
        clients</citetitle>, section <citetitle>Configure access and security
-       for instances</citetitle>. The guide is available from &suse-onlinedoc;.
+       for instances</citetitle>.
       </para>
      </listitem>
     </varlistentry>
@@ -951,7 +935,7 @@
        For details, refer to the &clouduser;, chapter <citetitle>OpenStack
        dashboard</citetitle> or chapter <citetitle>OpenStack command-line
        clients</citetitle>, section <citetitle>Configure access and security
-       for instances</citetitle>. The guide is available from &suse-onlinedoc;.
+       for instances</citetitle>.
       </para>
      </listitem>
     </varlistentry>
@@ -972,7 +956,6 @@
        &clouduser;, chapter <citetitle>OpenStack dashboard</citetitle> or
        chapter <citetitle>OpenStack command-line clients</citetitle>, section
        <citetitle>Launch and manage instances</citetitle>.
-       The guide is available from &suse-onlinedoc;.
       </para>
       <itemizedlist>
        <listitem>

--- a/xml/common_intro_available_doc_i.xml
+++ b/xml/common_intro_available_doc_i.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE sect1 
+<!DOCTYPE sect1
 [
   <!ENTITY % entities SYSTEM "entity-decl.ent">
   %entities;
@@ -22,10 +22,8 @@
  <title>Online Documentation and Latest Updates</title>
  <para>
   Documentation for our products is available at
-  <link xlink:href="http://www.suse.com/documentation/"/>, where you can also
+  <link xlink:href="http://documentation.suse.com"/>, where you can also
   find the latest updates, and browse or download the documentation in various formats.
- <!--and languages.The latest documentation updates usually can be found in
- the English language version.-->
  </para>
 </note>
  <para>

--- a/xml/common_intro_feedback_i.xml
+++ b/xml/common_intro_feedback_i.xml
@@ -67,7 +67,7 @@
      the other documentation included with this product. If you are reading the
      HTML version of this guide, use the Comments feature at the bottom of each page
      in the online documentation
-     at <link xlink:href="http://www.suse.com/documentation/"/>.
+     at <link xlink:href="http://documentation.suse.com"/>.
     </para>
     <para>If you are reading the single-page HTML version of this guide, you can
      use the <guimenu>Report Bug</guimenu> link next to each section to open

--- a/xml/common_intro_making_i.xml
+++ b/xml/common_intro_making_i.xml
@@ -34,6 +34,6 @@
   </para>
   <para>
    The XML source code of this documentation can be found at <link
-   xlink:href="&github.url;"/>.
+   xlink:href="https://github.com"/>.
   </para>
 </sect1>

--- a/xml/create-vapp_template-vcenter.xml
+++ b/xml/create-vapp_template-vcenter.xml
@@ -300,9 +300,8 @@ STARTMODE='auto'</screen>
       Allow the <literal>ardana</literal> user to <literal>sudo</literal>
       without password. Setting up <literal>sudo</literal> on &slsa; is covered
       in the &suse; documentation at <link
-      xlink:href="https://www.suse.com/documentation/sles-12/book_sle_admin/data/sec_sudo_conf.html">
-      Configuring sudo</link>. We
-      recommend creating user specific sudo config files in the
+      xlink:href="https://documentation.suse.com/sles/15-SP1/single-html/SLES-admin/#sec-sudo-conf"/>.
+      We recommend creating user specific sudo config files in the
       <filename>/etc/sudoers.d</filename> directory. Create an
       <filename>/etc/sudoers.d/ardana</filename> config file with the following
       content to allow sudo commands without the requirement of a password.

--- a/xml/depl_conf_admin_repos.xml
+++ b/xml/depl_conf_admin_repos.xml
@@ -320,8 +320,7 @@ mount -o loop <replaceable>/local/SUSE-OPENSTACK-CLOUD-&productnumber;-x86_64-DV
      repositories for this product available, including the repositories
      for all registered add-on products (like &productname;, &slsa; &hasi; and
      &storage;). Instructions for creating a distribution are in the &susemgr; documentation in <link
-     xlink:href="&suse-onlinedoc;/suse_manager/"/>. <!-- Check if SuMa 3
-     documentation contains a section to which we can link -->
+     xlink:href="https://documentation.suse.com/suma/4.0/"/>.
     </para>
     <para>
      During the distribution setups you need to provide a

--- a/xml/depl_inst_admin.xml
+++ b/xml/depl_inst_admin.xml
@@ -30,15 +30,9 @@
   <title>Starting the Operating System Installation</title>
   <para>
    Start the installation by booting into the &cloudos; installation system.
-   For an overview of a default &sls; installation, refer to the <link
-   xlink:href="&suse-onlinedoc;/sles-12/book_quickstarts/data/art_sle_installquick.html">&sls;
-   &instquick;</link>. <link
-   xlink:href="&suse-onlinedoc;/sles-12/book_sle_deployment/data/cha_inst.html">Detailed
-   installation instructions</link> are available in the &sls;
-   <citetitle>Deployment Guide</citetitle>. Both documents are available at
-   <link xlink:href="&suse-onlinedoc;/sles-12/"/>.
+   For an overview of a default &sls; installation, refer to <link
+   xlink:href="https://documentation.suse.com/sles/15-SP1/single-html/SLES-deployment/#cha-install"/>.
   </para>
-
   <para>
    The following sections will only cover the differences from the default
    installation process.
@@ -50,11 +44,7 @@
   <para>
    Registering &cloudos; during the installation process is required for
    getting product updates and for installing the &productname;
-   extension. Refer to the <link
-   xlink:href="&suse-onlinedoc;/sles-12/book_sle_deployment/data/sec_i_yast2_conf_manual_cc.html">SUSE
-   Customer Center Registration</link> section of the &cloudos; <citetitle>Deployment
-   Guide</citetitle> for further instructions.
-  </para>
+   extension.</para>
   <para>
    After a successful registration you will be asked whether
    to add the update repositories. If you agree, the latest updates will
@@ -91,29 +81,8 @@
    &cloudos; installation via <menuchoice><guimenu>&yast;</guimenu>
    <guimenu>Software</guimenu> <guimenu>Add-On Products</guimenu></menuchoice>.
    For details, refer to the section <link
-   xlink:href="https://www.suse.com/documentation/sles-12/book_sle_deployment/data/sec_add-ons_extensions.html">Installing
-   Modules and Extensions from Online Channels</link> of the &cloudos;
-   <citetitle>Deployment Guide</citetitle>.
+   xlink:href="https://documentation.suse.com/sles/15-SP1/single-html/SLES-deployment/#sec-yast-install-modules"/>.
   </para>
-
-<!-- fs 2015-12-17:
-     Leaving this in comments just in case we need to document how to install
-     Cloud from media
-
-  <para>
-   On the <guimenu>Installation Mode</guimenu> screen, click
-   <guimenu>Include Add-On products from Separate Media</guimenu>. Proceed
-   with <guimenu>Next</guimenu> to the add-on product installation dialog.
-   If you have direct access to the installation media (for example, via DVD
-   or flash disk), skip the network installation dialog. Otherwise configure
-   the network as described in <xref linkend="sec-depl-adm-inst-network"/>.
-   Add &cloud; and proceed with the installation. Consult the &sls;
-   <citetitle>Deployment Guide</citetitle> at
-   <link xlink:href="http://www.suse.com/documentation/sles11/book_sle_deployment/data/sec_i_yast2_inst_mode.html"/>
-   for detailed instructions.
-   </para>
--->
-
  </sect1>
  <sect1 xml:id="sec-depl-adm-inst-partition">
   <title>Partitioning</title>
@@ -131,9 +100,7 @@
   </para>
   <para>
    Help on using the partitioning tool is available at the section <link
-   xlink:href="&suse-onlinedoc;/sles11/book_sle_deployment/data/sec_yast2_i_y2_part_expert.html">Using
-   the YaST Partitioner</link> of the &cloudos; <citetitle>Deployment
-   Guide</citetitle>.
+   xlink:href="https://documentation.suse.com/sles/15-SP1/single-html/SLES-deployment/#sec-expert-partitioner"/>.
   </para>
  </sect1>
 
@@ -143,9 +110,7 @@
    In the final installation step, <guimenu>Installation Settings</guimenu>, you need to adjust
    the software selection and the firewall settings for your &admserv; setup. For more information
    refer to the <link
-   xlink:href="&suse-onlinedoc;/sles-12/book_sle_deployment/data/sec_i_yast2_proposal.html">Installation
-   Settings</link> section of the &cloudos; <citetitle>Deployment
-   Guide</citetitle>.
+   xlink:href="https://documentation.suse.com/sles/15-SP1/single-html/SLES-deployment/#sec-yast-install-perform"/>.
   </para>
 
   <sect2 xml:id="sec-depl-adm-inst-settings-software">

--- a/xml/depl_inst_nodes.xml
+++ b/xml/depl_inst_nodes.xml
@@ -67,8 +67,7 @@
       If this configuration does not match your needs (for example if you
       need special third party drivers) you need to make adjustments to this
       file. See the <link
-        xlink:href="http://www.suse.com/documentation/sles-12/book_autoyast/data/book_autoyast.html">&ay;
-      manual</link> for details.
+        xlink:href="https://documentation.suse.com/sles/15-SP1/single-html/SLES-autoyast/#book-autoyast"/> for details.
       If you change the &ay; configuration file, you need to re-upload
       it to &chef; using the following command:
      </para>
@@ -614,7 +613,7 @@
      cluster resource manager on a node is active during the software update,
      this can lead to unpredictable results like fencing of active nodes. For
      detailed instructions refer to <link
-     xlink:href="&suse-onlinedoc;/sle-ha-12/book_sleha/data/sec_ha_migration_update.html"/>.
+     xlink:href="https://documentation.suse.com/sle-ha/15-SP1/single-html/SLE-HA-guide/#sec-ha-clvm-migrate"/>.
     </para>
    </warning>
 
@@ -722,7 +721,7 @@
      cluster resource manager on a node is active during the software update,
      this can lead to unpredictable results like fencing of active nodes. For
      detailed instructions refer to <link
-     xlink:href="&suse-onlinedoc;/sle-ha-12/book_sleha/data/sec_ha_migration_update.html"/>.
+     xlink:href="https://documentation.suse.com/sle-ha/15-SP1/single-html/SLE-HA-guide/#sec-ha-clvm-migrate"/>.
     </para>
    </warning>
 

--- a/xml/depl_intro.xml
+++ b/xml/depl_intro.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE preface 
+<!DOCTYPE preface
 [
   <!ENTITY % entities SYSTEM "entity-decl.ent">
   %entities;
@@ -69,7 +69,7 @@
   of the &compnode;s. Object storage is managed by the &stornode;s.
 <!-- fs 2012-09-25: Preserve for 2.0
 Storage, attached to &vmguest;s, or object storage is managed by the
-&stornode;s.  
+&stornode;s.
 -->
  </para>
  <para>
@@ -80,7 +80,7 @@ Storage, attached to &vmguest;s, or object storage is managed by the
  <para>
   For an overview of the documentation available for your product and the
   latest documentation updates, refer to
-  <link xlink:href="http://www.suse.com/documentation"/>.
+  <link xlink:href="https://documentation.suse.com"/>.
  </para>
  <xi:include href="common_intro_available_doc_i.xml"/>
  <xi:include href="common_intro_feedback_i.xml"/>

--- a/xml/depl_nodes.xml
+++ b/xml/depl_nodes.xml
@@ -352,8 +352,8 @@
      <para>
       This configuration option defines what to do with the cluster
       partition(s) that do not have the quorum. See
-      <link xlink:href="&suse-onlinedoc;/sle-ha-12/book_sleha/data/sec_ha_config_basics_global.html"/>,
-      section <citetitle>Option no-quorum-policy</citetitle> for details.
+      <link xlink:href="https://documentation.suse.com/sle-ha/15-SP1/single-html/SLE-HA-guide/#sec-conf-hawk2-cluster-config"/>,
+      for details.
      </para>
      <para>
       The recommended setting is to choose <guimenu>Stop</guimenu>. However,
@@ -374,7 +374,7 @@
       them from causing trouble. This mechanism is called &stonith;
       (<quote>Shoot the other node in the head</quote>). &stonith; can be
       configured in a variety of ways, refer to
-      <link xlink:href="&suse-onlinedoc;/sle-ha-12/book_sleha/data/cha_ha_fencing.html"/>
+      <link xlink:href="https://documentation.suse.com/sle-ha/15-SP1/single-html/SLE-HA-guide/#cha-ha-fencing"/>
       for details. The following configuration options exist:
      </para>
      <variablelist>
@@ -385,7 +385,7 @@
         <para>
          &stonith; will not be configured when deploying the &barcl;. It needs
          to be configured manually as described in
-         <link xlink:href="&suse-onlinedoc;/sle-ha-12/book_sleha/data/cha_ha_fencing.html"/>.
+         <link xlink:href="https://documentation.suse.com/sle-ha/15-SP1/single-html/SLE-HA-guide/#cha-ha-fencing"/>.
          For experts only.
         </para>
        </listitem>
@@ -449,7 +449,7 @@
 <screen>sbd -d /dev/<replaceable>SBD</replaceable> create</screen>
           <para>
            Refer to
-           <link xlink:href="&suse-onlinedoc;/sle-ha-12/book_sleha/data/sec_ha_storage_protect_fencing.html#pro_ha_storage_protect_sbd_create"/>
+           <link xlink:href="https://documentation.suse.com/sle-ha/15-SP1/single-html/SLE-HA-guide/#sec-ha-storage-protect-test"/>
            for details.
           </para>
          </listitem>
@@ -459,9 +459,6 @@
          respective kernel module to be used. Find the most commonly used
          watchdog drivers in the following table:
         </para>
-<!--taroth 2016-11-28: table taken from
-         https://github.com/SUSE/doc-sleha/blob/develop/xml/ha_storage_protection.xml,
-         pro.ha.storage.protect.watchdog-->
         <informaltable>
          <tgroup cols="2">
           <thead>
@@ -768,20 +765,6 @@
    </itemizedlist>
   </warning>
 
-<!--taroth 2017-02-01: commenting as it is still not possible to update this screenshot-->
-
-<!-- <figure>
-   <title>Available Clusters in the Deployment Section</title>
-   <mediaobject>
-    <imageobject role="fo">
-     <imagedata fileref="depl_barclamp_database_cluster_deployment.png" width="100%" format="png"/>
-    </imageobject>
-    <imageobject role="html">
-     <imagedata fileref="depl_barclamp_database_cluster_deployment.png" width="75%" format="png"/>
-    </imageobject>
-   </mediaobject>
-  </figure>-->
-
   <important>
    <title>Service Management on the Cluster</title>
    <para>
@@ -790,7 +773,7 @@
     an HA-managed service, nor configure it to start on boot. Services may only
     be started or stopped by using the cluster management tools Hawk or the crm
     shell. See
-    <link xlink:href="&suse-onlinedoc;/sle-ha-12/book_sleha/data/sec_ha_config_basics_resources.html"/>
+    <link xlink:href="https://documentation.suse.com/sle-ha/15-SP1/single-html/SLE-HA-guide/#sec-ha-config-basics-resources"/>
     for more information.
    </para>
   </important>
@@ -1704,13 +1687,13 @@ and admins can see the available options in the barclamp -->
     <step>
      <para>
       <guimenu>scope</guimenu> corresponds to
-      <link xlink:href="https://github.com/zmartzone/mod_auth_openidc/blob/master/auth_openidc.conf">auth_openidc OIDCScope</link>. 
+      <link xlink:href="https://github.com/zmartzone/mod_auth_openidc/blob/master/auth_openidc.conf">auth_openidc OIDCScope</link>.
      </para>
     </step>
     <step>
      <para>
       <guimenu>metadata_url</guimenu> corresponds to
-      <link xlink:href="https://github.com/zmartzone/mod_auth_openidc/blob/master/auth_openidc.conf">auth_openidc OIDCProviderMetadataURL</link>.          
+      <link xlink:href="https://github.com/zmartzone/mod_auth_openidc/blob/master/auth_openidc.conf">auth_openidc OIDCProviderMetadataURL</link>.
      </para>
     </step>
     <step>
@@ -1765,7 +1748,7 @@ and admins can see the available options in the barclamp -->
     </step>
     <step>
      <para>
-      Use the Keystone <emphasis role="bold">admin</emphasis> credential. 
+      Use the Keystone <emphasis role="bold">admin</emphasis> credential.
      </para>
      <screen>source ~/.openrc</screen>
     </step>
@@ -5033,7 +5016,7 @@ openstack router add subnet <replaceable>router2</replaceable> priv-net-sub</scr
   <para>
    For information on how to deploy a Kubernetes cluster (either from command
    line or from the &o_dash; &dash;), see the &cloudsuppl;. It is available
-   from <link xlink:href="https://www.suse.com/documentation/cloud"></link>.
+   from <link xlink:href="https://documentation.suse.com/soc/9/"></link>.
   </para>
 
   <para>
@@ -5048,7 +5031,6 @@ openstack router add subnet <replaceable>router2</replaceable> priv-net-sub</scr
     <listitem>
      <para>
       Deploying Kubernetes clusters in a cloud without an Internet connection
-      (as described in <link xlink:href="https://www.suse.com/documentation/suse-openstack-cloud-7/singlehtml/book_cloud_suppl/book_cloud_suppl.html#sec.deploy.kubernetes.without">Deploying a Kubernetes Cluster Without Internet Access</link>))
       requires the <literal>registry_enabled</literal> option in its cluster
       template set to <literal>true</literal>. To make this offline scenario
       work, you also need to set the <guimenu>Delegate trust to cluster users if
@@ -7569,7 +7551,7 @@ radosgw_urls:
       users must be created for &o_blockstore;, &o_comp;, and
       &o_img;. Instructions for creating and managing pools, users and keyrings
       can be found in the <link
-      xlink:href="https://www.suse.com/documentation/suse-enterprise-storage-5/">
+      xlink:href="https://documentation.suse.com/ses/5.5/">
       SUSE Enterprise Storage</link> Administration Guide in the Key Management
       section.
      </para>

--- a/xml/depl_nostack_services.xml
+++ b/xml/depl_nostack_services.xml
@@ -115,8 +115,8 @@
       </para>
     </note>
     <para>
-    <!-- See https://www.suse.com/documentation/sles-12/book_sle_deployment/data/cha_add-ons.html -->
-    To be able to apply the Salt proposal, the <link xlink:href="https://www.suse.com/documentation/sles-12/book_sle_deployment/data/cha_add-ons.html">Advanced Systems Management Module</link>
+    To be able to apply the Salt proposal, the
+    <link xlink:href="https://documentation.suse.com/sles/15-SP1/single-html/SLES-deployment/#sec-yast-install-addons"/>
     must be available on the node where the <literal>salt-ssh</literal> role will be applied
     (usually the admin node).
     After the Module is available, the &barcl; can be applied.

--- a/xml/depl_require.xml
+++ b/xml/depl_require.xml
@@ -1154,7 +1154,7 @@
     component requires at least two machines (more are recommended) to store
     data redundantly. For information on hardware requirements for &ceph;, see
     <link
-    xlink:href="https://www.suse.com/documentation/ses-4/book_storage_admin/data/cha_ceph_sysreq.html"/>
+    xlink:href="https://documentation.suse.com/ses/5.5/single-html/ses-deployment/#storage-bp-hwreq"/>
     </para>
     <para>
      Each &ceph;/&swift; &stornode; needs at least two hard disks.
@@ -1256,7 +1256,7 @@
 
   <para>
    Certificates must be signed by a trusted authority. Refer to
-   <link xlink:href="&suse-onlinedoc;/sles-12/book_sle_admin/data/sec_apache2_ssl.html"/>
+   <link xlink:href="https://documentation.suse.com/sles/15-SP1/single-html/SLES-admin/#sec-apache2-ssl"/>
    for instructions on how to create and sign them.
   </para>
 
@@ -1988,7 +1988,7 @@
      &contrnode;. For details on the
      Pacemaker cluster stack and the &sle; &hasi;, refer to the
      &haguide;, available at
-     <link xlink:href="&suse-onlinedoc;/sle-ha-12/"/>.
+     <link xlink:href="https://documentation.suse.com/sle-ha/15-SP1/"/>.
      Note that &sle; &hasi; includes &lvs; as the load-balancer, and
      &productname; uses &haproxy; for this purpose
      (<link xlink:href="http://haproxy.1wt.eu/"/>).
@@ -2145,7 +2145,7 @@
      &ceph; is a distributed storage solution that can provide &ha;.  For &ha;
      redundant storage and monitors need to be configured in the &ceph;
      cluster. For more information refer to the &storage; documentation at
-     <link xlink:href="&suse-onlinedoc;/suse-enterprise-storage-5/index.html"/>.
+     <link xlink:href="https://documentation.suse.com/ses/5.5/"/>.
     </para>
    </sect3>
   </sect2>
@@ -2156,7 +2156,7 @@
     When considering setting up one or more &ha; clusters, refer to the
     chapter <citetitle>System Requirements</citetitle> in the
     &haguide; for &sle; &hasi;. The guide is available at
-    <link xlink:href="&suse-onlinedoc;/sle-ha-12/"/>.
+    <link xlink:href="https://documentation.suse.com/sle-ha/15-SP1/"/>.
    </para>
    <para>
     The HA requirements for &contrnode; also apply to &productname;. Note that by
@@ -2239,7 +2239,7 @@
       </itemizedlist>
       <para>
        For more information, refer to the &haguide;, available at
-       <link xlink:href="&suse-onlinedoc;/sle-ha-12/"/>.
+       <link xlink:href="https://documentation.suse.com/sle-ha/15-SP1/"/>.
        Especially read the following chapters: <citetitle>Configuration and
        Administration Basics</citetitle>, and <citetitle>Fencing and
        &stonith;</citetitle>, <citetitle> Storage Protection</citetitle>.
@@ -2263,7 +2263,7 @@
       </important>
       <para>
        For more information, refer to the &haguide;, available at
-       <link xlink:href="&suse-onlinedoc;/sle-ha-12/"/>.
+       <link xlink:href="https://documentation.suse.com/sle-ha/15-SP1/"/>.
        Especially read the following chapter: <citetitle>Network Device
        Bonding</citetitle>.
       </para>
@@ -2325,7 +2325,7 @@
     For a basic understanding and detailed information on the &sle;
     &hasi; (including the Pacemaker cluster stack), read the
     &haguide;. It is available at
-    <link xlink:href="&suse-onlinedoc;/sle-ha-12/"/>.
+    <link xlink:href="https://documentation.suse.com/sle-ha/15-SP1/"/>.
    </para>
    <para>
     In addition to the chapters mentioned in

--- a/xml/depl_smt_setup.xml
+++ b/xml/depl_smt_setup.xml
@@ -25,7 +25,7 @@
     &smt; server or a &susemgr; server that can be accessed from the
     &admserv;, skip this step.
    </para>
-  </abstract>  
+  </abstract>
  </info>
  <important>
   <title>Use of &smt; Server and Ports</title>
@@ -179,7 +179,7 @@
      <guimenu>YaST</guimenu> <guimenu>Security and Users</guimenu>
      <guimenu>CA Management</guimenu> </menuchoice> after the &smt;
      configuration is done. See
-   <link xlink:href="&suse-onlinedoc;/sles-12/book_security/data/cha_security_yast_ca.html"/>
+   <link xlink:href="https://documentation.suse.com/sles/15-SP1/single-html/SLES-security/#cha-security-yast-security"/>
    for more information.
     </para>
     <para>
@@ -269,7 +269,7 @@ done</screen>
   <title>For More Information</title>
 
   <para>
-   For detailed information about &smt; refer to the &smtool; manual at <link xlink:href="&suse-onlinedoc;/sles-12/book_smt/data/book_smt.html"/>.
+   For detailed information about &smt; refer to the &smtool; manual at <link xlink:href="https://documentation.suse.com/sles/12-SP5/single-html/SLES-smt/"/>.
   </para>
  </sect1>
 </chapter>

--- a/xml/depl_troubleshooting.xml
+++ b/xml/depl_troubleshooting.xml
@@ -910,7 +910,7 @@ EOF</screen>
    &stornode; is part of the problem, run
    <command>supportconfig</command> on the affected node as well. For
    details on how to run <command>supportconfig</command>, see
-   <link xlink:href="&suse-onlinedoc;/sles-12/book_sle_admin/data/cha_adm_support.html"/>.
+   <link xlink:href="https://documentation.suse.com/sles/15-SP1/single-html/SLES-admin/#cha-adm-support"/>.
   </para>
 
   <sect2 xml:id="sec-depl-trouble-support-ptf">

--- a/xml/depl_zsystems.xml
+++ b/xml/depl_zsystems.xml
@@ -699,29 +699,11 @@ XAUTOLOG VSMGUARD</screen>
     To install the image capture system, follow the default &slsa; for IBM
     &zseries; installation instructions that are available from the &suse; Web
     page: <link
-    xlink:href="https://www.suse.com/documentation/sles-12/book_sle_deployment/data/cha_zseries.html">Installation
+    xlink:href="https://documentation.suse.com/sles/15-SP1/single-html/SLES-deployment/#cha-zseries">Installation
     on IBM z Systems</link>. Make sure to fulfill the <xref
     linkend="sec-deploy-zsystems-image-requirements"/> when setting up the
     network and the partitions.
    </para>
-
-   <remark condition="clarity">
-    2016-10-17 - fs: What about registering the system? Should this step be
-    skipped?
-   </remark>
-
-
-<!--
-
-   <important>
-    <title>Do not Register the System</title>
-    <para>
-
-    </para>
-   </important>
-
--->
-
    <para>
     Once the system has been installed, make the following adjustments:
    </para>

--- a/xml/entity-decl.ent
+++ b/xml/entity-decl.ent
@@ -163,11 +163,6 @@ suggested official replacement from rsalevsky. -->
 <!ENTITY xen           "Xen">
 <!ENTITY xenreg        "Xen&reg;">
 
-<!-- +++++++++++++++++++++++ Links +++++++++++++++++++++++++++++++ -->
-
-<!ENTITY suse-onlinedoc "http://www.suse.com/documentation">
-<!ENTITY github.url     "https://github.com/SUSE-Cloud/doc-cloud">
-
 <!-- +++++++++++++++++++++++ Books +++++++++++++++++++++++++++++++ -->
 
 <!-- SOC -->

--- a/xml/install_caasp_heat_templates.xml
+++ b/xml/install_caasp_heat_templates.xml
@@ -115,7 +115,7 @@ git clone https://github.com/SUSE/caasp-openstack-heat-templates
   <para>
    When you have successfully accessed the admin node web interface via the
    floating IP, follow the instructions at <link
-   xlink:href="https://www.suse.com/documentation/suse-caasp-3/book_caasp_deployment/data/book_caasp_deployment.html"/> to
+   xlink:href="https://documentation.suse.com/suse-caasp/4.1/single-html/caasp-deployment/"/> to
    continue the setup of &caasp;.
   </para>
  </section>
@@ -601,7 +601,7 @@ i | sles12-velum-image | package    | 3.1.7-3.27.3  | x86_64 | update_caasp</scr
       can be retrieved from the &clm; node in the <filename>/etc/ssl/certs/</filename>
       directory. The filename should match the node name of your primary
       controller node. For example:
-      <filename>/etc/ssl/certs/ardana-stack1-cp1-core-m1.pem</filename>    
+      <filename>/etc/ssl/certs/ardana-stack1-cp1-core-m1.pem</filename>
       Download this file and provide it as the system-wide certificate.</para>
     </note>
     <para>
@@ -683,7 +683,7 @@ i | sles12-velum-image | package    | 3.1.7-3.27.3  | x86_64 | update_caasp</scr
   <title>More Information about &caasp;</title>
   <para>
    More information about the &caasp; is available at <link
-   xlink:href="https://www.suse.com/documentation/suse-caasp-3/book_caasp_deployment/data/book_caasp_deployment.html"/>
+   xlink:href="https://documentation.suse.com/suse-caasp/4.1/"/>
   </para>
  </section>
 </chapter>

--- a/xml/installation-installation-ses_integration.xml
+++ b/xml/installation-installation-ses_integration.xml
@@ -28,7 +28,7 @@
  </para>
  <para>
   For more information on &ses;, see
-  the <link xlink:href="https://www.suse.com/documentation/suse-enterprise-storage-5/">SES 5 and 5.5 documentation</link>.
+  the <link xlink:href="https://documentation.suse.com/ses/5.5"/>.
  </para>
 
   <section xml:id="ses-installation">
@@ -218,8 +218,7 @@ radosgw_urls:
    be created for &o_blockstore;, &o_blockstore; backup, &o_comp; and
    &o_img;. Instructions for creating and managing pools, users and keyrings is
    covered in the &ses; documentation under <link
-   xlink:href="https://www.suse.com/documentation/suse-enterprise-storage-5/book_storage_admin/data/storage_cephx_keymgmt.html">Key
-   Management</link>.
+   xlink:href="https://documentation.suse.com/en-us/ses/5.5/single-html/ses-admin/#storage-cephx-keymgmt"/>.
    </para>
    <para>
     After the required pools and users are set up on the &ceph;
@@ -411,7 +410,7 @@ rgw keystone verify ssl = false # If keystone is using self-signed
     gateway role to communicate securely using SSL, you need to either have a
     CA-issued certificate or create a self-signed one. Instructions for both
     are available in the <link
-    xlink:href="https://www.suse.com/documentation/suse-enterprise-storage-5/book_storage_admin/data/ceph_rgw_access.html">&ses;
+    xlink:href="https://documentation.suse.com/en-us/ses/5.5/single-html/ses-admin/#ceph-rgw-https">&ses;
     documentation</link>.
    </para>
    <para>

--- a/xml/installation-installation-sles-provisioning_sles.xml
+++ b/xml/installation-installation-sles-provisioning_sles.xml
@@ -345,7 +345,7 @@ passwd ardana</screen>
    <title>Allow user <literal>ardana</literal> to <literal>sudo</literal> without password</title>
    <para>
     Setting up sudo on &slsa; is covered in the <citetitle>&slsa; Administration Guide</citetitle> at
-    <link xlink:href="https://www.suse.com/documentation/sles-12/book_sle_admin/data/sec_sudo_conf.html"/>.
+    <link xlink:href="https://documentation.suse.com/sles/15-SP1/single-html/SLES-admin/#sec-sudo-conf"/>.
    </para>
    <para>
     The recommendation is to create user specific <command>sudo</command> config files under
@@ -375,7 +375,7 @@ deployer_ip=192.168.10.254
   <para>
    For more information about Zypper, see the
    <citetitle>&slsa; Administration Guide</citetitle> at
-   <link xlink:href="https://www.suse.com/documentation/sles-12/book_sle_admin/data/sec_zypper.html"/>.
+   <link xlink:href="https://documentation.suse.com/sles/15-SP1/single-html/SLES-admin/#sec-zypper"/>.
   </para>
   <warning>
    <para>

--- a/xml/installation-support.xml
+++ b/xml/installation-support.xml
@@ -4,9 +4,8 @@
   <!ENTITY % entities SYSTEM "entity-decl.ent">
   %entities;
 ]>
-<!-- Converted by suse-upgrade version 1.1 -->
 <part xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.0" xml:id="cha-inst-trouble">
- <title><!-- Troubleshooting and -->Support</title>
+ <title>Support</title>
  <info>
   <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
     <dm:maintainer>fs</dm:maintainer>
@@ -27,7 +26,6 @@
    <qandadiv>
     <title>Node Deployment</title>
     <qandaentry>
-     <!-- fs 2018-06-18: bsc 1088502 -->
      <question>
       <para>
        How to Disable the &yast; Installer Self-Update when deploying nodes?
@@ -93,7 +91,7 @@
    &stornode; is part of the problem, run
    <command>supportconfig</command> on the affected node as well. For
    details on how to run <command>supportconfig</command>, see
-   <link xlink:href="&suse-onlinedoc;/sles-12/book_sle_admin/data/cha_adm_support.html"/>.
+   <link xlink:href="https://documentation.suse.com/sles/15-SP1/single-html/SLES-admin/#cha-adm-support"/>.
   </para>
   </chapter>
 

--- a/xml/operations-general_troubleshooting.xml
+++ b/xml/operations-general_troubleshooting.xml
@@ -25,7 +25,7 @@
   <command>supportconfig</command> on the affected node as well. For details on
   how to run <command>supportconfig</command>, see
   <link
-   xlink:href="&suse-onlinedoc;/sles-12/book_sle_admin/data/cha_adm_support.html"/>.
+   xlink:href="https://documentation.suse.com/sles/15-SP1/single-html/SLES-admin/#cha-adm-support"/>.
  </para>
  <xi:include href="operations-alarm_resolutions.xml"/>
  <xi:include href="operations-troubleshooting-contacting_support.xml"/>

--- a/xml/planning-planning-hw_support_kvmguestos.xml
+++ b/xml/planning-planning-hw_support_kvmguestos.xml
@@ -7,6 +7,6 @@
  <title>KVM Guest OS Support</title>
  <para>
   For a list of the supported VM guests, see
-  <link xlink:href="https://www.suse.com/documentation/sles-12/book_virt/data/virt_support_guests.html"/>
+  <link xlink:href="https://documentation.suse.com/sles/15-SP1/single-html/SLES-virtualization/#virt-support-guests"/>
  </para>
 </section>

--- a/xml/planning-planning-suse-register_suse_automated.xml
+++ b/xml/planning-planning-suse-register_suse_automated.xml
@@ -9,7 +9,7 @@
   If you deploy your instances automatically using AutoYaST, you can register
   the system during the installation by providing the respective information in
   the AutoYaST control file. Refer to
-  <link xlink:href="https://www.suse.com/documentation/sles-12/book_autoyast/data/createprofile_register.html"/>
+  <link xlink:href="https://documentation.suse.com/sles/15-SP1/single-html/SLES-autoyast/#CreateProfile-Register"/>
   for details.
  </para>
 </section>

--- a/xml/poc-install-deployer-node.xml
+++ b/xml/poc-install-deployer-node.xml
@@ -11,15 +11,14 @@
  <para>
    This chapter takes you through the steps of installing the CLM deployer node.
    If you want more in-depth instructions, see the
-  <link xlink:href="https://www.suse.com/documentation/suse-openstack-cloud-9/book-deployment/data/book-deployment.html"><citetitle>Deployment Guide using Cloud Lifecycle Manager</citetitle></link>
-   for Cloud 9.
+  <xref linkend="book-deployment"/> for Cloud 9.
  </para>
  <section xml:id="install-os">
  <title>Install the Operating System</title>
   <para>Registering SUSE Linux Enterprise Server 12 SP4 during the
    installation process is required for getting product updates and
    for installing the SUSE OpenStack Cloud extension. Refer to the
-   <link xlink:href="https://www.suse.com/documentation/sled-12/book_sle_deployment/data/sec_i_yast2_conf_manual_cc.html"><citetitle>SUSE Customer Center Registration</citetitle></link>
+   <link xlink:href="https://documentation.suse.com/sled/15-SP1/single-html/SLED-deployment/#sec-yast-install-scc-registration"/>
    section of the SUSE Linux Enterprise Server 12 SP4 Deployment Guide for further instructions.</para>
   <para>Install a SLES12-SP4 server using the following values
    (accepting all other defaults):</para>
@@ -91,7 +90,7 @@ Users:
          credentials from Novell Customer Center or SUSE Customer
          Center (SCC), they are identical.
          For more information on SMT configuration, see the
-         <link xlink:href="https://www.suse.com/documentation/suse-openstack-cloud-9/book-deployment/data/app-deploy-smt-config.html"><citetitle>SMT Configuration</citetitle></link>
+         <xref linkend="clm-app-deploy-smt-config"/>
          in the SUSE OpenStack Cloud Deployment Guide.
          </para>
        </step>

--- a/xml/poc-map-ui-steps.xml
+++ b/xml/poc-map-ui-steps.xml
@@ -53,8 +53,7 @@
         <para>
           From the list of models, select an option to test.
           We recommend using the Entry-Scale Cloud. For more information,
-          see <link xlink:href="https://www.suse.com/documentation/suse-openstack-cloud-9/singlehtml/book-deployment/book-deployment.html#entry-scale-kvm"><citetitle>Entry-Scale Cloud</citetitle></link>
-          in the Deployment Guide.
+          see <xref linkend="entry-scale-kvm"/> in the Deployment Guide.
           Click <guimenu>Next</guimenu>.
         </para>
       </step>

--- a/xml/poc-overview.xml
+++ b/xml/poc-overview.xml
@@ -103,8 +103,7 @@
      <para>
       This guide also uses &suse; Enterprise Storage" (SES), powered by Ceph, as
       a software based storage solution on the backend. For more documentation
-      on SES, see <link xlink:href="https://www.suse.com/documentation/suse-enterprise-storage-5/"><citetitle>&suse; Enterprise Storage" 5</citetitle></link>
-      for the latest.
+      on SES, see <link xlink:href="https://documentation.suse.com/ses/5.5"/>.
      </para>
   </section>
 </chapter>

--- a/xml/poc-prerequisites.xml
+++ b/xml/poc-prerequisites.xml
@@ -136,7 +136,7 @@
       Before installing SUSE OpenStack Cloud, networks must be
       provisioned and tested. The networks are not installed or managed by the
       Cloud. You must install and manage the networks as documented in
-      <link xlink:href="https://www.suse.com/documentation/suse-openstack-cloud-9/singlehtml/book-deployment/book-deployment.html#example-configs"><citetitle>SUSE OpenStack Cloud Example Configurations</citetitle>.</link>
+      <xref linkend="example-configs"/>
     </para>
  </section>
 </chapter>

--- a/xml/poc_crowbar_guide.xml
+++ b/xml/poc_crowbar_guide.xml
@@ -378,7 +378,7 @@
      completed in advance (see <xref
       linkend="sec-depl-poc-networkjson"/>
      and
-     <link xlink:href="https://www.suse.com/documentation/suse-openstack-cloud-9/book_crowbar-deployment/data/book_crowbar-deployment.html"/>)
+     <xref linkend="book-crowbar-deployment"/>)
     </para>
    </step>
   </procedure>
@@ -756,7 +756,7 @@
       network barclamp template file
       <systemitem>/etc/crowbar/network.json</systemitem>. For more detailed
       explanation and description see
-      <link xlink:href="https://www.suse.com/documentation/suse-openstack-cloud-6/pdfdoc/book_cloud_deploy/book_cloud_deploy.pdf#page=240&amp;zoom=auto,63.779,788.031" />
+      <link xlink:href="https://documentation.suse.com/soc/9/single-html/suse-openstack-cloud-crowbar-deployment/#sec-depl-inst-admserv-post-network"/>
      </para>
     </listitem>
    </itemizedlist>
@@ -1352,13 +1352,13 @@
        the Administration Server. This means that all machines need to meet the
        hardware requirements for the chosen mode. The network mode can be
        configured using the YaST Crowbar module (see
-       <link xlink:href="https://www.suse.com/documentation/suse-openstack-cloud-9/book_crowbar-deployment/data/sec_depl_adm_inst_crowbar.html"/>).
+       <xref linkend="sec-depl-adm-inst-crowbar"/>).
        The network mode cannot be changed after the cloud is deployed.
       </para>
       <para>
        More flexible network mode setups can be configured by editing the
        Crowbar network configuration files (see
-       <link xlink:href="https://www.suse.com/documentation/suse-openstack-cloud-9/book_crowbar-deployment/data/sec_depl_inst_admserv_post_network.html"/>
+       <xref linkend="sec-depl-inst-admserv-post-network"/>
        for more information). SUSE or a partner can assist you in creating a
        custom setup within the scope of a consulting services agreement. For
        more information on &suse; consulting, visit

--- a/xml/preinstall-prepare-deployer.xml
+++ b/xml/preinstall-prepare-deployer.xml
@@ -20,11 +20,7 @@
   <para>
    Registering &cloudos; during the installation process is required for
    getting product updates and for installing the &productname;
-   extension. Refer to the <link
-   xlink:href="&suse-onlinedoc;/sles-12/book_sle_deployment/data/sec_i_yast2_conf_manual_cc.html">SUSE
-   Customer Center Registration</link> section of the &cloudos; <citetitle>Deployment
-   Guide</citetitle> for further instructions.
-  </para>
+   extension.</para>
   <para>
    After a successful registration you will be asked whether
    to add the update repositories. If you agree, the latest updates will
@@ -52,13 +48,8 @@
   </important>
   <note>
    <para>
-    For an overview of a default &sls; installation, refer to the <link
-    xlink:href="&suse-onlinedoc;/sles-12/book_quickstarts/data/art_sle_installquick.html">&sls;
-    &instquick;</link>. <link
-    xlink:href="&suse-onlinedoc;/sles-12/book_sle_deployment/data/cha_inst.html">Detailed
-    default installation information</link> is available in the &sls;
-    <citetitle>Deployment Guide</citetitle>. Both documents are available at
-    <link xlink:href="&suse-onlinedoc;/sles-12/"/>.
+    For an overview of a default &sls; installation, refer to <link
+    xlink:href="https://documentation.suse.com/sles/12-SP5/single-html/SLES-installquick/#art-sle-installquick"/>.
    </para>
   </note>
   <para>
@@ -132,9 +123,7 @@
    With <guimenu>Installation Settings</guimenu>, you need to adjust the
    software selection for your &clm; setup. For more information refer to the
    <link
-   xlink:href="&suse-onlinedoc;/sles-12/book_sle_deployment/data/sec_i_yast2_proposal.html">Installation
-   Settings</link> section of the &cloudos; <citetitle>Deployment
-   Guide</citetitle>.
+   xlink:href="https://documentation.suse.com/sles/15-SP1/single-html/SLES-deployment/#sec-yast-install-perform"/>.
   </para>
   <important>
    <title>Additional Installation Settings</title>
@@ -241,10 +230,8 @@
     Alternatively, install the &productname; after the
    &cloudos; installation via <menuchoice><guimenu>&yast;</guimenu>
    <guimenu>Software</guimenu> <guimenu>Add-On Products</guimenu></menuchoice>.
-   For details, refer to the section <link
-   xlink:href="https://www.suse.com/documentation/sles-12/book_sle_deployment/data/sec_add-ons_extensions.html">Installing
-   Modules and Extensions from Online Channels</link> of the &cloudos;
-   <citetitle>Deployment Guide</citetitle>.
+   For details, refer to <link
+   xlink:href="https://documentation.suse.com/sles/15-SP1/single-html/SLES-deployment/#sec-add-ons-extensions"/>.
    </para>
   </sect2>
  </sect1>

--- a/xml/preinstall-smt-setup.xml
+++ b/xml/preinstall-smt-setup.xml
@@ -43,7 +43,7 @@
   <screen>sudo zypper in -t pattern smt</screen>
  </sect1>
 
- <sect1 xml:id="app-deploy-smt-config">
+ <sect1 xml:id="clm-app-deploy-smt-config">
   <title>&smt; Configuration</title>
 
   <para>
@@ -176,7 +176,7 @@
      <guimenu>YaST</guimenu> <guimenu>Security and Users</guimenu>
      <guimenu>CA Management</guimenu> </menuchoice> after the &smt;
      configuration is done. See
-   <link xlink:href="&suse-onlinedoc;/sles-12/book_security/data/cha_security_yast_ca.html"/>
+   <link xlink:href="https://documentation.suse.com/sles/15-SP1/single-html/SLES-security/#cha-security-yast-security"/>
    for more information.
     </para>
     <para>
@@ -227,9 +227,9 @@ done</screen>
  </sect1>
  <sect1 xml:id="app-deploy-smt-info">
   <title>For More Information</title>
-
   <para>
-   For detailed information about &smt; refer to the &smtool; manual at <link xlink:href="&suse-onlinedoc;/sles-12/book_smt/data/book_smt.html"/>.
+   For detailed information about &smt; refer to the &smtool; manual at
+   <link xlink:href="https://documentation.suse.com/sles/12-SP5/single-html/SLES-smt/"/>.
   </para>
  </sect1>
 </chapter>

--- a/xml/security-using_apparmor.xml
+++ b/xml/security-using_apparmor.xml
@@ -44,70 +44,7 @@
    At this time, AppArmor is not enabled by default in &product;.
    However, we recommend enabling it for key virtualization processes on
    compute nodes. For more information, see the
-   <link xlink:href="https://www.suse.com/documentation/sles-12/book_security/data/part_apparmor.html">SUSE
-   Security Guide on AppArmor</link>.
+   <link xlink:href="https://documentation.suse.com/sles/15-SP1/single-html/SLES-security/#part-apparmor"/>.
   </para>
-<!--
-  <para>
-   AppArmor in &product; is installed and enabled on the KVM compute
-   nodes by default. It runs in enforce mode. It enforces mandatory access
-   control policies for the libvirt process. Customers can run 'systemctl
-   status apparmor' command on the compute nodes to check that the service is
-   active.
-  </para>
-  <para>
-   In this implementation it is designed to mitigate three threat scenarios:
-  </para>
-  <itemizedlist>
-   <listitem>
-    <para>
-     Hypervisor breakout followed by compromise of hosting qemu/kvm process.
-    </para>
-   </listitem>
-   <listitem>
-    <para>
-     Malicious manipulation of qemu APIs via nova compute.
-    </para>
-   </listitem>
-   <listitem>
-    <para>
-     Malicious manipulation of libvirt APIs via nova compute.
-    </para>
-   </listitem>
-  </itemizedlist>
-  <para>
-   The AppArmor profiles here:
-  </para>
-  <itemizedlist>
-   <listitem>
-    <para>
-     Use the sVirt mechanism to deliver a very locked down profile for KVM /
-     QEMU processes that guests run under. This enforces strict isolation of
-     the guest VMs, which is significantly more useful than just securing
-     libvirt.
-    </para>
-   </listitem>
-   <listitem>
-    <para>
-     Contains important improvements over stock Debian profiles: including
-    </para>
-    <itemizedlist>
-     <listitem>
-      <para>
-       Preventing libvirt from writing to any system config.
-      </para>
-     </listitem>
-     <listitem>
-      <para>
-       Preventing Libivirt from accessing any hardware and device nodes that
-       are not required for &productname;-based solutions. While the stock AppArmor
-       profiles are more permissive, as libvirt supports a larger set of
-       functionality than is exposed via nova compute, the profiles included
-       here only allow access to features exposed through nova.
-      </para>
-     </listitem>
-    </itemizedlist>
-   </listitem>
-</itemizedlist> -->
  </section>
 </chapter>

--- a/xml/soc-monitoring-operations-backup-recovery.xml
+++ b/xml/soc-monitoring-operations-backup-recovery.xml
@@ -133,8 +133,8 @@
     </para>
     <note>
      <para>
-         The directory for storing snapshots must be configured in the <literal>elasticsearch/repo_dir</literal>
-      setting in the monasca barclamp (see the <link xlink:href="https://www.suse.com/documentation/suse-openstack-cloud-7/singlehtml/book_cloud_deploybook_cloud_deploy.html#sec.depl.ostack.monasca/">&clouddeploy;</link>).
+      The directory for storing snapshots must be configured in the <literal>elasticsearch/repo_dir</literal>
+      setting in the monasca barclamp (see <xref linkend="sec-depl-ostack-monasca"/>).
       The directory must be manually mounted before creating the snapshot. The
       <literal>elasticsearch</literal> user must be specified as the owner of the directory.
      </para>

--- a/xml/soc-monitoring-operations-log-file-handling.xml
+++ b/xml/soc-monitoring-operations-log-file-handling.xml
@@ -31,6 +31,6 @@
  <para>
   For details on the <literal>systemd</literal> and <literal>journald</literal>
   utilities, refer to the
-  <link xlink:href="https://www.suse.com/documentation/sles-12/singlehtml/book_sle_admin/book_sle_admin.html#part.system">SUSE Linux Enterprise Server documentation</link>.
+  <link xlink:href="https://documentation.suse.com/sles/15-SP1/single-html/SLES-admin/#part-system"/>.
  </para>
 </section>

--- a/xml/soc-operations-maintenance.xml
+++ b/xml/soc-operations-maintenance.xml
@@ -38,8 +38,7 @@
     be used to place services and cluster nodes into <quote>Maintenance
     Mode</quote> before performing maintenance functions on them. For more
     information, see <link
-    xlink:href="https://www.suse.com/documentation/sle_ha/singlehtml/book_sleha/book_sleha.html#cha.ha.configuration.gui">&sle;
-    High Availability documentation</link>.
+    xlink:href="https://documentation.suse.com/sle-ha/15-SP1/single-html/SLE-HA-guide/#cha-conf-hawk2"/>.
    </para>
   </note>
   <variablelist>
@@ -331,7 +330,7 @@
      <para> The upgrade will not start when &ceph; is deployed via &crow;. Only
      external &ceph; is supported. Documentation for &ses; is available at
      <link
-      xlink:href="https://www.suse.com/documentation/suse-enterprise-storage-5"/>.
+      xlink:href="https://documentation.suse.com/ses/5.5"/>.
      </para>
     </listitem>
     <listitem>
@@ -381,7 +380,7 @@
      <para>
        If &ses; is currently deployed using &crow;, migrate it to an
        external cluster. You may want to upgrade &ses;, refer to
-       <link xlink:href="https://www.suse.com/documentation/suse-enterprise-storage-5/book_storage_deployment/data/ceph_upgrade_4to5crowbar.html"/>.
+       <link xlink:href="https://documentation.suse.com/ses/5.5/single-html/ses-deployment/#ceph-upgrade-4to5crowbar"/>.
      </para>
     </listitem>
    </itemizedlist>
@@ -584,7 +583,7 @@
   </varlistentry>
    </variablelist>
   </section>
-  
+
   <section xml:id="sec-upgrade-web-ui">
    <title>Upgrading Using the Web Interface</title>
    <para>
@@ -1550,8 +1549,7 @@
     <para>
      Put the cluster into maintenance mode. Detailed information about the
      &pacemaker; GUI and its operation is available in the <link
-     xlink:href="https://www.suse.com/documentation/sle_ha/singlehtml/book_sleha/book_sleha.html#cha.ha.configuration.gui">&sle;
-     High Availability documentation</link>.
+     xlink:href="https://documentation.suse.com/sle-ha/15-SP1/single-html/SLE-HA-guide/#cha-conf-hawk2"/>.
     </para>
    </step>
    <step>

--- a/xml/suppl_intro.xml
+++ b/xml/suppl_intro.xml
@@ -33,7 +33,7 @@
  <para>
   For an overview of the documentation available for your product and the
   latest documentation updates, refer to
-  <link xlink:href="http://www.suse.com/documentation"/>.
+  <link xlink:href="http://documentation.suse.com"/>.
  </para>
  <xi:include href="common_intro_available_doc_i.xml"/>
  <xi:include href="common_intro_feedback_i.xml"/>


### PR DESCRIPTION
The server has changed and links to suse.com/doc are no longer
active or with supported redirects. This manually fixes all
of the links and updates them appropriately for SES 9.