### PR TITLE
designate zone/pool scheme to the worker/producer scheme migration 

### DIFF
--- a/xml/installation-installation-designate-designate_install_overview.xml
+++ b/xml/installation-installation-designate-designate_install_overview.xml
@@ -67,4 +67,5 @@
  <xi:include href="installation-installation-designate-install_designate_BIND.xml"/>
  <xi:include href="installation-installation-designate-install_designate_PowerDNS.xml"/>
  <xi:include href="installation-installation-designate-designate_cfg_dns_ns.xml"/>
+ <xi:include href="installation-installation-designate-designate_migrate_zone_pool_to_worker_producer.xml"/>
 </chapter>

--- a/xml/installation-installation-designate-designate_migrate_zone_pool_to_worker_producer.xml
+++ b/xml/installation-installation-designate-designate_migrate_zone_pool_to_worker_producer.xml
@@ -1,0 +1,77 @@
+<?xml version="1.0"?>
+<!DOCTYPE section [
+ <!ENTITY % entities SYSTEM "entity-decl.ent"> %entities;
+]>
+<section xml:id="DNS-MIGRATE"
+ xmlns="http://docbook.org/ns/docbook" version="5.1"
+ xmlns:xi="http://www.w3.org/2001/XInclude"
+ xmlns:xlink="http://www.w3.org/1999/xlink">
+ <title>Migrate Zone/Pool to Worker/Producer after Upgrade</title>
+ <para>
+  After upgrade, the following steps may be used to migrate the zone/pool 
+  scheme to the worker/producer scheme:
+ </para>
+  <procedure>
+   <step>
+    <para>
+     Log in to the &clm;.
+    </para>
+   </step>
+   <step>
+    <para>
+     Edit the file
+     <filename>~/openstack/my_cloud/definitions/data/control_plane.yml</filename> 
+     to replace <literal>designate-pool-manager</literal> to <literal>designate-worker</literal> and <literal>designate-zone-manager</literal> to <literal>designate-producer</literal>
+    </para>
+<screen>control-planes:
+          - name: control-plane-1
+          region-name: region1
+
+          clusters:
+          - name: cluster1
+          service-components:
+          - lifecycle-manager
+          - mariadb
+          - ip-cluster
+          - apache2
+          - ...
+          - designate-api
+          - designate-central
+          - designate-worker
+          - designate-producer
+          - designate-mdns
+          - designate-client
+          - powerdns</screen>
+   </step>
+   <step>
+    <para>
+     Commit your changes to git:
+    </para>
+<screen>&prompt.ardana;cd ~/openstack/ardana/ansible
+&prompt.ardana;git commit -m "<replaceable>COMMIT_MESSAGE</replaceable>"
+</screen>
+   </step>
+   <step>
+    <para>
+     Run the configuration processor:
+    </para>
+<screen>&prompt.ardana;cd ~/openstack/ardana/ansible
+&prompt.ardana;ansible-playbook -i hosts/localhost config-processor-run.yml</screen>
+   </step>
+   <step>
+    <para>
+     Create a deployment directory:
+    </para>
+<screen>&prompt.ardana;cd ~/openstack/ardana/ansible
+&prompt.ardana;ansible-playbook -i hosts/localhost ready-deployment.yml</screen>
+   </step>
+   <step>
+    <para>
+     Run the <literal>designate-migrate.yml</literal> playbook to migrate 
+     the designate services:
+    </para>
+<screen>&prompt.ardana;cd ~/scratch/ansible/next/ardana/ansible
+&prompt.ardana;ansible-playbook -i hosts/verb_hosts designate-migrate.yml</screen>
+   </step>
+  </procedure>
+</section>


### PR DESCRIPTION
Documentation for how to migrate from using the designate zone/pool scheme to the worker/producer scheme after an upgrade