### PR TITLE
Clarify wipe_disks does not affect non-OS partitions (bsc#1092420)

### DIFF
--- a/xml/installation-installation-installation_troubleshooting.xml
+++ b/xml/installation-installation-installation_troubleshooting.xml
@@ -187,7 +187,7 @@ ansible-playbook -i hosts/verb_hosts wipe_disks.yml</screen>
    to confirm that you want to complete this action or abort it if you do not
    want to proceed. You can optionally use the <literal>--limit
    &lt;NODE_NAME&gt;</literal> switch on this playbook to restrict it to
-   specific nodes.
+   specific nodes. This action will not affect the OS partitions on the servers.
   </para>
   <para>
    If you receive an error stating that <literal>osconfig</literal> has already

--- a/xml/installation-installation-multipath_boot_from_san.xml
+++ b/xml/installation-installation-multipath_boot_from_san.xml
@@ -234,7 +234,7 @@ IPADDR=10.13.111.14
    </step>
    <step>
     <para>
-     To ensure that all existing partitions on the nodes are wiped prior to
+     To ensure that all existing non-OS partitions on the nodes are wiped prior to
      installation, you need to run the <filename>wipe_disks.yml</filename>
      playbook. The <filename>wipe_disks.yml</filename> playbook is only meant
      to be run on systems immediately after running

--- a/xml/installation-kvm_xpointer.xml
+++ b/xml/installation-kvm_xpointer.xml
@@ -746,7 +746,7 @@ ansible-playbook -i hosts/localhost ready-deployment.yml</screen>
    <step>
     <para>
      [OPTIONAL] - Run the <literal>wipe_disks.yml</literal> playbook to ensure
-     all of your partitions on your nodes are completely wiped before
+     all of your non-OS partitions on your nodes are completely wiped before
      continuing with the installation. The <filename>wipe_disks.yml</filename>
      playbook is only meant to be run on systems immediately after running
      <filename>bm-reimage.yml</filename>. If used for any other case, it may

--- a/xml/operations-maintenance-compute-add_sles_compute.xml
+++ b/xml/operations-maintenance-compute-add_sles_compute.xml
@@ -153,7 +153,7 @@ ansible-playbook -i hosts/localhost ready-deployment.yml</screen>
    <listitem>
     <para>
      [OPTIONAL] - Run the <literal>wipe_disks.yml</literal> playbook to ensure
-     all of your partitions on your nodes are completely wiped prior to
+     all of your non-OS partitions on your nodes are completely wiped prior to
      continuing with the installation.
     </para>
     <note>
@@ -327,7 +327,7 @@ ansible-playbook -i hosts/localhost ready-deployment.yml</screen>
    <step>
     <para>
      [OPTIONAL] - Run the <literal>wipe_disks.yml</literal> playbook to ensure
-     all of your partitions on your hosts are completely wiped prior to
+     all of your non-OS partitions on your hosts are completely wiped prior to
      continuing with the installation. The <filename>wipe_disks.yml</filename>
      playbook is only meant to be run on systems immediately after running
      <filename>bm-reimage.yml</filename>. If used for any other case, it may

--- a/xml/operations-maintenance-controller-onetwo_controller_recovery.xml
+++ b/xml/operations-maintenance-controller-onetwo_controller_recovery.xml
@@ -124,7 +124,7 @@
    <listitem>
     <para>
      [OPTIONAL] - Run the <literal>wipe_disks.yml</literal> playbook to ensure
-     all of your partitions on your nodes are completely wiped prior to
+     all of your non-OS partitions on your nodes are completely wiped prior to
      continuing with the installation. The <filename>wipe_disks.yml</filename>
      playbook is only meant to be run on systems immediately after running
      <filename>bm-reimage.yml</filename>. If used for any other case, it may

--- a/xml/operations-maintenance-networking-add_network_node.xml
+++ b/xml/operations-maintenance-networking-add_network_node.xml
@@ -244,7 +244,7 @@
    <listitem>
     <para>
      [OPTIONAL] - Run the <literal>wipe_disks.yml</literal> playbook to ensure
-     all of your partitions on your nodes are completely wiped prior to
+     all of your non-OS partitions on your nodes are completely wiped prior to
      continuing with the installation. The <filename>wipe_disks.yml</filename>
      playbook is only meant to be run on systems immediately after running
      <filename>bm-reimage.yml</filename>. If used for any other case, it may


### PR DESCRIPTION
Specify in documentation that the wipe_disks playbook does not affect OS partitions.

cherry-pick from SOC9: 6e7b812c7c85a40ac39b6dfb7a7b2b80db700f64