### PR TITLE
Update Kibana direct access instructions (SOC-10982)

### DIFF
--- a/xml/operations-central_log_access_data.xml
+++ b/xml/operations-central_log_access_data.xml
@@ -189,53 +189,13 @@
    <title>Access Kibana Using a Direct Link:</title>
    <para>
     This section helps you verify the horizon virtual IP (VIP) address that you
-    should use.
+    should use. To provide enhanced security, access to Kibana is not available on the
+    External network.
    </para>
    <orderedlist>
     <listitem>
      <para>
-      To find hostname, run:
-     </para>
-<screen>&prompt.ardana;grep -i log-svr /etc/hosts</screen>
-    </listitem>
-    <listitem>
-     <para>
-      Navigate to the following directory:
-     </para>
-<screen>&prompt.ardana;~/openstack/my_cloud/definition/data</screen>
-     <note>
-      <para>
-       The file <filename>network_groups.yml</filename> in the
-       <filename>~/openstack/my_cloud/definition/data</filename>
-       directory is the input model file that may be copied automatically to
-       other directories.
-      </para>
-     </note>
-    </listitem>
-    <listitem>
-     <para>
-      Open the following file for editing:
-     </para>
-<screen>network_groups.yml </screen>
-    </listitem>
-    <listitem>
-     <para>
-      Find the following entry:
-     </para>
-<screen>external-name</screen>
-    </listitem>
-    <listitem>
-     <para>
-      If your administrator set a hostname value in the
-      <replaceable>EXTERNAL_NAME</replaceable> field during the
-      configuration process for your cloud, then Kibana will be accessed over
-      port 5601 on that hostname.
-     </para>
-    </listitem>
-    <listitem>
-     <para>
-      If your administrator did not set a hostname value, then to determine
-      which IP address to use, from your &clm;, run:
+      To determine which IP address to use to access Kibana, from your &clm;, run:
      </para>
 <screen>&prompt.ardana;grep HZN-WEB /etc/hosts</screen>
      <para>


### PR DESCRIPTION
Kibana is not available on the external network, removed the section indicating support for External network access to Kibana, retained VIP access instructions.
![soc-10982](https://user-images.githubusercontent.com/23247873/86165010-8e7c7200-bac7-11ea-9f5a-236cd9fc5dce.png)
