### PR TITLE
Update REAMDE, maintenance/cloud_9 is the default branch now (noref)

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -19,7 +19,7 @@ The following guides are available:
 
 These guides are all maintained and created in this GitHub
 repository. Released versions of these guides have been published at
-https://www.suse.com/documentation/.
+https://documentation.suse.com/soc.
 
 The following guides are built directly from upstream OpenStack sources:
 
@@ -31,7 +31,7 @@ project repositories. Released versions of the upstream OpenStack guides
 have been built using the `suse_sphinx_theme`.
 
 Released versions of these guides have also been published at
-https://www.suse.com/documentation/.
+https://documentation.suse.com/soc.
 
 Licensing
 ---------
@@ -49,15 +49,52 @@ and Apache 2.0: https://www.apache.org/licenses/LICENSE-2.0
 Branches
 --------
 
-***On Jun 21, 2019, we changed to a new branching model. This entailed having to force push the
-master branch. ***
+[IMPORTANT]
+====
+Do not add further changes to the `master` branch!
+It is only used as an archive now.
 
-* *Use the master branch* as the basis of your commits of new feature branches.
+In the final months of 2019 and in early Jan 2020, we maintained two branches in the `doc-cloud` repo:
 
-* The *develop branch has been deleted* on the server. Do not push to the `develop` branch.
-  Your changes may go lost in the medium term and never make it to the proper branch.
+* `master`
+* `maintenance/cloud_9` (`cloud_9` for short)
 
-* If you *created* a local clone or GitHub fork of this repo *before June 21, 2019, do the following*:
+The original plan was to use `master` for SOC 10 documentation.
+Since SOC 10 was cancelled, we were in a less than perfect situation:
+The `cloud_9` was several commits ahead of `master` and in turn, the `master` branch had some SOC 9 content that had not been backported to `cloud_9`.
+
+To solve the problem and to simplify the overall arrangement, we have merged the outstanding commits from `master` into `cloud_9`.
+We also made `cloud_9` the default branch.
+For all SOC 9-related documentation updates, please use `maintenance/cloud_9`.
+We do not foresee further active use of the `master` branch.
+It will be kept purely as an archive.
+====
+
+* *Use the maintenance/cloud_9 branch* as the basis of your commits for new feature branches.
+
+* The *master branch* serves as an archive only.
+  If you add changes to the `master` branch, they may never be published.
+
+* The *develop branch has been deleted* on the server.
+  Do not push a new `develop` branch.
+
+.Overview of important branches
+[options="header"]
+|============================================================
+| Name                             | Purpose
+| `maintenance/cloud_9`            | Maintenance branch for SOC 9 (default)
+| `master`                         | Archive branch
+| `maintenance/cloud_1.0`          | Maintenance branch for SC 1.0
+| `maintenance/cloud_2.0`          | Maintenance branch for SC 2.0
+| `maintenance/cloud_3.0`          | Maintenance branch for SC 3.0
+| `maintenance/cloud_4`            | Maintenance branch for SC 4
+| `maintenance/cloud_5`            | Maintenance branch for SC 5
+| `maintenance/openstack_cloud_6`  | Maintenance branch for SOC 6
+| `maintenance/cloud_7`            | Maintenance branch for SOC 7
+| `maintenance/cloud_8`            | Maintenance branch for SOC 8
+|============================================================
+
+* If you created a local clone or GitHub fork of this repo before June 21, 2019, do the following:
 +
 [arabic]
 . Make sure that your `master` and `develop` branches do not contain any important changes.
@@ -69,23 +106,6 @@ master branch. ***
 . Go to the master branch: `git checkout master`
 . Hard-reset the state of the master branch to the state on GitHub: `git reset --hard origin/master`
 . Delete your local develop branch: `git branch -D develop`
-
-
-.Overview of important branches
-[options="header"]
-|============================================================
-| Name                             | Purpose
-| `master`                         | Current working branch
-| `maintenance/cloud_1.0`          | Maintenance branch for SC 1.0
-| `maintenance/cloud_2.0`          | Maintenance branch for SC 2.0
-| `maintenance/cloud_3.0`          | Maintenance branch for SC 3.0
-| `maintenance/cloud_4`            | Maintenance branch for SC 4
-| `maintenance/cloud_5`            | Maintenance branch for SC 5
-| `maintenance/openstack_cloud_6`  | Maintenance branch for SOC 6
-| `maintenance/cloud_7`            | Maintenance branch for SOC 7
-| `maintenance/cloud_8`            | Maintenance branch for SOC 8
-| `maintenance/cloud_9`            | Maintenance branch for SOC 9
-|============================================================
 
 
 Contributing


### PR DESCRIPTION
Cause it's the truth as well. (cf. #1245)