### PR TITLE
Update spare pool description (SOC-8726)

### DIFF
--- a/xml/networking-octavia_admin.xml
+++ b/xml/networking-octavia_admin.xml
@@ -190,47 +190,41 @@
    <emphasis role="bold">Spare Pools</emphasis>
   </para>
   <para>
-   The Octavia driver provides support for creating spare pools of the HAProxy
-   software installed in VMs. This means instead of creating a new load
-   balancer when loads increase, create new load balancer calls will pull a
-   load balancer from the spare pool. The spare pools feature consumes
-   resources, therefore the load balancers in the spares pool has been set to
-   0, which is the default and also disables the feature.
+    The Octavia driver provides support for creating spare pools of
+    the HAProxy software installed in VMs. This means instead of
+    creating a new load balancer when loads increase, create new load
+    balancer calls will pull a load balancer from the spare pool. The
+    spare pools feature consumes resources, therefore the load
+    balancers in the spares pool has been set to 0, which is the
+    default and also disables the feature.
   </para>
   <para>
-   Reasons to enable a load balancing spare pool in &productname;
+    Reasons to enable a load balancing spare pool in &productname;
   </para>
   <orderedlist>
-   <listitem>
-    <para>
-     You expect a large number of load balancers to be provisioned all at once
-     (puppet scripts, or ansible scripts) and you want them to come up quickly.
-    </para>
-   </listitem>
-   <listitem>
-    <para>
-     You want to reduce the wait time a customer has while requesting a new
-     load balancer.
-    </para>
-   </listitem>
+    <listitem>
+      <para>
+        You expect a large number of load balancers to be provisioned all at once
+        (puppet scripts, or ansible scripts) and you want them to come up quickly.
+      </para>
+    </listitem>
+    <listitem>
+      <para>
+        You want to reduce the wait time a customer has while requesting a new
+        load balancer.
+      </para>
+    </listitem>
   </orderedlist>
   <para>
-   To increase the number of load balancers in your spares pool, edit the
-   Octavia configuration files by uncommenting the
-   <literal>spare_amphora_pool_size</literal> and adding the number of load
-   balancers you would like to include in your spares pool.
+    To increase the number of load balancers in your spares pool, edit
+    the Octavia configuration files by uncommenting the
+    <literal>spare_amphora_pool_size</literal> and adding the number of load
+    balancers you would like to include in your spares pool.
   </para>
-<screen># Pool size for the spare pool
-# spare_amphora_pool_size = 0</screen>
-  <important>
-   <!-- FIXME: Removed version number 3.0 from following para. Still correct?
-   - sknorr, 2018-03-27 -->
-   <para>
-    In &productname; the spare pool cannot be used to speed up fail
-    overs. If a load balancer fails in &productname;, Octavia will always provision
-    a new VM to replace that failed load balancer.
-   </para>
-  </important>
+  <screen>
+# Pool size for the spare pool
+# spare_amphora_pool_size = 0
+  </screen>
  </section>
  <section xml:id="Amphora">
   <title>Managing Amphora</title>


### PR DESCRIPTION
I have tested failover in both `standalone` and `active/standby`
topologies and found that on failover a spare is used contrary to the
statement in the deleted paragraph.

Signed-off-by: Nicolas Bock <nicolas.bock@suse.com>