### PR TITLE
WIP: Fixing links from suse.com/doc to new URL (noref)

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -10,7 +10,7 @@ Three books are currently available:
 * End User Guide
 
 Released versions of these guides have been published at
-https://www.suse.com/documentation/.
+https://documentation.suse.com/.
 
 
 Branches

--- a/xml/admin-keystone.xml
+++ b/xml/admin-keystone.xml
@@ -1423,7 +1423,7 @@ domain_name_url_safe = off</screen>
             <filename>/etc/keystone/domains/keystone.DOMAIN_NAME.conf</filename>
             override entries made with the Keystone Barclamp (see the SUSE
             documentation for <link
-            xlink:href="https://www.suse.com/documentation/suse-openstack-cloud-8/singlehtml/book_deployment/book_deployment.html#sec.depl.ostack.keystone">Deploying
+            xlink:href="https://documentation.suse.com/soc/8/html/suse-openstack-cloud-crowbar-all/cha-depl-ostack.html#sec-depl-ostack-keystone">Deploying
             Keystone</link>). Incorrect manual entries may cause errors. Some
             LDAP integration entries are defaulted in the Keystone Barclamp, so
             manual entries may not be necessary.

--- a/xml/admin-nova.xml
+++ b/xml/admin-nova.xml
@@ -1122,7 +1122,7 @@ hugetlbfs on /dev/hugepages type hugetlbfs (rw)</screen>
         <para>The next steps show how a regular Linux system might be configured as an NFS v4
                     server for live migration. For detailed information and alternative ways to
                     configure NFS on Linux, see instructions for <link xmlns:xl="http://www.w3.org/1999/xlink" xl:href="https://help.ubuntu.com/community/SettingUpNFSHowTo">Ubuntu</link>, <link xmlns:xl="http://www.w3.org/1999/xlink" xl:href="https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/Storage_Administration_Guide/nfs-serverconfig.html">RHEL and derivatives</link>
-                    or <link xmlns:xl="http://www.w3.org/1999/xlink" xl:href="https://www.suse.com/documentation/sles-12/book_sle_admin/data/sec_nfs_configuring-nfs-server.html">SLES and OpenSUSE</link>.</para>
+                    or <link xmlns:xl="http://www.w3.org/1999/xlink" xl:href="https://documentation.suse.com/sles/12-SP5/single-html/SLES-admin/#sec-nfs-configuring-nfs-server">SLES and OpenSUSE</link>.</para>
         <procedure>
           <step>
             <para>Ensure that UID and GID of the nova user are identical on the compute hosts

--- a/xml/bk_openstack_admin.xml
+++ b/xml/bk_openstack_admin.xml
@@ -3812,7 +3812,7 @@ for your operating system.</para>
       <title>Customize and configure the Dashboard</title>
         <para>
          For information on this topic, see the SUSE OpenStack Supplement Guide,
-         available from <link xlink:href="https://www.suse.com/documentation/cloud/"/>.
+         available at <link xlink:href="https://documentation.suse.com/soc/8/single-html/suse-openstack-cloud-supplement"/>.
        </para>
     </sect1>
 <!-- <remark>taroth 2017-02-01: commenting section as it is partly Ubuntu-specific</remark>-->
@@ -4858,7 +4858,7 @@ that month.</para>
         </procedure>
       </sect2>
     </sect1>
-    <sect1>
+    <sect1 xml:id="osadm-manage-flavor">
       <title>Manage flavors</title>
       <para>In OpenStack, a flavor defines the compute, memory, and storage
 capacity of a virtual server, also known as an instance. As an
@@ -35946,7 +35946,7 @@ use the latter.</para>
       </sect2>
     </sect1>
   </chapter>
-  <chapter>
+  <chapter xml:id="osadm-os-cli">
     <title>OpenStack command-line clients</title>
     <info/>
     <sect1>
@@ -36990,7 +36990,7 @@ Listing assignments using role list is deprecated as of the Newton release. Use 
         </sect3>
       </sect2>
     </sect1>
-    <sect1>
+    <sect1 xml:id="osadm-security-group">
       <title>Manage project security</title>
       <para>Security groups are sets of IP filter rules that are applied to all
 project instances, which define networking access to the instance. Group
@@ -38350,7 +38350,7 @@ destination host and pool.</para>
         </note>
       </sect2>
     </sect1>
-    <sect1>
+    <sect1 xml:id="osadm-manage-flavors-cmd">
       <title>Manage flavors</title>
       <para>In OpenStack, flavors define the compute, memory, and
 storage capacity of nova computing instances. To put it

--- a/xml/book_cloud_suppl.xml
+++ b/xml/book_cloud_suppl.xml
@@ -187,7 +187,7 @@
     <para>
      For a list of supported VM guests, refer to the &slsreg; &virtual;,
      section <citetitle>Supported VM Guests</citetitle>. It is available at
-     <link xlink:href="https://www.suse.com/documentation/sles-12/book_virt/data/virt_support_guests.html"/>.
+     <link xlink:href="https://documentation.suse.com/sles/12-SP5/single-html/SLES-virtualization/#virt-support-guests"/>.
     </para>
     <para>
      Depending on the virtualization platform on which you want to use the
@@ -359,12 +359,6 @@
      </para>
     </step>
    </procedure>
-
-   <para>
-    For more detailed information on how to build appliance images, refer to
-    the &suseonsite; documentation, available at
-    <link xlink:href="http://www.suse.com/documentation/suse_studio/"/>.
-   </para>
   </sect1>
   <sect1 xml:id="sec-adm-cli-img-props">
    <title>Image Properties</title>
@@ -511,7 +505,7 @@
         </para>
        </note>
 <!--taroth 2013-10-17: Xen:
-        http://docserv.nue.suse.com/documents/SLES/SLES-xen/single-html/#sec.xen.config.disk-->
+        http://docserv.nue.suse.com\/documents/SLES/SLES-xen/single-html/#sec.xen.config.disk-->
       </listitem>
       <listitem>
        <para>
@@ -924,11 +918,8 @@
        <quote>size</quote> of a virtual server that can be launched.
       </para>
       <para>
-       For more details and a list of default flavors available, refer to the
-       &cloudadmin;, chapter <citetitle>Dashboard</citetitle> or
-       chapter <citetitle>OpenStack command-line clients</citetitle>, section
-       <citetitle>Manage Flavors</citetitle>. The guide is available from
-       &suse-onlinedoc;.
+       For more details and a list of default flavors available, see
+       <xref linkend="osadm-manage-flavors-cmd"/> and <xref linkend="osadm-manage-flavor"/>.
       </para>
      </listitem>
     </varlistentry>
@@ -947,10 +938,7 @@
        belonging to that project.
       </para>
       <para>
-       For details, refer to the &clouduser;, chapter <citetitle>OpenStack
-       dashboard</citetitle> or chapter <citetitle>OpenStack command-line
-       clients</citetitle>, section <citetitle>Configure access and security
-       for instances</citetitle>. The guide is available from &suse-onlinedoc;.
+       For details, see <xref linkend="osadm-security-group"/>.
       </para>
      </listitem>
     </varlistentry>
@@ -963,10 +951,7 @@
        set of firewall policies (security group rules).
       </para>
       <para>
-       For details, refer to the &clouduser;, chapter <citetitle>OpenStack
-       dashboard</citetitle> or chapter <citetitle>OpenStack command-line
-       clients</citetitle>, section <citetitle>Configure access and security
-       for instances</citetitle>. The guide is available from &suse-onlinedoc;.
+       For details, see <xref linkend="osadm-security-group"/>.
       </para>
      </listitem>
     </varlistentry>
@@ -983,11 +968,8 @@
      <term>Boot Source of the Instance</term>
      <listitem>
       <para>
-       You can launch instances from the following sources. For details, see the
-       &clouduser;, chapter <citetitle>OpenStack dashboard</citetitle> or
-       chapter <citetitle>OpenStack command-line clients</citetitle>, section
-       <citetitle>Launch and manage instances</citetitle>.
-       The guide is available from &suse-onlinedoc;. 
+       You can launch instances from the following sources. For details, see
+       <xref linkend="osadm-os-cli"/>.
       </para>
       <itemizedlist>
        <listitem>

--- a/xml/common_intro_available_doc_i.xml
+++ b/xml/common_intro_available_doc_i.xml
@@ -22,7 +22,7 @@
  <title>Online Documentation and Latest Updates</title>
  <para>
   Documentation for our products is available at
-  <link xlink:href="http://www.suse.com/documentation/"/>, where you can also
+  <link xlink:href="http://documentation.suse.com"/>, where you can also
   find the latest updates, and browse or download the documentation in various formats.
  <!--and languages.The latest documentation updates usually can be found in
  the English language version.-->

--- a/xml/common_intro_feedback_i.xml
+++ b/xml/common_intro_feedback_i.xml
@@ -67,7 +67,7 @@
      the other documentation included with this product. If you are reading the
      HTML version of this guide, use the Comments feature at the bottom of each page
      in the online documentation
-     at <link xlink:href="http://www.suse.com/documentation/"/>.
+     at <link xlink:href="http://documentation.suse.com"/>.
     </para>
     <para>If you are reading the single-page HTML version of this guide, you can
      use the <guimenu>Report Bug</guimenu> link next to each section to open

--- a/xml/create-vapp_template-vcenter.xml
+++ b/xml/create-vapp_template-vcenter.xml
@@ -319,9 +319,8 @@ STARTMODE='auto'</screen>
       Allow the <literal>ardana</literal> user to <literal>sudo</literal>
       without password. Setting up <literal>sudo</literal> on &slsa; is covered
       in the &suse; documentation at <link
-      xlink:href="https://www.suse.com/documentation/sles-12/book_sle_admin/data/sec_sudo_conf.html">
-      Configuring sudo</link>. We
-      recommend creating user specific sudo config files in the
+      xlink:href="https://documentation.suse.com/sles/12-SP5/single-html/SLES-admin/#sec-sudo-conf"/>.
+      We recommend creating user specific sudo config files in the
       <filename>/etc/sudoers.d</filename> directory. Create an
       <filename>/etc/sudoers.d/ardana</filename> config file with the following
       content to allow sudo commands without the requirement of a password.

--- a/xml/crowbar_install_caasp_heat_templates.xml
+++ b/xml/crowbar_install_caasp_heat_templates.xml
@@ -115,7 +115,7 @@ git clone https://github.com/SUSE/caasp-openstack-heat-templates
   <para>
    When you have successfully accessed the admin node web interface via the
    floating IP, follow the instructions at <link
-   xlink:href="https://www.suse.com/documentation/suse-caasp-3/book_caasp_deployment/data/book_caasp_deployment.html"/> to
+   xlink:href="https://documentation.suse.com/suse-caasp/3/single-html/caasp-deployment/"/> to
    continue the setup of &caasp;.
   </para>
  </section>
@@ -542,8 +542,8 @@ i | sles12-velum-image | package    | 3.1.7-3.27.3  | x86_64 | update_caasp</scr
  <section>
   <title>More Information about &caasp;</title>
    <para>
-  More information about the &caasp; is available at <link
-  xlink:href="https://www.suse.com/documentation/suse-caasp-3/book_caasp_deployment/data/book_caasp_deployment.html"/>
+  More information about &caasp; is available at <link
+  xlink:href="https://documentation.suse.com/suse-caasp/3/single-html/caasp-deployment/"/>
  </para>
  </section>
 </chapter>

--- a/xml/depl_conf_admin_repos.xml
+++ b/xml/depl_conf_admin_repos.xml
@@ -320,8 +320,7 @@ mount -o loop <replaceable>/local/SUSE-OPENSTACK-CLOUD-&productnumber;-x86_64-DV
      repositories for this product available, including the repositories
      for all registered add-on products (like &productname;, &slsa; &hasi; and
      &storage;). Instructions for creating a distribution are in the &susemgr; documentation in <link
-     xlink:href="&suse-onlinedoc;/suse_manager/"/>. <!-- Check if SuMa 3
-     documentation contains a section to which we can link -->
+     xlink:href="https://documentation.suse.com/suma/"/>.
     </para>
     <para>
      During the distribution setups you need to provide a

--- a/xml/depl_inst_admin.xml
+++ b/xml/depl_inst_admin.xml
@@ -30,15 +30,9 @@
   <title>Starting the Operating System Installation</title>
   <para>
    Start the installation by booting into the &cloudos; installation system.
-   For an overview of a default &sls; installation, refer to the <link
-   xlink:href="&suse-onlinedoc;/sles-12/book_quickstarts/data/art_sle_installquick.html">&sls;
-   &instquick;</link>. <link
-   xlink:href="&suse-onlinedoc;/sles-12/book_sle_deployment/data/cha_inst.html">Detailed
-   installation instructions</link> are available in the &sls;
-   <citetitle>Deployment Guide</citetitle>. Both documents are available at
-   <link xlink:href="&suse-onlinedoc;/sles-12/"/>.
+   For detailed installation instructions for &sls;, refer to <link
+   xlink:href="https://documentation.suse.com/sles/12-SP5/single-html/SLES-deployment/#cha-install"/>.
   </para>
-
   <para>
    The following sections will only cover the differences from the default
    installation process.
@@ -50,10 +44,7 @@
   <para>
    Registering &cloudos; during the installation process is required for
    getting product updates and for installing the &productname;
-   extension. Refer to the <link
-   xlink:href="&suse-onlinedoc;/sles-12/book_sle_deployment/data/sec_i_yast2_conf_manual_cc.html">SUSE
-   Customer Center Registration</link> section of the &cloudos; <citetitle>Deployment
-   Guide</citetitle> for further instructions.
+   extension. Refer to <link xlink:href="https://documentation.suse.com/sles/12-SP5/single-html/SLES-deployment/#sec-i-yast2-conf-manual-cc"/>
   </para>
   <para>
    After a successful registration you will be asked whether
@@ -91,9 +82,7 @@
    &cloudos; installation via <menuchoice><guimenu>&yast;</guimenu>
    <guimenu>Software</guimenu> <guimenu>Add-On Products</guimenu></menuchoice>.
    For details, refer to the section <link
-   xlink:href="https://www.suse.com/documentation/sles-12/book_sle_deployment/data/sec_add-ons_extensions.html">Installing
-   Modules and Extensions from Online Channels</link> of the &cloudos;
-   <citetitle>Deployment Guide</citetitle>.
+   xlink:href="https://documentation.suse.com/sles/12-SP5/single-html/SLES-deployment/#sec-add-ons-extensions"/>.
   </para>
 
 <!-- fs 2015-12-17:
@@ -109,7 +98,7 @@
    the network as described in <xref linkend="sec-depl-adm-inst-network"/>.
    Add &cloud; and proceed with the installation. Consult the &sls;
    <citetitle>Deployment Guide</citetitle> at
-   <link xlink:href="http://www.suse.com/documentation/sles11/book_sle_deployment/data/sec_i_yast2_inst_mode.html"/>
+   <link xlink:href="http://www.suse.com\/documentation/sles11/book_sle_deployment/data/sec_i_yast2_inst_mode.html"/>
    for detailed instructions.
    </para>
 -->
@@ -131,9 +120,7 @@
   </para>
   <para>
    Help on using the partitioning tool is available at the section <link
-   xlink:href="&suse-onlinedoc;/sles11/book_sle_deployment/data/sec_yast2_i_y2_part_expert.html">Using
-   the YaST Partitioner</link> of the &cloudos; <citetitle>Deployment
-   Guide</citetitle>.
+   xlink:href="https://documentation.suse.com/sles/12-SP5/single-html/SLES-deployment/#sec-yast2-i-y2-part-expert"/>.
   </para>
  </sect1>
 
@@ -143,9 +130,7 @@
    In the final installation step, <guimenu>Installation Settings</guimenu>, you need to adjust
    the software selection and the firewall settings for your &admserv; setup. For more information
    refer to the <link
-   xlink:href="&suse-onlinedoc;/sles-12/book_sle_deployment/data/sec_i_yast2_proposal.html">Installation
-   Settings</link> section of the &cloudos; <citetitle>Deployment
-   Guide</citetitle>.
+   xlink:href="https://documentation.suse.com/sles/12-SP5/single-html/SLES-deployment/#sec-i-yast2-proposal"/>.
   </para>
 
   <sect2 xml:id="sec-depl-adm-inst-settings-software">

--- a/xml/depl_inst_nodes.xml
+++ b/xml/depl_inst_nodes.xml
@@ -67,8 +67,7 @@
       If this configuration does not match your needs (for example if you
       need special third party drivers) you need to make adjustments to this
       file. See the <link
-        xlink:href="http://www.suse.com/documentation/sles-12/book_autoyast/data/book_autoyast.html">&ay;
-      manual</link> for details.
+        xlink:href="https://documentation.suse.com/sles/12-SP5/single-html/SLES-autoyast/"/> for details.
       If you change the &ay; configuration file, you need to re-upload
       it to &chef; using the following command:
      </para>
@@ -614,7 +613,7 @@
      cluster resource manager on a node is active during the software update,
      this can lead to unpredictable results like fencing of active nodes. For
      detailed instructions refer to <link
-     xlink:href="&suse-onlinedoc;/sle-ha-12/book_sleha/data/sec_ha_migration_update.html"/>.
+     xlink:href="https://documentation.suse.com/sle-ha/12-SP5/single-html/SLE-HA-guide/#sec-ha-migration-update"/>.
     </para>
    </warning>
 
@@ -722,7 +721,7 @@
      cluster resource manager on a node is active during the software update,
      this can lead to unpredictable results like fencing of active nodes. For
      detailed instructions refer to <link
-     xlink:href="&suse-onlinedoc;/sle-ha-12/book_sleha/data/sec_ha_migration_update.html"/>.
+     xlink:href="https://documentation.suse.com/sle-ha/12-SP5/single-html/SLE-HA-guide/#sec-ha-migration-update"/>.
     </para>
    </warning>
 

--- a/xml/depl_intro.xml
+++ b/xml/depl_intro.xml
@@ -80,7 +80,7 @@ Storage, attached to &vmguest;s, or object storage is managed by the
  <para>
   For an overview of the documentation available for your product and the
   latest documentation updates, refer to
-  <link xlink:href="http://www.suse.com/documentation"/>.
+  <link xlink:href="https://documentation.suse.com"/>.
  </para>
  <xi:include href="common_intro_available_doc_i.xml"/>
  <xi:include href="common_intro_feedback_i.xml"/>

--- a/xml/depl_maintenance.xml
+++ b/xml/depl_maintenance.xml
@@ -48,8 +48,7 @@
     be used to place services and cluster nodes into <quote>Maintenance
     Mode</quote> before performing maintenance functions on them. For more
     information, see <link
-    xlink:href="https://www.suse.com/documentation/sle_ha/singlehtml/book_sleha/book_sleha.html#cha.ha.configuration.gui">&sle;
-    High Availability documentation</link>.
+    xlink:href="https://documentation.suse.com/sle-ha/12-SP5/single-html/SLE-HA-guide/#cha-conf-hawk2"/>.
    </para>
   </note>
 
@@ -361,7 +360,7 @@
      <para> The upgrade will not start when &ceph; is deployed via &crow;. Only
      external &ceph; is supported. Documentation for &ses; is available at
      <link
-     xlink:href="https://www.suse.com/documentation/suse-enterprise-storage-5/"/>.
+      xlink:href="https://documentation.suse.com/ses/5.5"/>.
      </para>
     </listitem>
     <listitem>
@@ -408,9 +407,9 @@
     </listitem>
     <listitem>
      <para>
-       If &ses; is now deployed using &crow;, it should be migrated to an
-       external cluster. You may want to upgrade &ses;, please refer to <link xlink:href="https://www.suse.com/documentation/suse-enterprise-storage-5/book_storage_deployment/data/ceph_upgrade_4to5crowbar.html">&ses;
-       Upgrade Instructions</link>.
+       If &ses; is deployed using &crow;, migrate it to an
+       external cluster. You may want to upgrade &ses;, refer to
+       <link xlink:href="https://documentation.suse.com/ses/5.5/single-html/ses-deployment/#ceph-upgrade-4to5crowbar"/>.
      </para>
     </listitem>
     <listitem>
@@ -2048,8 +2047,7 @@ migrate</screen>
     <para>
      Put the cluster into maintenance mode. Detailed information about the
      &pacemaker; GUI and its operation is available in the <link
-     xlink:href="https://www.suse.com/documentation/sle_ha/singlehtml/book_sleha/book_sleha.html#cha.ha.configuration.gui">&sle;
-     High Availability documentation</link>.
+     xlink:href="https://documentation.suse.com/sle-ha/12-SP5/single-html/SLE-HA-guide/#cha-conf-hawk2"/>.
     </para>
    </step>
    <step>

--- a/xml/depl_nodes.xml
+++ b/xml/depl_nodes.xml
@@ -834,8 +834,8 @@ MariaDB [powerdns]> select * from domains;
      <para>
       This configuration option defines what to do with the cluster
       partition(s) that do not have the quorum. See
-      <link xlink:href="&suse-onlinedoc;/sle-ha-12/book_sleha/data/sec_ha_config_basics_global.html"/>,
-      section <citetitle>Option no-quorum-policy</citetitle> for details.
+      <link xlink:href="https://documentation.suse.com/sle-ha/12-SP5/single-html/SLE-HA-guide/#sec-ha-config-basics-global-quorum"/>,
+      for details.
      </para>
      <para>
       The recommended setting is to choose <guimenu>Stop</guimenu>. However,
@@ -856,7 +856,7 @@ MariaDB [powerdns]> select * from domains;
       them from causing trouble. This mechanism is called &stonith;
       (<quote>Shoot the other node in the head</quote>). &stonith; can be
       configured in a variety of ways, refer to
-      <link xlink:href="&suse-onlinedoc;/sle-ha-12/book_sleha/data/cha_ha_fencing.html"/>
+      <link xlink:href="https://documentation.suse.com/sle-ha/12-SP5/single-html/SLE-HA-guide/#cha-ha-fencing"/>
       for details. The following configuration options exist:
      </para>
      <variablelist>
@@ -867,7 +867,7 @@ MariaDB [powerdns]> select * from domains;
         <para>
          &stonith; will not be configured when deploying the &barcl;. It needs
          to be configured manually as described in
-         <link xlink:href="&suse-onlinedoc;/sle-ha-12/book_sleha/data/cha_ha_fencing.html"/>.
+         <link xlink:href="https://documentation.suse.com/sle-ha/12-SP5/single-html/SLE-HA-guide/#cha-ha-fencing"/>.
          For experts only.
         </para>
        </listitem>
@@ -931,7 +931,7 @@ MariaDB [powerdns]> select * from domains;
 <screen>sbd -d /dev/<replaceable>SBD</replaceable> create</screen>
           <para>
            Refer to
-           <link xlink:href="&suse-onlinedoc;/sle-ha-12/book_sleha/data/sec_ha_storage_protect_fencing.html#pro_ha_storage_protect_sbd_create"/>
+           <link xlink:href="https://documentation.suse.com/sle-ha/12-SP5/single-html/SLE-HA-guide/#pro-ha-storage-protect-sbd-create"/>
            for details.
           </para>
          </listitem>
@@ -1272,7 +1272,7 @@ MariaDB [powerdns]> select * from domains;
     an HA-managed service, nor configure it to start on boot. Services may only
     be started or stopped by using the cluster management tools Hawk or the crm
     shell. See
-    <link xlink:href="&suse-onlinedoc;/sle-ha-12/book_sleha/data/sec_ha_config_basics_resources.html"/>
+    <link xlink:href="https://documentation.suse.com/sle-ha/12-SP5/single-html/SLE-HA-guide/#sec-ha-config-basics-resources"/>
     for more information.
    </para>
   </important>
@@ -5297,7 +5297,7 @@ neutron router-interface-add <replaceable>router2</replaceable> priv-net-sub</sc
   <para>
    For information on how to deploy a Kubernetes cluster (either from command
    line or from the &o_dash; &dash;), see the &cloudsuppl;. It is available
-   from <link xlink:href="https://www.suse.com/documentation/cloud"></link>.
+   from <link xlink:href="https://documentation.suse.com/soc/8/"></link>.
   </para>
 
   <para>
@@ -5312,7 +5312,7 @@ neutron router-interface-add <replaceable>router2</replaceable> priv-net-sub</sc
     <listitem>
      <para>
       Deploying Kubernetes clusters in a cloud without an Internet connection
-      (as described in <link xlink:href="https://www.suse.com/documentation/suse-openstack-cloud-7/singlehtml/book_cloud_suppl/book_cloud_suppl.html#sec.deploy.kubernetes.without">Deploying a Kubernetes Cluster Without Internet Access</link>))
+      (see also <link xlink:href="https://documentation.suse.com/soc/8/single-html/suse-openstack-cloud-supplement/#sec-deploy-kubernetes-without"/>)
       requires the <literal>registry_enabled</literal> option in its cluster
       template set to <literal>true</literal>. To make this offline scenario
       work, you also need to set the <guimenu>Delegate trust to cluster users if
@@ -5884,11 +5884,8 @@ neutron router-interface-add <replaceable>router2</replaceable> priv-net-sub</sc
       to work.
      </para>
      <para>
-      For instructions on creating an elasticsearch snapshot, see the
-      &productname; Monitoring <citetitle>&socmmsop;</citetitle>, chapter
-      <citetitle>Operation and Maintenance</citetitle>, section
-      <citetitle>Database</citetitle>. It is available from
-      <link xlink:href="https://www.suse.com/documentation/"></link>.
+      For instructions on creating an elasticsearch snapshot, see
+      <link xlink:href="https://documentation.suse.com/soc/8/html/suse-openstack-cloud-socmmsoperator/idg-msoperator-shared-operationmaintenance-c-operate-xml-1.html"/>.
      </para>
     </listitem>
    </varlistentry>
@@ -7002,9 +6999,7 @@ Apply the &barcl; to a Control Node.
    &o_img; component. Refer to the &cloudsuppl;, chapter <citetitle>Manage
    images</citetitle>
 <!--<xref linkend="sec-adm-cli-img"/>-->
-   for instructions. Images for &cloud; can be built in SUSE Studio. Refer to
-   the &cloudsuppl;, section <citetitle>Building Images with
-   &susestudio;</citetitle>.
+   for instructions.
   </para>
 
   <para>

--- a/xml/depl_poc.xml
+++ b/xml/depl_poc.xml
@@ -286,7 +286,7 @@ installed, configured, and optimized before installing &cloud;. Storage services
 	  according to the specific requirements. This step must be discussed
 	  and completed in advance. <!-- (see <xref
       linkend="sec-depl-poc-networkjson"/> and <link
-      xlink:href="https://www.suse.com/documentation/suse-openstack-cloud-6/book_cloud_deploy/data/book_cloud_deploy.html"/>) -->
+      xlink:href="https://www.suse.com\/documentation/suse-openstack-cloud-6/book_cloud_deploy/data/book_cloud_deploy.html"/>) -->
         </para>
       </step>
     </procedure>
@@ -457,7 +457,7 @@ The sizing recommendation includes an Admin Node (bare metal or VM), Controller 
     </listitem>
     <listitem>
       <para>
-        Address pool management. While the addresses can be managed with the YaST Crowbar module, complex network setups require to manually edit the network barclamp template file <systemitem>/etc/crowbar/network.json</systemitem>. For more detailed explanation and description see <link xlink:href="https://www.suse.com/documentation/suse-openstack-cloud-6/pdfdoc/book_cloud_deploy/book_cloud_deploy.pdf#page=240&amp;zoom=auto,63.779,788.031" />
+        Address pool management. While the addresses can be managed with the YaST Crowbar module, complex network setups require to manually edit the network barclamp template file <systemitem>/etc/crowbar/network.json</systemitem>. For more detailed explanation and description see <link xlink:href="https://documentation.suse.com/soc/8/single-html/suse-openstack-cloud-deployment/#sec-deploy-network-json-edit" />.
       </para>
     </listitem>
   </itemizedlist>
@@ -795,11 +795,11 @@ externally. All &cloud; users and administrators need to be able to access the p
         </para>
 
         <para>
-          &cloud; supports different network modes: single, dual, and team. Starting with &cloud; 6, the networking mode is applied to all nodes and the Administration Server. This means that all machines need to meet the hardware requirements for the chosen mode. The network mode can be configured using the YaST Crowbar module (see <link xlink:href="https://www.suse.com/documentation/suse-openstack-cloud-6/book_cloud_deploy/data/sec_depl_adm_inst_crowbar.html"/>). The network mode cannot be changed after the cloud is deployed.
+          &cloud; supports different network modes: single, dual, and team. Starting with &cloud; 6, the networking mode is applied to all nodes and the Administration Server. This means that all machines need to meet the hardware requirements for the chosen mode. The network mode can be configured using the YaST Crowbar module (see <link xlink:href="https://documentation.suse.com/soc/8/single-html/suse-openstack-cloud-deployment/#sec-depl-adm-inst-crowbar"/>). The network mode cannot be changed after the cloud is deployed.
         </para>
         <para>
           More flexible network mode setups can be configured by editing the Crowbar
-          network configuration files (see <link xlink:href="https://www.suse.com/documentation/suse-openstack-cloud-6/book_cloud_deploy/data/app_deploy_network_json.html"/> for more information). SUSE or a partner can assist you in creating a custom setup within the scope of a consulting services agreement.
+          network configuration files (see <link xlink:href="https://documentation.suse.com/soc/8/single-html/suse-openstack-cloud-deployment/#sec-deploy-network-json-edit"/> for more information). SUSE or a partner can assist you in creating a custom setup within the scope of a consulting services agreement.
           For more information on &suse; consulting, visit <link xlink:href="http://www.suse.com/consulting/"/>.
         </para>
       </listitem>

--- a/xml/depl_require.xml
+++ b/xml/depl_require.xml
@@ -1152,7 +1152,7 @@
     component requires at least two machines (more are recommended) to store
     data redundantly. For information on hardware requirements for &ceph;, see
     <link
-    xlink:href="https://www.suse.com/documentation/ses-4/book_storage_admin/data/cha_ceph_sysreq.html"/>
+    xlink:href="https://documentation.suse.com/ses/5.5/single-html/ses-deployment/#storage-bp-hwreq"/>
     </para>
     <para>
      Each &ceph;/&swift; &stornode; needs at least two hard disks.
@@ -1254,7 +1254,7 @@
 
   <para>
    Certificates must be signed by a trusted authority. Refer to
-   <link xlink:href="&suse-onlinedoc;/sles-12/book_sle_admin/data/sec_apache2_ssl.html"/>
+   <link xlink:href="https://documentation.suse.com/sles/12-SP5/single-html/SLES-admin/#sec-apache2-ssl"/>
    for instructions on how to create and sign them.
   </para>
 
@@ -1975,7 +1975,7 @@
      &contrnode;. For details on the
      Pacemaker cluster stack and the &sle; &hasi;, refer to the
      &haguide;, available at
-     <link xlink:href="&suse-onlinedoc;/sle-ha-12/"/>.
+     <link xlink:href="https://documentation.suse.com/sle-ha/12-SP5/"/>.
      Note that &sle; &hasi; includes &lvs; as the load-balancer, and
      &productname; uses &haproxy; for this purpose
      (<link xlink:href="http://haproxy.1wt.eu/"/>).
@@ -2136,7 +2136,7 @@
      &ceph; is a distributed storage solution that can provide &ha;.  For &ha;
      redundant storage and monitors need to be configured in the &ceph;
      cluster. For more information refer to the &storage; documentation at
-     <link xlink:href="&suse-onlinedoc;/suse-enterprise-storage-5/index.html"/>.
+     <link xlink:href="https://documentation.suse.com/ses/5.5/"/>.
     </para>
    </sect3>
   </sect2>
@@ -2147,7 +2147,7 @@
     When considering setting up one or more &ha; clusters, refer to the
     chapter <citetitle>System Requirements</citetitle> in the
     &haguide; for &sle; &hasi;. The guide is available at
-    <link xlink:href="&suse-onlinedoc;/sle-ha-12/"/>.
+    <link xlink:href="https://documentation.suse.com/sle-ha/12-SP5/"/>.
    </para>
    <para>
     The HA requirements for &contrnode; also apply to &productname;. Note that by
@@ -2230,7 +2230,7 @@
       </itemizedlist>
       <para>
        For more information, refer to the &haguide;, available at
-       <link xlink:href="&suse-onlinedoc;/sle-ha-12/"/>.
+       <link xlink:href="https://documentation.suse.com/sle-ha/12-SP5/"/>.
        Especially read the following chapters: <citetitle>Configuration and
        Administration Basics</citetitle>, and <citetitle>Fencing and
        &stonith;</citetitle>, <citetitle> Storage Protection</citetitle>.
@@ -2254,7 +2254,7 @@
       </important>
       <para>
        For more information, refer to the &haguide;, available at
-       <link xlink:href="&suse-onlinedoc;/sle-ha-12/"/>.
+       <link xlink:href="https://documentation.suse.com/sle-ha/12-SP5/"/>.
        Especially read the following chapter: <citetitle>Network Device
        Bonding</citetitle>.
       </para>
@@ -2316,7 +2316,7 @@
     For a basic understanding and detailed information on the &sle;
     &hasi; (including the Pacemaker cluster stack), read the
     &haguide;. It is available at
-    <link xlink:href="&suse-onlinedoc;/sle-ha-12/"/>.
+    <link xlink:href="https://documentation.suse.com/sle-ha/12-SP5/"/>.
    </para>
    <para>
     In addition to the chapters mentioned in

--- a/xml/depl_smt_setup.xml
+++ b/xml/depl_smt_setup.xml
@@ -179,7 +179,7 @@
      <guimenu>YaST</guimenu> <guimenu>Security and Users</guimenu>
      <guimenu>CA Management</guimenu> </menuchoice> after the &smt;
      configuration is done. See
-   <link xlink:href="&suse-onlinedoc;/sles-12/book_security/data/cha_security_yast_ca.html"/>
+   <link xlink:href="https://documentation.suse.com/sles/12-SP5/single-html/SLES-security/#cha-security-yast-ca"/>
    for more information.
     </para>
     <para>
@@ -269,7 +269,7 @@ done</screen>
   <title>For More Information</title>
 
   <para>
-   For detailed information about &smt; refer to the &smtool; manual at <link xlink:href="&suse-onlinedoc;/sles-12/book_smt/data/book_smt.html"/>.
+   For detailed information about &smt; refer to the &smtool; manual at <link xlink:href="https://documentation.suse.com/sles/12-SP5/single-html/SLES-smt/"/>.
   </para>
  </sect1>
 </chapter>

--- a/xml/depl_troubleshooting.xml
+++ b/xml/depl_troubleshooting.xml
@@ -915,7 +915,7 @@ EOF</screen>
    &stornode; is part of the problem, run
    <command>supportconfig</command> on the affected node as well. For
    details on how to run <command>supportconfig</command>, see
-   <link xlink:href="&suse-onlinedoc;/sles-12/book_sle_admin/data/cha_adm_support.html"/>.
+   <link xlink:href="https://documentation.suse.com/sles/12-SP5/single-html/SLES-admin/#cha-adm-support"/>.
   </para>
 
   <sect2 xml:id="sec-depl-trouble-support-ptf">

--- a/xml/depl_zsystems.xml
+++ b/xml/depl_zsystems.xml
@@ -699,7 +699,7 @@ XAUTOLOG VSMGUARD</screen>
     To install the image capture system, follow the default &slsa; for IBM
     &zseries; installation instructions that are available from the &suse; Web
     page: <link
-    xlink:href="https://www.suse.com/documentation/sles-12/book_sle_deployment/data/cha_zseries.html">Installation
+    xlink:href="https://documentation.suse.com/sles/12-SP5/single-html/SLES-deployment/#cha-zseries">Installation
     on IBM z Systems</link>. Make sure to fulfill the <xref
     linkend="sec-deploy-zsystems-image-requirements"/> when setting up the
     network and the partitions.

--- a/xml/entity-decl.ent
+++ b/xml/entity-decl.ent
@@ -175,8 +175,9 @@ suggested official replacement from rsalevsky. -->
 
 <!-- +++++++++++++++++++++++ Links +++++++++++++++++++++++++++++++ -->
 
-<!ENTITY suse-onlinedoc "http://www.suse.com/documentation">
+<!ENTITY suse-onlinedoc "http://documentation.suse.com">
 <!ENTITY github.url     "https://github.com/SUSE-Cloud/doc-cloud">
+
 
 <!-- +++++++++++++++++++++++ Books +++++++++++++++++++++++++++++++ -->
 

--- a/xml/install_caasp_heat_templates.xml
+++ b/xml/install_caasp_heat_templates.xml
@@ -115,7 +115,7 @@ git clone https://github.com/SUSE/caasp-openstack-heat-templates
   <para>
    When you have successfully accessed the admin node web interface via the
    floating IP, follow the instructions at <link
-   xlink:href="https://www.suse.com/documentation/suse-caasp-3/book_caasp_deployment/data/book_caasp_deployment.html"/> to
+   xlink:href="https://documentation.suse.com/suse-caasp/3/single-html/caasp-deployment/"/> to
    continue the setup of &caasp;.
   </para>
  </section>
@@ -650,7 +650,7 @@ i | sles12-velum-image | package    | 3.1.7-3.27.3  | x86_64 | update_caasp</scr
   <title>More Information about &caasp;</title>
    <para>
   More information about the &caasp; is available at <link
-  xlink:href="https://www.suse.com/documentation/suse-caasp-3/book_caasp_deployment/data/book_caasp_deployment.html"/>
+  xlink:href="https://documentation.suse.com/suse-caasp/3/single-html/caasp-deployment/"/>
  </para>
  </section>
 </chapter>

--- a/xml/installation-installation-ses_integration.xml
+++ b/xml/installation-installation-ses_integration.xml
@@ -173,7 +173,7 @@
    Instructions for creating and managing pools, users and keyrings is covered
    in the &ses; documentation under
    <link
-   xlink:href="https://www.suse.com/documentation/suse-enterprise-storage-5/book_storage_admin/data/storage_cephx_keymgmt.html">Key
+   xlink:href="https://documentation.suse.com/ses/5.5/single-html/ses-admin/#storage-cephx-keymgmt">Key
    Management</link>.
   </para>
   <para>
@@ -316,7 +316,7 @@ rgw keystone verify ssl = false # If keystone is using self-signed
    CA-issued certificate or create a self-signed one. Instructions for both are
    available in the
    <link
-    xlink:href="https://www.suse.com/documentation/suse-enterprise-storage-5/book_storage_admin/data/ceph_rgw_access.html">&ses;
+    xlink:href="https://documentation.suse.com/ses/5.5/single-html/ses-admin/#ceph-rgw-access">&ses;
    documentation</link>.
   </para>
   <para>

--- a/xml/installation-installation-sles-provisioning_sles.xml
+++ b/xml/installation-installation-sles-provisioning_sles.xml
@@ -345,7 +345,7 @@ passwd ardana</screen>
    <title>Allow user <literal>ardana</literal> to <literal>sudo</literal> without password</title>
    <para>
     Setting up sudo on &slsa; is covered in the <citetitle>&slsa; Administration Guide</citetitle> at
-    <link xlink:href="https://www.suse.com/documentation/sles-12/book_sle_admin/data/sec_sudo_conf.html"/>.
+    <link xlink:href="https://documentation.suse.com/sles/12-SP5/single-html/SLES-admin/#sec-sudo-conf"/>.
    </para>
    <para>
     The recommendation is to create user specific <command>sudo</command> config files under
@@ -375,7 +375,7 @@ deployer_ip=192.168.10.254
   <para>
    For more information about Zypper, see the
    <citetitle>&slsa; Administration Guide</citetitle> at
-   <link xlink:href="https://www.suse.com/documentation/sles-12/book_sle_admin/data/sec_zypper.html"/>.
+   <link xlink:href="https://documentation.suse.com/sles/12-SP5/single-html/SLES-admin/#sec-zypper"/>.
   </para>
   <warning>
    <para>

--- a/xml/installation-support.xml
+++ b/xml/installation-support.xml
@@ -94,7 +94,7 @@
    &stornode; is part of the problem, run
    <command>supportconfig</command> on the affected node as well. For
    details on how to run <command>supportconfig</command>, see
-   <link xlink:href="&suse-onlinedoc;/sles-12/book_sle_admin/data/cha_adm_support.html"/>.
+   <link xlink:href="https://documentation.suse.com/sles/12-SP5/single-html/SLES-admin/#cha-adm-support"/>.
   </para>
 
   <sect2 xml:id="inst-support-ptf">

--- a/xml/msoperator-cmmoperator-install-c-cmmoinstall.xml
+++ b/xml/msoperator-cmmoperator-install-c-cmmoinstall.xml
@@ -5,9 +5,7 @@
  <title>Installation</title>
  <para>
   SUSE OpenStack Cloud Monitoring is automatically installed and configured if
-  you deploy the Monasca barclamp. For details, see the SUSE OpenStack Cloud
-  <citetitle>Deployment Guide</citetitle>, chapter <citetitle>Deploying the
-  OpenStack Services</citetitle>, section <citetitle>Deploying Monasca</citetitle>.
-  It is available from <ulink url="https://www.suse.com/documentation"></ulink>.
+  you deploy the Monasca barclamp. For details, see
+  <ulink url="https://documentation.suse.com/soc/8/single-html/suse-openstack-cloud-deployment/#sec-depl-ostack-monasca"/>.
  </para>
 </chapter>

--- a/xml/msoperator-cmmoperator-operate-c-backupdb.xml
+++ b/xml/msoperator-cmmoperator-operate-c-backupdb.xml
@@ -98,7 +98,7 @@ To restart the Monitoring API and the Log API, use the following command:
    <note>
     <para>
         The directory for storing snapshots must be configured in the <literal>elasticsearch/repo_dir</literal> 
-     setting in the Monasca barclamp (see the <ulink url="https://www.suse.com/documentation/suse-openstack-cloud-7/singlehtml/book_cloud_deploybook_cloud_deploy.html#sec.depl.ostack.monasca/">&clouddeploy-bare;</ulink>).  
+     setting in the Monasca barclamp (see the <ulink url="https://documentation.suse.com/soc/8/single-html/suse-openstack-cloud-deployment/#sec-depl-ostack-monasca">&clouddeploy-bare;</ulink>).  
      The directory must be manually mounted before creating the snapshot. The 
      <literal>elasticsearch</literal> user must be specified as the owner of the directory.
     </para>

--- a/xml/msoperator-shared-operationmaintenance-c-logfilelocation.xml
+++ b/xml/msoperator-shared-operationmaintenance-c-logfilelocation.xml
@@ -26,6 +26,6 @@
  <para>
   For details on the <literal>systemd</literal> and <literal>journald</literal>
   utilities, refer to the
-  <ulink url="https://www.suse.com/documentation/sles-12/singlehtml/book_sle_admin/book_sle_admin.html#part.system">SUSE Linux Enterprise Server documentation</ulink>.
+  <ulink url="https://documentation.suse.com/sles/12-SP5/single-html/SLES-admin/#part-system"/>.
  </para>
 </section>

--- a/xml/operations-general_troubleshooting.xml
+++ b/xml/operations-general_troubleshooting.xml
@@ -25,7 +25,7 @@
   <command>supportconfig</command> on the affected node as well. For details on
   how to run <command>supportconfig</command>, see
   <link
-   xlink:href="&suse-onlinedoc;/sles-12/book_sle_admin/data/cha_adm_support.html"/>.
+   xlink:href="https://documentation.suse.com/sles/12-SP5/single-html/SLES-admin/#cha-adm-support"/>.
  </para>
  <xi:include href="operations-alarm_resolutions.xml"/>
  <xi:include href="operations-troubleshooting-contacting_support.xml"/>

--- a/xml/osoperator-osoperator-install-c-osoinstall.xml
+++ b/xml/osoperator-osoperator-install-c-osoinstall.xml
@@ -5,10 +5,7 @@
  <title>Installation</title>
  <para>
   SUSE OpenStack Cloud Monitoring is automatically installed and configured if
-  you deploy the Monasca barclamp. For details, see the SUSE OpenStack Cloud
-  <citetitle>Deployment Guide</citetitle>, chapter
-  <citetitle>Deploying the OpenStack Services</citetitle>,
-  section <citetitle>Deploying Monasca</citetitle>. It is available from
-  <ulink url="https://www.suse.com/documentation"></ulink>.
+  you deploy the Monasca barclamp. For details, see
+  <ulink url="https://documentation.suse.com/soc/8/single-html/suse-openstack-cloud-deployment/#sec-depl-ostack-monasca"/>.
  </para>
 </chapter>

--- a/xml/osoperator-osoperator-intro-c-osotasks.xml
+++ b/xml/osoperator-osoperator-intro-c-osotasks.xml
@@ -89,11 +89,8 @@
  <para>
   Your individual agent configuration determines which metrics are available
   for monitoring your services and servers. For details on installing and
-  configuring a Metrics Agent, refer to the SUSE OpenStack Cloud <citetitle>Deployment
-  Guide</citetitle>, chapter <citetitle>Deploying the OpenStack Services</citetitle>,
-  section <citetitle>Deploying Monasca</citetitle>. It is available from
-  <ulink url="https://www.suse.com/documentation"></ulink>.
-<!--taroth 2017-05-11: add chapter and section title here, too-->
+  configuring a Metrics Agent, refer to
+  <ulink url="https://documentation.suse.com/soc/8/html/suse-openstack-cloud-crowbar-all/cha-depl-ostack.html#sec-depl-ostack-monasca"/>.
  </para>
  <para>
   As soon as an agent is available, you have access to the <phrase>SUSE
@@ -125,12 +122,8 @@
  <para>
   The Log Agent collects the log data from the services and servers and sends
   them to the Monitoring Service for further processing. For details on
-  installing and configuring a Log Agent, refer to the SUSE OpenStack Cloud
-  <citetitle>Deployment Guide</citetitle>, chapter <citetitle>Deploying the
-  OpenStack Services</citetitle>, section <citetitle>Deploying Monasca</citetitle>.
-  It is available from
-  <ulink url="https://www.suse.com/documentation"></ulink>.
-<!--taroth 2017-05-11: add chapter and section title here, too-->
+  installing and configuring a Log Agent, refer to
+  <ulink url="https://documentation.suse.com/soc/8/html/suse-openstack-cloud-crowbar-all/cha-depl-ostack.html#sec-depl-ostack-monasca"/>.
  </para>
  <para>
   <phrase>SUSE OpenStack Cloud Monitoring</phrase> stores the log data in a

--- a/xml/planning-planning-hw_support_kvmguestos.xml
+++ b/xml/planning-planning-hw_support_kvmguestos.xml
@@ -7,6 +7,6 @@
  <title>KVM Guest OS Support</title>
  <para>
   For a list of the supported VM guests, see
-  <link xlink:href="https://www.suse.com/documentation/sles-12/book_virt/data/virt_support_guests.html"/>
+  <link xlink:href="https://documentation.suse.com/sles/12-SP5/single-html/SLES-virtualization/#virt-support-guests"/>
  </para>
 </section>

--- a/xml/planning-planning-suse-register_suse_automated.xml
+++ b/xml/planning-planning-suse-register_suse_automated.xml
@@ -9,7 +9,7 @@
   If you deploy your instances automatically using AutoYaST, you can register
   the system during the installation by providing the respective information in
   the AutoYaST control file. Refer to
-  <link xlink:href="https://www.suse.com/documentation/sles-12/book_autoyast/data/createprofile_register.html"/>
+  <link xlink:href="https://documentation.suse.com/sles/12-SP5/single-html/SLES-autoyast/#CreateProfile-Register"/>
   for details.
  </para>
 </section>

--- a/xml/preinstall-prepare-deployer.xml
+++ b/xml/preinstall-prepare-deployer.xml
@@ -20,10 +20,8 @@
   <para>
    Registering &cloudos; during the installation process is required for
    getting product updates and for installing the &productname;
-   extension. Refer to the <link
-   xlink:href="&suse-onlinedoc;/sles-12/book_sle_deployment/data/sec_i_yast2_conf_manual_cc.html">SUSE
-   Customer Center Registration</link> section of the &cloudos; <citetitle>Deployment
-   Guide</citetitle> for further instructions.
+   extension. Refer to <link xlink:href="https://documentation.suse.com/sles/12-SP5/single-html/SLES-deployment/#sec-i-yast2-conf-manual-cc"/>
+   for further instructions.
   </para>
   <para>
    After a successful registration you will be asked whether
@@ -52,13 +50,8 @@
   </important>
   <note>
    <para>
-    For an overview of a default &sls; installation, refer to the <link
-    xlink:href="&suse-onlinedoc;/sles-12/book_quickstarts/data/art_sle_installquick.html">&sls;
-    &instquick;</link>. <link
-    xlink:href="&suse-onlinedoc;/sles-12/book_sle_deployment/data/cha_inst.html">Detailed
-    default installation information</link> is available in the &sls;
-    <citetitle>Deployment Guide</citetitle>. Both documents are available at
-    <link xlink:href="&suse-onlinedoc;/sles-12/"/>.
+    For an overview of a default &sls; installation, refer to <link
+    xlink:href="https://documentation.suse.com/sles/12-SP5/single-html/SLES-installquick/#art-sle-installquick"/>.
    </para>
   </note>
   <para>
@@ -132,9 +125,7 @@
    With <guimenu>Installation Settings</guimenu>, you need to adjust the
    software selection for your &clm; setup. For more information refer to the
    <link
-   xlink:href="&suse-onlinedoc;/sles-12/book_sle_deployment/data/sec_i_yast2_proposal.html">Installation
-   Settings</link> section of the &cloudos; <citetitle>Deployment
-   Guide</citetitle>.
+   xlink:href="https://documentation.suse.com/sles/12-SP5/single-html/SLES-deployment/#sec-i-yast2-proposal"/>.
   </para>
   <important>
    <title>Additional Installation Settings</title>
@@ -247,10 +238,8 @@
     Alternatively, install the &productname; after the
    &cloudos; installation via <menuchoice><guimenu>&yast;</guimenu>
    <guimenu>Software</guimenu> <guimenu>Add-On Products</guimenu></menuchoice>.
-   For details, refer to the section <link
-   xlink:href="https://www.suse.com/documentation/sles-12/book_sle_deployment/data/sec_add-ons_extensions.html">Installing
-   Modules and Extensions from Online Channels</link> of the &cloudos;
-   <citetitle>Deployment Guide</citetitle>.
+   For details, refer to <link
+   xlink:href="https://documentation.suse.com/sles/12-SP5/single-html/SLES-deployment/#sec-add-ons-extensions"/>.
    </para>
   </sect2>
  </sect1>

--- a/xml/preinstall-smt-setup.xml
+++ b/xml/preinstall-smt-setup.xml
@@ -176,7 +176,7 @@
      <guimenu>YaST</guimenu> <guimenu>Security and Users</guimenu>
      <guimenu>CA Management</guimenu> </menuchoice> after the &smt;
      configuration is done. See
-   <link xlink:href="&suse-onlinedoc;/sles-12/book_security/data/cha_security_yast_ca.html"/>
+   <link xlink:href="https://documentation.suse.com/sles/12-SP5/single-html/SLES-security/#cha-security-yast-ca"/>
    for more information.
     </para>
     <para>
@@ -227,9 +227,9 @@ done</screen>
  </sect1>
  <sect1 xml:id="app-deploy-smt-info">
   <title>For More Information</title>
-
   <para>
-   For detailed information about &smt; refer to the &smtool; manual at <link xlink:href="&suse-onlinedoc;/sles-12/book_smt/data/book_smt.html"/>.
+   For detailed information about &smt; refer to the &smtool; manual at
+   <link xlink:href="https://documentation.suse.com/sles/12-SP5/single-html/SLES-smt/"/>.
   </para>
  </sect1>
 </chapter>

--- a/xml/security-using_apparmor.xml
+++ b/xml/security-using_apparmor.xml
@@ -44,8 +44,7 @@
    At this time, AppArmor is not enabled by default in &kw-hos-phrase;.
    However, we recommend enabling it for key virtualization processes on
    compute nodes. For more information, see the
-   <link xlink:href="https://www.suse.com/documentation/sles-12/book_security/data/part_apparmor.html">SUSE
-   Security Guide on AppArmor</link>.
+   <link xlink:href="https://documentation.suse.com/sles/12-SP5/single-html/SLES-security/#part-apparmor"/>.
   </para>
 <!--
   <para>

--- a/xml/suppl_intro.xml
+++ b/xml/suppl_intro.xml
@@ -33,7 +33,7 @@
  <para>
   For an overview of the documentation available for your product and the
   latest documentation updates, refer to
-  <link xlink:href="http://www.suse.com/documentation"/>.
+  <link xlink:href="http://documentation.suse.com"/>.
  </para>
  <xi:include href="common_intro_available_doc_i.xml"/>
  <xi:include href="common_intro_feedback_i.xml"/>


### PR DESCRIPTION
The server has changed and links to suse.com/doc are no longer
active or with supported redirects. This manually fixes all
of the links and updates them appropriately for SES 8.