### PR TITLE
Update Octavia load balancer documentation (SOC-11383)

### DIFF
--- a/xml/depl_conf_admin_repos.xml
+++ b/xml/depl_conf_admin_repos.xml
@@ -583,6 +583,9 @@ createrepo &tftp_dir;/repos/&sle_repo;-Pool/</screen>
        Mandatory Repositories
       </para>
      </entry>
+     <entry>
+      <para></para>
+     </entry>
     </row>
     <row>
      <entry>

--- a/xml/installation-installation-configure_lbaas.xml
+++ b/xml/installation-installation-configure_lbaas.xml
@@ -226,6 +226,14 @@ if needed.
       If you run the registration by accident, the system will only upload a
       new image if the underlying image has been changed.
      </para>
+     <para>
+      Ensure there are not multiple amphora images listed. Execute following command:
+     </para>
+<screen>&prompt.ardana; openstack image list --tag amphora </screen>
+     <para>
+      If the above command returns more than one image, unset the old amphora image. To unset the image execute following command:
+     </para>
+<screen>&prompt.ardana; openstack image unset --tag amphora &lt;oldimageid&gt; </screen>
     </important>
     <para>
      If you have already created load balancers, they will not receive the new

--- a/xml/poc_crowbar_guide.xml
+++ b/xml/poc_crowbar_guide.xml
@@ -689,6 +689,9 @@
       <entry>
        <para></para>
       </entry>
+      <entry>
+       <para></para>
+      </entry>
      </row>
      <row>
       <entry>
@@ -700,6 +703,9 @@
        <para>
         3 Control Nodes
        </para>
+      </entry>
+      <entry>
+       <para></para>
       </entry>
       <entry>
        <para></para>


### PR DESCRIPTION
added comments to untag the amphora image if more than one amphora images are listed after upgrade.