### PR TITLE
Add notes on octavia / heat integration (SOC-11239)

### DIFF
--- a/xml/depl_nodes.xml
+++ b/xml/depl_nodes.xml
@@ -4768,6 +4768,20 @@ openstack router add subnet <replaceable>router2</replaceable> priv-net-sub</scr
     since the latter is the default role assigned by our hybrid LDAP back-end
     among others.-->
    </para>
+   <important>
+     <para>
+       If the Octavia barclamp is deployed, the <literal>trusts_delegated_roles</literal>
+       configuration option either needs to be set to an empty value, or the
+       <literal>load-balancer_member</literal> role needs to be included, otherwise
+       it won't be possible to create Octavia load balancers via heat stacks.
+       Refer to the <xref linkend="sec-depl-ostack-octavia-migrate-users"/> section for more
+       details on the list of specialized roles employed by Octavia.
+       Also note that adding the <literal>load-balancer_member</literal> role
+       to the <literal>trusts_delegated_roles</literal> list has the undesired
+       side effect that only users that have this role assigned to them will be
+       allowed to access the Heat API, as covered previously in this section.
+     </para>
+   </important>
    <para>
     To view or change the trusts_delegated_role setting you need to open the
     &o_orch; &barcl; and click <guimenu>Raw</guimenu> in the
@@ -7044,6 +7058,14 @@ monitoring</guimenu>
         <literal>openstack loadbalancer</literal> CLI commands or use
         the load balancer horizon dashboard unless their accounts are explicitly
         reconfigured to be associated with one or more of these roles.
+      </para>
+    </important>
+    <important>
+      <para>
+        Please follow the instructions documented under <xref linkend="sec-depl-ostack-heat-delegated-roles"/>
+        on updating the trusts roles in the heat barclamp configuration. This is
+        required to configure heat to use the correct roles when communicating with
+        the Octavia API and manage load balancers.
       </para>
     </important>
   </sect2>


### PR DESCRIPTION
Document the heat configuration changes required to enable
heat to orchestrate Octavia load balancers.
Due to the fact that Octavia uses its own specialized keystone
roles to control access to its API, the list of heat trusts
roles also needs to be adjusted, otherwise users will not be
able to create Octavia load balancers via OS::Octavia::LoadBalancer
heat stack resources.