### PR TITLE
Fix table issues in bk_openstack_admin.xml

### DIFF
--- a/xml/admin-neutron-config-qos.xml
+++ b/xml/admin-neutron-config-qos.xml
@@ -71,6 +71,8 @@
             <entry>
               <para>Egress</para>
             </entry>
+            <entry></entry>
+            <entry></entry>
           </row>
           <row>
             <entry>
@@ -82,6 +84,7 @@
             <entry>
               <para>Egress</para>
             </entry>
+            <entry></entry>
           </row>
         </tbody>
       </tgroup>

--- a/xml/bk_openstack_admin.xml
+++ b/xml/bk_openstack_admin.xml
@@ -30599,33 +30599,28 @@ the volume backup</para>
         <title>OpenStack Object Storage</title>
         <para>The following meters are collected for OpenStack Object Storage:</para>
         <informaltable>
-          <tgroup cols="11">
+          <tgroup cols="6">
             <colspec colname="c1" colwidth="26.9*"/>
             <colspec colname="c2" colwidth="1.5*"/>
             <colspec colname="c3" colwidth="7.5*"/>
             <colspec colname="c4" colwidth="1.5*"/>
             <colspec colname="c5" colwidth="6.0*"/>
             <colspec colname="c6" colwidth="3.0*"/>
-            <colspec colname="c7" colwidth="10.4*"/>
-            <colspec colname="c8" colwidth="6.0*"/>
-            <colspec colname="c9" colwidth="11.9*"/>
-            <colspec colname="c10" colwidth="0.0*"/>
-            <colspec colname="c11" colwidth="25.4*"/>
             <thead>
               <row>
-                <entry namest="c1" nameend="c2">
+                <entry>
                   <para>Name</para>
                 </entry>
-                <entry namest="c1" nameend="c2">
+                <entry>
                   <para>Type</para>
                 </entry>
-                <entry namest="c1" nameend="c2">
+                <entry>
                   <para>Unit</para>
                 </entry>
-                <entry namest="c1" nameend="c2">
+                <entry>
                   <para>Resource</para>
                 </entry>
-                <entry namest="c1" nameend="c2">
+                <entry>
                   <para>Origin</para>
                 </entry>
                 <entry>
@@ -30635,26 +30630,26 @@ the volume backup</para>
             </thead>
             <tbody>
               <row>
-                <entry namest="c1" nameend="c11">
+                <entry namest="c1" nameend="c6">
                   <para>
                     <emphasis role="bold">Meters added in the Icehouse release or earlier</emphasis>
                   </para>
                 </entry>
               </row>
               <row>
-                <entry namest="c1" nameend="c2">
+                <entry>
                   <para>storage.objects</para>
                 </entry>
-                <entry namest="c1" nameend="c2">
+                <entry>
                   <para>Gauge</para>
                 </entry>
-                <entry namest="c1" nameend="c2">
+                <entry>
                   <para>object</para>
                 </entry>
-                <entry namest="c1" nameend="c2">
+                <entry>
                   <para>storage ID</para>
                 </entry>
-                <entry namest="c1" nameend="c2">
+                <entry>
                   <para>Pollster</para>
                 </entry>
                 <entry>
@@ -30662,19 +30657,19 @@ the volume backup</para>
                 </entry>
               </row>
               <row>
-                <entry namest="c1" nameend="c2">
+                <entry>
                   <para>storage.objects.size</para>
                 </entry>
-                <entry namest="c1" nameend="c2">
+                <entry>
                   <para>Gauge</para>
                 </entry>
-                <entry namest="c1" nameend="c2">
+                <entry>
                   <para>B</para>
                 </entry>
-                <entry namest="c1" nameend="c2">
+                <entry>
                   <para>storage ID</para>
                 </entry>
-                <entry namest="c1" nameend="c2">
+                <entry>
                   <para>Pollster</para>
                 </entry>
                 <entry>
@@ -30682,19 +30677,19 @@ the volume backup</para>
                 </entry>
               </row>
               <row>
-                <entry namest="c1" nameend="c2">
+                <entry>
                   <para>storage.objects.containers</para>
                 </entry>
-                <entry namest="c1" nameend="c2">
+                <entry>
                   <para>Gauge</para>
                 </entry>
-                <entry namest="c1" nameend="c2">
+                <entry>
                   <para>container</para>
                 </entry>
-                <entry namest="c1" nameend="c2">
+                <entry>
                   <para>storage ID</para>
                 </entry>
-                <entry namest="c1" nameend="c2">
+                <entry>
                   <para>Pollster</para>
                 </entry>
                 <entry>
@@ -30702,19 +30697,19 @@ the volume backup</para>
                 </entry>
               </row>
               <row>
-                <entry namest="c1" nameend="c2">
+                <entry>
                   <para>storage.objects.incoming.bytes</para>
                 </entry>
-                <entry namest="c1" nameend="c2">
+                <entry>
                   <para>Delta</para>
                 </entry>
-                <entry namest="c1" nameend="c2">
+                <entry>
                   <para>B</para>
                 </entry>
-                <entry namest="c1" nameend="c2">
+                <entry>
                   <para>storage ID</para>
                 </entry>
-                <entry namest="c1" nameend="c2">
+                <entry>
                   <para>Notification</para>
                 </entry>
                 <entry>
@@ -30722,19 +30717,19 @@ the volume backup</para>
                 </entry>
               </row>
               <row>
-                <entry namest="c1" nameend="c2">
+                <entry>
                   <para>storage.objects.outgoing.bytes</para>
                 </entry>
-                <entry namest="c1" nameend="c2">
+                <entry>
                   <para>Delta</para>
                 </entry>
-                <entry namest="c1" nameend="c2">
+                <entry>
                   <para>B</para>
                 </entry>
-                <entry namest="c1" nameend="c2">
+                <entry>
                   <para>storage ID</para>
                 </entry>
-                <entry namest="c1" nameend="c2">
+                <entry>
                   <para>Notification</para>
                 </entry>
                 <entry>
@@ -30742,19 +30737,19 @@ the volume backup</para>
                 </entry>
               </row>
               <row>
-                <entry namest="c1" nameend="c2">
+                <entry>
                   <para>storage.api.request</para>
                 </entry>
-                <entry namest="c1" nameend="c2">
+                <entry>
                   <para>Delta</para>
                 </entry>
-                <entry namest="c1" nameend="c2">
+                <entry>
                   <para>request</para>
                 </entry>
-                <entry namest="c1" nameend="c2">
+                <entry>
                   <para>storage ID</para>
                 </entry>
-                <entry namest="c1" nameend="c2">
+                <entry>
                   <para>Notification</para>
                 </entry>
                 <entry>
@@ -30763,19 +30758,19 @@ OpenStack Object Storage</para>
                 </entry>
               </row>
               <row>
-                <entry namest="c1" nameend="c2">
+                <entry>
                   <para>storage.containers.objects</para>
                 </entry>
-                <entry namest="c1" nameend="c2">
+                <entry>
                   <para>Gauge</para>
                 </entry>
-                <entry namest="c1" nameend="c2">
+                <entry>
                   <para>object</para>
                 </entry>
-                <entry namest="c1" nameend="c2">
+                <entry>
                   <para>storage ID/container</para>
                 </entry>
-                <entry namest="c1" nameend="c2">
+                <entry>
                   <para>Pollster</para>
                 </entry>
                 <entry>
@@ -30783,19 +30778,19 @@ OpenStack Object Storage</para>
                 </entry>
               </row>
               <row>
-                <entry namest="c1" nameend="c2">
+                <entry>
                   <para>storage.containers.objects.size</para>
                 </entry>
-                <entry namest="c1" nameend="c2">
+                <entry>
                   <para>Gauge</para>
                 </entry>
-                <entry namest="c1" nameend="c2">
+                <entry>
                   <para>B</para>
                 </entry>
-                <entry namest="c1" nameend="c2">
+                <entry>
                   <para>storage ID/container</para>
                 </entry>
-                <entry namest="c1" nameend="c2">
+                <entry>
                   <para>Pollster</para>
                 </entry>
                 <entry>
@@ -30803,31 +30798,31 @@ OpenStack Object Storage</para>
                 </entry>
               </row>
               <row>
-                <entry namest="c1" nameend="c11">
+                <entry namest="c1" nameend="c6">
                   <para>
                     <emphasis role="bold">meters deprecated in the Kilo release</emphasis>
                   </para>
                 </entry>
               </row>
               <row>
-                <entry namest="c1" nameend="c11">
+                <entry namest="c1" nameend="c6">
                   <para>storage.objects.in| Delta | B     | storage ID | Notific| Number of incomcoming.bytes       |       |       |            | ation   | ing bytes</para>
                 </entry>
               </row>
               <row>
-                <entry namest="c1" nameend="c2">
+                <entry>
                   <para>storage.objects.outgoing.bytes</para>
                 </entry>
-                <entry namest="c1" nameend="c2">
+                <entry>
                   <para>Delta</para>
                 </entry>
-                <entry namest="c1" nameend="c2">
+                <entry>
                   <para>B</para>
                 </entry>
-                <entry namest="c1" nameend="c2">
+                <entry>
                   <para>storage ID</para>
                 </entry>
-                <entry namest="c1" nameend="c2">
+                <entry>
                   <para>Notification</para>
                 </entry>
                 <entry>
@@ -30835,19 +30830,19 @@ OpenStack Object Storage</para>
                 </entry>
               </row>
               <row>
-                <entry namest="c1" nameend="c2">
+                <entry>
                   <para>storage.api.request</para>
                 </entry>
-                <entry namest="c1" nameend="c2">
+                <entry>
                   <para>Delta</para>
                 </entry>
-                <entry namest="c1" nameend="c2">
+                <entry>
                   <para>request</para>
                 </entry>
-                <entry namest="c1" nameend="c2">
+                <entry>
                   <para>storage ID</para>
                 </entry>
-                <entry namest="c1" nameend="c2">
+                <entry>
                   <para>Notification</para>
                 </entry>
                 <entry>
@@ -31046,32 +31041,28 @@ needs approximately 30 minutes to generate the usage logs.</para>
         <title>OpenStack Identity</title>
         <para>The following meters are collected for OpenStack Identity:</para>
         <informaltable>
-          <tgroup cols="10">
+          <tgroup cols="6">
             <colspec colname="c1" colwidth="26.5*"/>
             <colspec colname="c2" colwidth="0.0*"/>
             <colspec colname="c3" colwidth="8.8*"/>
             <colspec colname="c4" colwidth="8.8*"/>
             <colspec colname="c5" colwidth="1.5*"/>
             <colspec colname="c6" colwidth="11.8*"/>
-            <colspec colname="c7" colwidth="2.9*"/>
-            <colspec colname="c8" colwidth="14.7*"/>
-            <colspec colname="c9" colwidth="0.0*"/>
-            <colspec colname="c10" colwidth="25.0*"/>
             <thead>
               <row>
-                <entry namest="c1" nameend="c2">
+                <entry>
                   <para>Name</para>
                 </entry>
                 <entry>
                   <para>Type</para>
                 </entry>
-                <entry namest="c1" nameend="c2">
+                <entry>
                   <para>Unit</para>
                 </entry>
-                <entry namest="c1" nameend="c2">
+                <entry>
                   <para>Resource</para>
                 </entry>
-                <entry namest="c1" nameend="c2">
+                <entry>
                   <para>Origin</para>
                 </entry>
                 <entry>
@@ -31081,26 +31072,26 @@ needs approximately 30 minutes to generate the usage logs.</para>
             </thead>
             <tbody>
               <row>
-                <entry namest="c1" nameend="c10">
+                <entry namest="c1" nameend="c6">
                   <para>
                     <emphasis role="bold">Meters added in the Juno release</emphasis>
                   </para>
                 </entry>
               </row>
               <row>
-                <entry namest="c1" nameend="c2">
+                <entry>
                   <para>identity.authenticate.success</para>
                 </entry>
                 <entry>
                   <para>Delta</para>
                 </entry>
-                <entry namest="c1" nameend="c2">
+                <entry>
                   <para>user</para>
                 </entry>
-                <entry namest="c1" nameend="c2">
+                <entry>
                   <para>user ID</para>
                 </entry>
-                <entry namest="c1" nameend="c2">
+                <entry>
                   <para>Notification</para>
                 </entry>
                 <entry>
@@ -31108,19 +31099,19 @@ needs approximately 30 minutes to generate the usage logs.</para>
                 </entry>
               </row>
               <row>
-                <entry namest="c1" nameend="c2">
+                <entry>
                   <para>identity.authenticate.pending</para>
                 </entry>
                 <entry>
                   <para>Delta</para>
                 </entry>
-                <entry namest="c1" nameend="c2">
+                <entry>
                   <para>user</para>
                 </entry>
-                <entry namest="c1" nameend="c2">
+                <entry>
                   <para>user ID</para>
                 </entry>
-                <entry namest="c1" nameend="c2">
+                <entry>
                   <para>Notification</para>
                 </entry>
                 <entry>
@@ -31128,19 +31119,19 @@ needs approximately 30 minutes to generate the usage logs.</para>
                 </entry>
               </row>
               <row>
-                <entry namest="c1" nameend="c2">
+                <entry>
                   <para>identity.authenticate.failure</para>
                 </entry>
                 <entry>
                   <para>Delta</para>
                 </entry>
-                <entry namest="c1" nameend="c2">
+                <entry>
                   <para>user</para>
                 </entry>
-                <entry namest="c1" nameend="c2">
+                <entry>
                   <para>user ID</para>
                 </entry>
-                <entry namest="c1" nameend="c2">
+                <entry>
                   <para>Notification</para>
                 </entry>
                 <entry>
@@ -31149,19 +31140,19 @@ authenticate</para>
                 </entry>
               </row>
               <row>
-                <entry namest="c1" nameend="c2">
+                <entry>
                   <para>identity.user.created</para>
                 </entry>
                 <entry>
                   <para>Delta</para>
                 </entry>
-                <entry namest="c1" nameend="c2">
+                <entry>
                   <para>user</para>
                 </entry>
-                <entry namest="c1" nameend="c2">
+                <entry>
                   <para>user ID</para>
                 </entry>
-                <entry namest="c1" nameend="c2">
+                <entry>
                   <para>Notification</para>
                 </entry>
                 <entry>
@@ -31169,19 +31160,19 @@ authenticate</para>
                 </entry>
               </row>
               <row>
-                <entry namest="c1" nameend="c2">
+                <entry>
                   <para>identity.user.deleted</para>
                 </entry>
                 <entry>
                   <para>Delta</para>
                 </entry>
-                <entry namest="c1" nameend="c2">
+                <entry>
                   <para>user</para>
                 </entry>
-                <entry namest="c1" nameend="c2">
+                <entry>
                   <para>user ID</para>
                 </entry>
-                <entry namest="c1" nameend="c2">
+                <entry>
                   <para>Notification</para>
                 </entry>
                 <entry>
@@ -31189,19 +31180,19 @@ authenticate</para>
                 </entry>
               </row>
               <row>
-                <entry namest="c1" nameend="c2">
+                <entry>
                   <para>identity.user.updated</para>
                 </entry>
                 <entry>
                   <para>Delta</para>
                 </entry>
-                <entry namest="c1" nameend="c2">
+                <entry>
                   <para>user</para>
                 </entry>
-                <entry namest="c1" nameend="c2">
+                <entry>
                   <para>user ID</para>
                 </entry>
-                <entry namest="c1" nameend="c2">
+                <entry>
                   <para>Notification</para>
                 </entry>
                 <entry>
@@ -31209,19 +31200,19 @@ authenticate</para>
                 </entry>
               </row>
               <row>
-                <entry namest="c1" nameend="c2">
+                <entry>
                   <para>identity.group.created</para>
                 </entry>
                 <entry>
                   <para>Delta</para>
                 </entry>
-                <entry namest="c1" nameend="c2">
+                <entry>
                   <para>group</para>
                 </entry>
-                <entry namest="c1" nameend="c2">
+                <entry>
                   <para>group ID</para>
                 </entry>
-                <entry namest="c1" nameend="c2">
+                <entry>
                   <para>Notification</para>
                 </entry>
                 <entry>
@@ -31229,19 +31220,19 @@ authenticate</para>
                 </entry>
               </row>
               <row>
-                <entry namest="c1" nameend="c2">
+                <entry>
                   <para>identity.group.deleted</para>
                 </entry>
                 <entry>
                   <para>Delta</para>
                 </entry>
-                <entry namest="c1" nameend="c2">
+                <entry>
                   <para>group</para>
                 </entry>
-                <entry namest="c1" nameend="c2">
+                <entry>
                   <para>group ID</para>
                 </entry>
-                <entry namest="c1" nameend="c2">
+                <entry>
                   <para>Notification</para>
                 </entry>
                 <entry>
@@ -31249,19 +31240,19 @@ authenticate</para>
                 </entry>
               </row>
               <row>
-                <entry namest="c1" nameend="c2">
+                <entry>
                   <para>identity.group.updated</para>
                 </entry>
                 <entry>
                   <para>Delta</para>
                 </entry>
-                <entry namest="c1" nameend="c2">
+                <entry>
                   <para>group</para>
                 </entry>
-                <entry namest="c1" nameend="c2">
+                <entry>
                   <para>group ID</para>
                 </entry>
-                <entry namest="c1" nameend="c2">
+                <entry>
                   <para>Notification</para>
                 </entry>
                 <entry>
@@ -31269,19 +31260,19 @@ authenticate</para>
                 </entry>
               </row>
               <row>
-                <entry namest="c1" nameend="c2">
+                <entry>
                   <para>identity.role.created</para>
                 </entry>
                 <entry>
                   <para>Delta</para>
                 </entry>
-                <entry namest="c1" nameend="c2">
+                <entry>
                   <para>role</para>
                 </entry>
-                <entry namest="c1" nameend="c2">
+                <entry>
                   <para>role ID</para>
                 </entry>
-                <entry namest="c1" nameend="c2">
+                <entry>
                   <para>Notification</para>
                 </entry>
                 <entry>
@@ -31289,19 +31280,19 @@ authenticate</para>
                 </entry>
               </row>
               <row>
-                <entry namest="c1" nameend="c2">
+                <entry>
                   <para>identity.role.deleted</para>
                 </entry>
                 <entry>
                   <para>Delta</para>
                 </entry>
-                <entry namest="c1" nameend="c2">
+                <entry>
                   <para>role</para>
                 </entry>
-                <entry namest="c1" nameend="c2">
+                <entry>
                   <para>role ID</para>
                 </entry>
-                <entry namest="c1" nameend="c2">
+                <entry>
                   <para>Notification</para>
                 </entry>
                 <entry>
@@ -31309,19 +31300,19 @@ authenticate</para>
                 </entry>
               </row>
               <row>
-                <entry namest="c1" nameend="c2">
+                <entry>
                   <para>identity.role.updated</para>
                 </entry>
                 <entry>
                   <para>Delta</para>
                 </entry>
-                <entry namest="c1" nameend="c2">
+                <entry>
                   <para>role</para>
                 </entry>
-                <entry namest="c1" nameend="c2">
+                <entry>
                   <para>role ID</para>
                 </entry>
-                <entry namest="c1" nameend="c2">
+                <entry>
                   <para>Notification</para>
                 </entry>
                 <entry>
@@ -31329,19 +31320,19 @@ authenticate</para>
                 </entry>
               </row>
               <row>
-                <entry namest="c1" nameend="c2">
+                <entry>
                   <para>identity.project.created</para>
                 </entry>
                 <entry>
                   <para>Delta</para>
                 </entry>
-                <entry namest="c1" nameend="c2">
+                <entry>
                   <para>project</para>
                 </entry>
-                <entry namest="c1" nameend="c2">
+                <entry>
                   <para>project ID</para>
                 </entry>
-                <entry namest="c1" nameend="c2">
+                <entry>
                   <para>Notification</para>
                 </entry>
                 <entry>
@@ -31349,19 +31340,19 @@ authenticate</para>
                 </entry>
               </row>
               <row>
-                <entry namest="c1" nameend="c2">
+                <entry>
                   <para>identity.project.deleted</para>
                 </entry>
                 <entry>
                   <para>Delta</para>
                 </entry>
-                <entry namest="c1" nameend="c2">
+                <entry>
                   <para>project</para>
                 </entry>
-                <entry namest="c1" nameend="c2">
+                <entry>
                   <para>project ID</para>
                 </entry>
-                <entry namest="c1" nameend="c2">
+                <entry>
                   <para>Notification</para>
                 </entry>
                 <entry>
@@ -31369,19 +31360,19 @@ authenticate</para>
                 </entry>
               </row>
               <row>
-                <entry namest="c1" nameend="c2">
+                <entry>
                   <para>identity.project.updated</para>
                 </entry>
                 <entry>
                   <para>Delta</para>
                 </entry>
-                <entry namest="c1" nameend="c2">
+                <entry>
                   <para>project</para>
                 </entry>
-                <entry namest="c1" nameend="c2">
+                <entry>
                   <para>project ID</para>
                 </entry>
-                <entry namest="c1" nameend="c2">
+                <entry>
                   <para>Notification</para>
                 </entry>
                 <entry>
@@ -31389,19 +31380,19 @@ authenticate</para>
                 </entry>
               </row>
               <row>
-                <entry namest="c1" nameend="c2">
+                <entry>
                   <para>identity.trust.created</para>
                 </entry>
                 <entry>
                   <para>Delta</para>
                 </entry>
-                <entry namest="c1" nameend="c2">
+                <entry>
                   <para>trust</para>
                 </entry>
-                <entry namest="c1" nameend="c2">
+                <entry>
                   <para>trust ID</para>
                 </entry>
-                <entry namest="c1" nameend="c2">
+                <entry>
                   <para>Notification</para>
                 </entry>
                 <entry>
@@ -31409,19 +31400,19 @@ authenticate</para>
                 </entry>
               </row>
               <row>
-                <entry namest="c1" nameend="c2">
+                <entry>
                   <para>identity.trust.deleted</para>
                 </entry>
                 <entry>
                   <para>Delta</para>
                 </entry>
-                <entry namest="c1" nameend="c2">
+                <entry>
                   <para>trust</para>
                 </entry>
-                <entry namest="c1" nameend="c2">
+                <entry>
                   <para>trust ID</para>
                 </entry>
-                <entry namest="c1" nameend="c2">
+                <entry>
                   <para>Notification</para>
                 </entry>
                 <entry>
@@ -31429,26 +31420,26 @@ authenticate</para>
                 </entry>
               </row>
               <row>
-                <entry namest="c1" nameend="c10">
+                <entry namest="c1" nameend="c6">
                   <para>
                     <emphasis role="bold">Meters added in the Kilo release</emphasis>
                   </para>
                 </entry>
               </row>
               <row>
-                <entry namest="c1" nameend="c2">
+                <entry>
                   <para>identity.role_assignment.created</para>
                 </entry>
                 <entry>
                   <para>Delta</para>
                 </entry>
-                <entry namest="c1" nameend="c2">
+                <entry>
                   <para>role_assignment</para>
                 </entry>
-                <entry namest="c1" nameend="c2">
+                <entry>
                   <para>role ID</para>
                 </entry>
-                <entry namest="c1" nameend="c2">
+                <entry>
                   <para>Notification</para>
                 </entry>
                 <entry>
@@ -31458,19 +31449,19 @@ target</para>
                 </entry>
               </row>
               <row>
-                <entry namest="c1" nameend="c2">
+                <entry>
                   <para>identity.role_assignment.deleted</para>
                 </entry>
                 <entry>
                   <para>Delta</para>
                 </entry>
-                <entry namest="c1" nameend="c2">
+                <entry>
                   <para>role_assignment</para>
                 </entry>
-                <entry namest="c1" nameend="c2">
+                <entry>
                   <para>role ID</para>
                 </entry>
-                <entry namest="c1" nameend="c2">
+                <entry>
                   <para>Notification</para>
                 </entry>
                 <entry>
@@ -31480,7 +31471,7 @@ on a target</para>
                 </entry>
               </row>
               <row>
-                <entry namest="c1" nameend="c10">
+                <entry namest="c1" nameend="c6">
                   <para>
                     <emphasis role="bold">All meters thoroughly deprecated in the liberty release</emphasis>
                   </para>
@@ -33746,43 +33737,38 @@ firewall rule</para>
         <title>Orchestration service</title>
         <para>The following meters are collected for the Orchestration service:</para>
         <informaltable>
-          <tgroup cols="11">
+          <tgroup cols="6">
             <colspec colname="c1" colwidth="23.9*"/>
             <colspec colname="c2" colwidth="1.5*"/>
             <colspec colname="c3" colwidth="7.5*"/>
             <colspec colname="c4" colwidth="1.5*"/>
             <colspec colname="c5" colwidth="6.0*"/>
             <colspec colname="c6" colwidth="1.5*"/>
-            <colspec colname="c7" colwidth="11.9*"/>
-            <colspec colname="c8" colwidth="1.5*"/>
-            <colspec colname="c9" colwidth="17.9*"/>
-            <colspec colname="c10" colwidth="0.0*"/>
-            <colspec colname="c11" colwidth="26.9*"/>
             <thead>
               <row>
                 <entry>
                   <para>Name</para>
                 </entry>
-                <entry namest="c1" nameend="c2">
+                <entry>
                   <para>Type</para>
                 </entry>
-                <entry namest="c1" nameend="c2">
+                <entry>
                   <para>Unit</para>
                 </entry>
-                <entry namest="c1" nameend="c2">
+                <entry>
                   <para>Resource</para>
                 </entry>
-                <entry namest="c1" nameend="c2">
+                <entry>
                   <para>Origin</para>
                 </entry>
-                <entry namest="c1" nameend="c2">
+                <entry>
                   <para>Note</para>
                 </entry>
               </row>
             </thead>
             <tbody>
               <row>
-                <entry namest="c1" nameend="c11">
+                <entry namest="c1" nameend="c6">
                   <para>
                     <emphasis role="bold">Meters added in the Icehouse release or earlier</emphasis>
                   </para>
@@ -33792,19 +33778,19 @@ firewall rule</para>
                 <entry>
                   <para>stack.create</para>
                 </entry>
-                <entry namest="c1" nameend="c2">
+                <entry>
                   <para>Delta</para>
                 </entry>
-                <entry namest="c1" nameend="c2">
+                <entry>
                   <para>stack</para>
                 </entry>
-                <entry namest="c1" nameend="c2">
+                <entry>
                   <para>stack ID</para>
                 </entry>
-                <entry namest="c1" nameend="c2">
+                <entry>
                   <para>Notification</para>
                 </entry>
-                <entry namest="c1" nameend="c2">
+                <entry>
                   <para>Stack was successfully created</para>
                 </entry>
               </row>
@@ -33812,19 +33798,19 @@ firewall rule</para>
                 <entry>
                   <para>stack.update</para>
                 </entry>
-                <entry namest="c1" nameend="c2">
+                <entry>
                   <para>Delta</para>
                 </entry>
-                <entry namest="c1" nameend="c2">
+                <entry>
                   <para>stack</para>
                 </entry>
-                <entry namest="c1" nameend="c2">
+                <entry>
                   <para>stack ID</para>
                 </entry>
-                <entry namest="c1" nameend="c2">
+                <entry>
                   <para>Notification</para>
                 </entry>
-                <entry namest="c1" nameend="c2">
+                <entry>
                   <para>Stack was successfully updated</para>
                 </entry>
               </row>
@@ -33832,19 +33818,19 @@ firewall rule</para>
                 <entry>
                   <para>stack.delete</para>
                 </entry>
-                <entry namest="c1" nameend="c2">
+                <entry>
                   <para>Delta</para>
                 </entry>
-                <entry namest="c1" nameend="c2">
+                <entry>
                   <para>stack</para>
                 </entry>
-                <entry namest="c1" nameend="c2">
+                <entry>
                   <para>stack ID</para>
                 </entry>
-                <entry namest="c1" nameend="c2">
+                <entry>
                   <para>Notification</para>
                 </entry>
-                <entry namest="c1" nameend="c2">
+                <entry>
                   <para>Stack was successfully deleted</para>
                 </entry>
               </row>
@@ -33852,19 +33838,19 @@ firewall rule</para>
                 <entry>
                   <para>stack.resume</para>
                 </entry>
-                <entry namest="c1" nameend="c2">
+                <entry>
                   <para>Delta</para>
                 </entry>
-                <entry namest="c1" nameend="c2">
+                <entry>
                   <para>stack</para>
                 </entry>
-                <entry namest="c1" nameend="c2">
+                <entry>
                   <para>stack ID</para>
                 </entry>
-                <entry namest="c1" nameend="c2">
+                <entry>
                   <para>Notification</para>
                 </entry>
-                <entry namest="c1" nameend="c2">
+                <entry>
                   <para>Stack was successfully resumed</para>
                 </entry>
               </row>
@@ -33872,24 +33858,24 @@ firewall rule</para>
                 <entry>
                   <para>stack.suspend</para>
                 </entry>
-                <entry namest="c1" nameend="c2">
+                <entry>
                   <para>Delta</para>
                 </entry>
-                <entry namest="c1" nameend="c2">
+                <entry>
                   <para>stack</para>
                 </entry>
-                <entry namest="c1" nameend="c2">
+                <entry>
                   <para>stack ID</para>
                 </entry>
-                <entry namest="c1" nameend="c2">
+                <entry>
                   <para>Notification</para>
                 </entry>
-                <entry namest="c1" nameend="c2">
+                <entry>
                   <para>Stack was successfully suspended</para>
                 </entry>
               </row>
               <row>
-                <entry namest="c1" nameend="c11">
+                <entry namest="c1" nameend="c6">
                   <para>
                     <emphasis role="bold">All meters thoroughly deprecated in the Liberty release</emphasis>
                   </para>
@@ -33904,33 +33890,28 @@ firewall rule</para>
         <para>The following meters are collected for the Data processing service for
 OpenStack:</para>
         <informaltable>
-          <tgroup cols="11">
+          <tgroup cols="6">
             <colspec colname="c1" colwidth="23.9*"/>
             <colspec colname="c2" colwidth="1.5*"/>
             <colspec colname="c3" colwidth="7.5*"/>
             <colspec colname="c4" colwidth="1.5*"/>
             <colspec colname="c5" colwidth="9.0*"/>
             <colspec colname="c6" colwidth="0.0*"/>
-            <colspec colname="c7" colwidth="13.4*"/>
-            <colspec colname="c8" colwidth="1.5*"/>
-            <colspec colname="c9" colwidth="16.4*"/>
-            <colspec colname="c10" colwidth="1.5*"/>
-            <colspec colname="c11" colwidth="23.9*"/>
             <thead>
               <row>
                 <entry>
                   <para>Name</para>
                 </entry>
-                <entry namest="c1" nameend="c2">
+                <entry>
                   <para>Type</para>
                 </entry>
-                <entry namest="c1" nameend="c3">
+                <entry>
                   <para>Unit</para>
                 </entry>
-                <entry namest="c1" nameend="c2">
+                <entry>
                   <para>Resource</para>
                 </entry>
-                <entry namest="c1" nameend="c2">
+                <entry>
                   <para>Origin</para>
                 </entry>
                 <entry>
@@ -33940,7 +33921,7 @@ OpenStack:</para>
             </thead>
             <tbody>
               <row>
-                <entry namest="c1" nameend="c11">
+                <entry namest="c1" nameend="c6">
                   <para>
                     <emphasis role="bold">Meters added in the Juno release</emphasis>
                   </para>
@@ -33950,16 +33931,16 @@ OpenStack:</para>
                 <entry>
                   <para>cluster.create</para>
                 </entry>
-                <entry namest="c1" nameend="c2">
+                <entry>
                   <para>Delta</para>
                 </entry>
-                <entry namest="c1" nameend="c3">
+                <entry>
                   <para>cluster</para>
                 </entry>
-                <entry namest="c1" nameend="c2">
+                <entry>
                   <para>cluster ID</para>
                 </entry>
-                <entry namest="c1" nameend="c2">
+                <entry>
                   <para>Notification</para>
                 </entry>
                 <entry>
@@ -33972,16 +33953,16 @@ created</para>
                 <entry>
                   <para>cluster.update</para>
                 </entry>
-                <entry namest="c1" nameend="c2">
+                <entry>
                   <para>Delta</para>
                 </entry>
-                <entry namest="c1" nameend="c3">
+                <entry>
                   <para>cluster</para>
                 </entry>
-                <entry namest="c1" nameend="c2">
+                <entry>
                   <para>cluster ID</para>
                 </entry>
-                <entry namest="c1" nameend="c2">
+                <entry>
                   <para>Notification</para>
                 </entry>
                 <entry>
@@ -33994,16 +33975,16 @@ updated</para>
                 <entry>
                   <para>cluster.delete</para>
                 </entry>
-                <entry namest="c1" nameend="c2">
+                <entry>
                   <para>Delta</para>
                 </entry>
-                <entry namest="c1" nameend="c3">
+                <entry>
                   <para>cluster</para>
                 </entry>
-                <entry namest="c1" nameend="c2">
+                <entry>
                   <para>cluster ID</para>
                 </entry>
-                <entry namest="c1" nameend="c2">
+                <entry>
                   <para>Notification</para>
                 </entry>
                 <entry>
@@ -34013,7 +33994,7 @@ deleted</para>
                 </entry>
               </row>
               <row>
-                <entry namest="c1" nameend="c11">
+                <entry namest="c1" nameend="c6">
                   <para>
                     <emphasis role="bold">All meters thoroughly deprecated in the Liberty release</emphasis>
                   </para>

--- a/xml/depl_conf_admin_repos.xml
+++ b/xml/depl_conf_admin_repos.xml
@@ -582,6 +582,7 @@ The following tables show the locations of all repositories that can be used for
        Mandatory Repositories
       </para>
      </entry>
+     <entry/>
     </row>
     <row>
      <entry>
@@ -820,8 +821,8 @@ The following tables show the locations of all repositories that can be used for
  <table xml:id="tab-depl-adm-conf-local-repos">
   <title>Default Repository Locations on the &admserv;</title>
   <tgroup cols="2">
-   <colspec colnum="1" colname="1" colwidth="25*"/>
-   <colspec colnum="2" colname="2" colwidth="75*"/>
+   <colspec colnum="1" colname="c1" colwidth="25*"/>
+   <colspec colnum="2" colname="c2" colwidth="75*"/>
    <thead>
     <row>
      <entry>
@@ -838,7 +839,7 @@ The following tables show the locations of all repositories that can be used for
    </thead>
    <tbody>
     <row>
-     <entry namest="1" nameend="2">
+     <entry namest="c1" nameend="c2">
       <para>
        Mandatory Repositories
       </para>
@@ -893,7 +894,7 @@ The following tables show the locations of all repositories that can be used for
      </entry>
     </row>
     <row>
-     <entry namest="1" nameend="2">
+     <entry namest="c1" nameend="c2">
       <para>
        Optional Repositories
       </para>

--- a/xml/depl_poc.xml
+++ b/xml/depl_poc.xml
@@ -420,14 +420,14 @@ The sizing recommendation includes an Admin Node (bare metal or VM), Controller 
             <row>
               <entry><para>DHCP, DNS</para></entry>
               <entry><para>Isolated within administrator network</para></entry>
-              <entry><para></para>
-              </entry>
+              <entry><para></para></entry>
+              <entry/>
             </row>
             <row>
               <entry><para>HA</para></entry>
               <entry><para>3 Control Nodes</para></entry>
-              <entry><para></para>
-              </entry>
+              <entry/>
+              <entry/>
             </row>
             </tbody>
            </tgroup>

--- a/xml/installation-installation-preinstall_checklist.xml
+++ b/xml/installation-installation-preinstall_checklist.xml
@@ -36,8 +36,11 @@
     <tbody>
      <row>
       <entry/>
-      <entry vendor="hpe">
+      <entry>
+       <para vendor="hpe">
        Setup the iLO Advanced license in the iLO configuration
+       </para>
+       <para vendor="suse"/>
       </entry>
      </row>
      <row>
@@ -693,7 +696,7 @@
     the ARP timeout on the TOR switches will help.
    </para>
   </note>
-  <table xml:id="cp-1" colsep="1" rowsep="1">
+  <table xml:id="cp-1">
    <title>Control Plane 1</title>
    <tgroup cols="3">
     <colspec colname="c1" colnum="1" colwidth="1*"/>
@@ -742,7 +745,7 @@ logical drives with that amount of space)
     </tbody>
    </tgroup>
   </table>
-  <table xml:id="cp-2" colsep="1" rowsep="1">
+  <table xml:id="cp-2">
    <title>Control Plane 2</title>
    <tgroup cols="3">
     <colspec colname="c1" colnum="1" colwidth="1*"/>
@@ -792,7 +795,7 @@ logical drives with that amount of space)
     </tbody>
    </tgroup>
   </table>
-  <table xml:id="cp-3" colsep="1" rowsep="1">
+  <table xml:id="cp-3">
    <title>Control Plane 3</title>
    <tgroup cols="3">
     <colspec colname="c1" colnum="1" colwidth="1*"/>

--- a/xml/operations-maintenance-controller-full_recovery_test.xml
+++ b/xml/operations-maintenance-controller-full_recovery_test.xml
@@ -408,11 +408,9 @@ freezer_ssh_private_key: |
 <para>In the default installation Interval for various backup jobs are:</para>
 <table xml:id="FreezerBackupJobScheduleTable" colsep="1" rowsep="1">
   <title>Default Interval for Freezer backup jobs</title>
-  <tgroup cols="4">
+  <tgroup cols="2">
    <colspec colname="c1" colnum="1" colwidth="1.0*"/>
    <colspec colname="c2" colnum="2" colwidth="1.0*"/>
-   <colspec colname="c3" colnum="3" colwidth="1.0*"/>
-   <colspec colname="c4" colnum="4" colwidth="1.0*"/>
    <thead>
     <row>
      <entry>Job Name</entry>


### PR DESCRIPTION
This PR contains fixes for tables in `bk_openstack_admin.xml`
    
* Remove too many `<colspecs/>` elements
* Fix `tgroup/@cols` attribute
* Remove unneccessary `namest` and `nameend` attributes in entry
* Change nameend attribute to match `tgroup/@cols` attribute
    
TODO: Adapt `colspec/@colwidth` in some tables