### PR TITLE
Designate: recommend deploying DNS in a cluster in HA deployment (SOC-10636)

### DIFF
--- a/xml/depl_nodes.xml
+++ b/xml/depl_nodes.xml
@@ -171,6 +171,12 @@
     barclamp that is not the admin node. The admin node is not added to the
     public network. So another node is needed that can be attached to the public
     network and appear in the designate default pool.
+
+    In High Availability deployments where Designate services are running in a cluster,
+    it is highly recommended that DNS services are running in a cluster as well.
+    For example, in a typical High Availability deployment where the controllers
+    are deployed in a 3-node cluster, the DNS barclamp should be applied to all the
+    controllers, in the same manner as Designate.
    </para>
   </note>
   <variablelist>


### PR DESCRIPTION
…10636)

In HA deployment, we should recommend users to deploy both DNS and Designate
into the same cluster nodes to avoid single point of failure.