### PR TITLE
Revert "Octavia: update documentation on lb-mgmg-net (SOC-10904)"

### DIFF
--- a/xml/depl_cisco.xml
+++ b/xml/depl_cisco.xml
@@ -103,10 +103,6 @@
               <replaceable>...</replaceable>,
               "conduit" : "intf0"
             },
-            "octavia" : {
-              <replaceable>...</replaceable>,
-              "conduit" : "intf0"
-            },
             "admin" : {
               <replaceable>...</replaceable>,
               "conduit" : "intf0"

--- a/xml/depl_conf_admin_crowbar.xml
+++ b/xml/depl_conf_admin_crowbar.xml
@@ -1835,18 +1835,6 @@ lrwxrwxrwx 1 0 Jun 19 08:43 eth3 -&gt; ../../devices/pci0000:00/0000:00:1c.0/000
        </entry>
        <entry>
         <para>
-         Octavia Management Network (octavia)
-        </para>
-       </entry>
-      </row>
-      <row>
-       <entry>
-        <para>
-         700
-        </para>
-       </entry>
-       <entry>
-        <para>
          Private Network (nova-fixed)
         </para>
        </entry>
@@ -2010,7 +1998,6 @@ bastion:
 bmc_vlan:  eth0
 nova_fixed: eth0
 nova_floating: eth0
-octavia: eth0
 os_sdn: eth0
 public: eth0
 storage: eth0

--- a/xml/depl_nodes.xml
+++ b/xml/depl_nodes.xml
@@ -7674,7 +7674,7 @@ Apply the &barcl; to a Control Node.
     },
     "nova_fixed": {
       "conduit": "intf1",
-      "vlan": 700,
+      "vlan": 500,
       "use_vlan": true,
       "add_bridge": false,
       "add_ovs_bridge": false,
@@ -7709,21 +7709,6 @@ Apply the &barcl; to a Control Node.
         }
       },
       "mtu": 1500
-    },
-    "octavia": {
-      "conduit": "intf1",
-      "vlan": 500,
-      "use_vlan": true,
-      "add_bridge": false,
-      "add_ovs_bridge": false,
-      "mtu": 1500,
-      "subnet": "192.168.131.0",
-      "netmask": "255.255.255.0",
-      "router": "192.168.131.1",
-      "broadcast": "192.168.131.255",
-      "ranges": {
-        "host": { "start": "192.168.131.10", "end": "192.168.131.239" }
-      }
     },
     "bmc": {
       "conduit": "bmc",

--- a/xml/depl_require.xml
+++ b/xml/depl_require.xml
@@ -163,8 +163,8 @@
      </para>
     </listitem>
    </varlistentry>
-   <varlistentry xml:id="vle-netw-octa">
-    <term>The &octavia; Management Network (octavia, 192.168.131/24)</term>
+   <varlistentry>
+    <term>The &octavia; Management Network</term>
     <listitem>
      <para>
       &octavia; uses a set of instances on a Compute node called amphorae
@@ -195,11 +195,6 @@
     <listitem>
      <para>
       <xref linkend="vle-netw-sdn" xrefstyle="select:label nopage"/>
-     </para>
-    </listitem>
-    <listitem>
-     <para>
-      <xref linkend="vle-netw-octa" xrefstyle="select:label nopage"/>
      </para>
     </listitem>
    </itemizedlist>
@@ -781,55 +776,6 @@
          If &o_netw; is configured with <literal>openvswitch</literal>
          and <literal>gre</literal>, each network node and all
          &compnode;s will get an IP address from this range.
-        </para>
-       </entry>
-      </row>
-     </tbody>
-    </tgroup>
-   </table>
-   <table>
-    <title><systemitem class="etheraddress">192.168.131/24</systemitem> (Octavia) Network Address Allocation</title>
-    <tgroup cols="3">
-     <colspec colnum="1" colname="1" colwidth="20*"/>
-     <colspec colnum="2" colname="2" colwidth="33*"/>
-     <colspec colnum="3" colname="3" colwidth="47*"/>
-     <thead>
-      <row>
-       <entry>
-        <para>
-         Function
-        </para>
-       </entry>
-       <entry>
-        <para>
-         Address
-        </para>
-       </entry>
-       <entry>
-        <para>
-         Remark
-        </para>
-       </entry>
-      </row>
-     </thead>
-     <tbody>
-      <row>
-       <entry>
-        <para>
-         host
-        </para>
-       </entry>
-       <entry>
-        <para>
-         <systemitem class="etheraddress">192.168.131.10</systemitem> -
-         <systemitem class="etheraddress">192.168.131.239</systemitem>
-        </para>
-       </entry>
-       <entry>
-        <para>
-         If &o_netw; is configured with <literal>openvswitch</literal>
-         and <literal>gre</literal>, each Amphora (LoadBalancer) node
-         will get a management IP address from this range.
         </para>
        </entry>
       </row>


### PR DESCRIPTION
Reverts SUSE-Cloud/doc-cloud#1265

In light of https://github.com/crowbar/crowbar-core/pull/2023 the doc is no longer applicable. We'll need to redo the docs after the dust settles.
