### PR TITLE
Clarify reboot instructions during update workflow (SOC-11386)

### DIFF
--- a/xml/operations-maintenance-update_maintenance.xml
+++ b/xml/operations-maintenance-update_maintenance.xml
@@ -214,8 +214,11 @@ package updates] ***</screen>
 --limit  <replaceable>TARGET_NODE_NAME</replaceable> \
 -e zypper_update_include_reboot_patches=true</screen>
       <para>
-       Run <filename>ardana-reboot.yml</filename>. This will cause cloud
-       service interruption.
+	If the output of <filename>ardana-update-pkgs.yml</filename> indicates 
+	that a reboot is required, run <filename>ardana-reboot.yml</filename> 
+	<emphasis>after</emphasis> completing the <filename>ardana-update.yml</filename> 
+	step below. Running <filename>ardana-reboot.yml</filename>
+	will cause cloud service interruption.
       </para>
       <note>
        <para>


### PR DESCRIPTION
specified that the reboot should only take place after the update playbook has been run. 

![clmupdate_update](https://user-images.githubusercontent.com/23247873/92271342-7ac10380-ee9c-11ea-85a0-74fb7bf4bd18.png)
