### PR TITLE
Note support for SES6 integration with SOC9 CLM (SOC-9238)

### DIFF
--- a/xml/installation-installation-ses_integration.xml
+++ b/xml/installation-installation-ses_integration.xml
@@ -12,8 +12,15 @@
   (SES). Integrating &ses; enables &ceph; to provide RADOS Block Device (RBD),
   block storage, image storage, object storage via RADOS Gateway (RGW),
   and CephFS (file storage) in &productname;. The following documentation
-  outlines integration for &ses; 5 and 5.5.
+  outlines integration for &ses; 5 , 5.5, and 6.0
  </para>
+ <note>
+    <para>Integration with &ses; 6.0 is configured using the same
+    steps as &ses; 5.5 except that salt-api queries authenticating with the 
+    <literal>sharedsecret=</literal> parameter should be updated to use 
+    <literal>password=</literal> 
+  </para>
+ </note>
  <para>
    &ses; 5.5 uses a Salt runner that creates users and pools. Salt generates
    a yaml configuration that is needed to integrate with &cloud;.


### PR DESCRIPTION
Add note that SES6 integration is supported, with a caveat related to Flavio's findings in SOC-9238