### PR TITLE
Clarify reboot instructions during update workflow (SOC-11386)

### DIFF
--- a/xml/operations-maintenance-update_maintenance.xml
+++ b/xml/operations-maintenance-update_maintenance.xml
@@ -278,8 +278,11 @@ package updates] ***</screen>
 --limit  <replaceable>TARGET_NODE_NAME</replaceable> \
 -e zypper_update_include_reboot_patches=true</screen>
       <para>
-       Run <filename>ardana-reboot.yml</filename>. This will cause cloud
-       service interruption.
+	If the output of <filename>ardana-update-pkgs.yml</filename> indicates 
+	that a reboot is required, run <filename>ardana-reboot.yml</filename> 
+	<emphasis>after</emphasis> completing the <filename>ardana-update.yml</filename> 
+	step below. Running <filename>ardana-reboot.yml</filename>
+	will cause cloud service interruption.
       </para>
       <note>
        <para>


### PR DESCRIPTION
![soc-11386-cloud8](https://user-images.githubusercontent.com/23247873/96033043-67e30c80-0e14-11eb-9732-92821bae5c1d.png)

cherry-pick from SOC 9 change at https://github.com/SUSE-Cloud/doc-cloud/pull/1289