### PR TITLE
Clarify wipe_disks does not affect non-OS partitions (bsc#1092420)

### DIFF
--- a/xml/installation-installation-installation_troubleshooting.xml
+++ b/xml/installation-installation-installation_troubleshooting.xml
@@ -187,7 +187,7 @@ ansible-playbook -i hosts/verb_hosts wipe_disks.yml</screen>
    to confirm that you want to complete this action or abort it if you do not
    want to proceed. You can optionally use the <literal>--limit
    &lt;NODE_NAME&gt;</literal> switch on this playbook to restrict it to
-   specific nodes.
+   specific nodes. This action will not affect the OS partitions on the servers.
   </para>
   <para>
    If you receive an error stating that <literal>osconfig</literal> has already

--- a/xml/installation-installation-multipath_boot_from_san.xml
+++ b/xml/installation-installation-multipath_boot_from_san.xml
@@ -254,7 +254,7 @@ IPADDR=10.10.100.10
    </step>
    <step>
     <para>
-     Ensure that all existing partitions on the nodes are wiped prior to
+     Ensure that all existing non-OS partitions on the nodes are wiped prior to
      installation by running the <filename>wipe_disks.yml</filename> playbook.
     </para>
     <note>

--- a/xml/installation-kvm_xpointer.xml
+++ b/xml/installation-kvm_xpointer.xml
@@ -745,7 +745,7 @@ ansible-playbook -i hosts/localhost ready-deployment.yml</screen>
    <step>
     <para>
      [OPTIONAL] - Run the <literal>wipe_disks.yml</literal> playbook to ensure
-     all of your partitions on your nodes are completely wiped before
+     all of your non-OS partitions on your nodes are completely wiped before
      continuing with the installation. The <filename>wipe_disks.yml</filename>
      playbook is only meant to be run on systems immediately after running
      <filename>bm-reimage.yml</filename>. If used for any other case, it may

--- a/xml/operations-maintenance-compute-add_sles_compute.xml
+++ b/xml/operations-maintenance-compute-add_sles_compute.xml
@@ -153,7 +153,7 @@
    <listitem>
     <para>
      [OPTIONAL] - Run the <literal>wipe_disks.yml</literal> playbook to ensure
-     all of your partitions on your nodes are completely wiped prior to
+     all of your non-OS partitions on your nodes are completely wiped prior to
      continuing with the installation.
     </para>
     <note>
@@ -327,7 +327,7 @@
    <step>
     <para>
      [OPTIONAL] - Run the <literal>wipe_disks.yml</literal> playbook to ensure
-     all of your partitions on your hosts are completely wiped prior to
+     all of your non-OS partitions on your hosts are completely wiped prior to
      continuing with the installation. The <filename>wipe_disks.yml</filename>
      playbook is only meant to be run on systems immediately after running
      <filename>bm-reimage.yml</filename>. If used for any other case, it may

--- a/xml/operations-maintenance-controller-onetwo_controller_recovery.xml
+++ b/xml/operations-maintenance-controller-onetwo_controller_recovery.xml
@@ -124,7 +124,7 @@
    <listitem>
     <para>
      Run the <filename>wipe_disks.yml</filename> playbook to ensure the
-     partitions on your nodes are completely wiped prior to continuing with the
+     non-OS partitions on your nodes are completely wiped prior to continuing with the
      installation.
     </para>
     <important>

--- a/xml/operations-maintenance-controller-replace_dedicated_lm.xml
+++ b/xml/operations-maintenance-controller-replace_dedicated_lm.xml
@@ -99,7 +99,7 @@ Original contents retained as ~/.ssh/known_hosts.old</screen>
   <step>
    <para>
     Run the <filename>wipe_disks.yml</filename> playbook to ensure
-    all partitions on the new node are completely wiped prior to
+    all non-OS partitions on the new node are completely wiped prior to
     continuing with the installation. (The value to be used for
     <literal>hostname</literal> is the host's identifier from
     <filename>~/scratch/ansible/next/ardana/ansible/hosts/verb_hosts</filename>.)

--- a/xml/operations-maintenance-controller-replace_shared_lm.xml
+++ b/xml/operations-maintenance-controller-replace_shared_lm.xml
@@ -84,7 +84,7 @@ ilo-password: deployment</screen>
   <step>
    <para>
     Run the <filename>wipe_disks.yml</filename> playbook to ensure
-    all partitions on the new node are completely wiped prior to
+    all non-OS partitions on the new node are completely wiped prior to
     continuing with the installation. (The value to be used for
     <literal>hostname</literal> is the host's identifier from
     <filename>~/scratch/ansible/next/ardana/ansible/hosts/verb_hosts</filename>.)

--- a/xml/operations-maintenance-networking-add_network_node.xml
+++ b/xml/operations-maintenance-networking-add_network_node.xml
@@ -244,7 +244,7 @@
    <listitem>
     <para>
      [OPTIONAL] - Run the <literal>wipe_disks.yml</literal> playbook to ensure
-     all of your partitions on your nodes are completely wiped prior to
+     all of your non-OS partitions on your nodes are completely wiped prior to
      continuing with the installation. The <filename>wipe_disks.yml</filename>
      playbook is only meant to be run on systems immediately after running
      <filename>bm-reimage.yml</filename>. If used for any other case, it may

--- a/xml/operations-maintenance-swift-replacing_swift_node.xml
+++ b/xml/operations-maintenance-swift-replacing_swift_node.xml
@@ -141,7 +141,8 @@
    </step>
    <step>
     <para>
-     Wipe the disks on the <literal>NEW REPLACEMENT NODE</literal>.
+      Wipe the disks on the <literal>NEW REPLACEMENT NODE</literal>.
+      This action will not affect the OS partitions on the server.
     </para>
     <screen>&prompt.ardana;cd ~/scratch/ansible/next/ardana/ansible
 &prompt.ardana;ansible-playbook -i hosts/verb_hosts wipe_disks.yml --limit <literal>NEW_REPLACEMENT_NODE</literal></screen>


### PR DESCRIPTION
Clarifies in the documentation that the wipe_disks playbook does not wipe out OS partitions. There was some verbiage to this effect in a few spots, but it was inconsistently applied.