### PR TITLE
Add file output instructions to SES configuration steps (bsc#1158671)

### DIFF
--- a/xml/depl_nodes.xml
+++ b/xml/depl_nodes.xml
@@ -7935,8 +7935,10 @@ Apply the &barcl; to a Control Node.
     </step>
     <step>
      <para>
-      A YAML file is created with content similar to the following
-      example:
+      YAML output is created with content similar to the following
+      example, and can be redirected to a file using the redirect
+      operator <literal>&gt;</literal> or using the additional
+      parameter <literal>--out-file=&lt;filename&gt;</literal>:
      </para>
      <screen>ceph_conf:
      cluster_network: 10.84.56.0/21


### PR DESCRIPTION
The SES instructions tell a user to unload a configuration file but only specify how to output the configuration to the terminal, not to a file.

Added file output and redirect instructions.