### PR TITLE
Soc 11356crow

### DIFF
--- a/xml/depl_nodes.xml
+++ b/xml/depl_nodes.xml
@@ -8382,13 +8382,6 @@ radosgw_urls:
      <row>
       <entry>
        <para>
-        <systemitem class="service">openstack-nova-consoleauth</systemitem>
-       </para>
-      </entry>
-     </row>
-     <row>
-      <entry>
-       <para>
         <systemitem class="service">openstack-nova-novncproxy</systemitem>
        </para>
       </entry>

--- a/xml/depl_nodes.xml
+++ b/xml/depl_nodes.xml
@@ -8354,7 +8354,7 @@ radosgw_urls:
      </row>
 <!-- nova-controller -->
      <row>
-      <entry morerows="6">
+      <entry morerows="5">
        <para>
         nova-controller
        </para>


### PR DESCRIPTION
Removed nova-consoleauth entry from deploy nodes list from crowbar documentation as per - soc-11356 ticket.