### PR TITLE
Add DB and Fernet maintenance tasks to documentation (SOC-9876)

### DIFF
--- a/xml/operations-maintenance-database_maintenance.xml
+++ b/xml/operations-maintenance-database_maintenance.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0"?>
+<?xml-stylesheet href="urn:x-suse:xslt:profiling:docbook51-profile.xsl"
+ type="text/xml"
+ title="Profiling step"?>
+<!DOCTYPE section [
+ <!ENTITY % entities SYSTEM "entity-decl.ent"> %entities;
+]>
+<section xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude"
+ xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="database-maintenance">
+  <title>Periodic OpenStack Maintenance Tasks</title>
+  <para>
+    Heat-manage helps manage Heat specific database operations. The associated
+    database should be periodically purged to save space. The following should
+    be setup as a cron job on the servers where the heat service is running at
+    <literal>/etc/cron.weekly/local-cleanup-heat</literal>
+    with the following content:
+  </para>
+  <screen>
+  #!/bin/bash
+  su heat -s /bin/bash -c "/usr/bin/heat-manage purge_deleted -g days 14" || :
+  </screen>
+  <para>
+     nova-manage db archive_deleted_rows command will move deleted rows
+     from production tables to shadow tables. Including
+     <literal>--until-complete</literal> will make the command run continuously
+     until all deleted rows are archived. It is recommended to setup this task
+     as <literal>/etc/cron.weekly/local-cleanup-nova</literal>
+     on the servers where the nova service is running, with the
+     following content:
+  </para>
+  <screen>
+  #!/bin/bash
+  su nova -s /bin/bash -c "/usr/bin/nova-manage db archive_deleted_rows --until-complete" || :
+  </screen>
+</section> 

--- a/xml/operations-maintenance-system_maintenance.xml
+++ b/xml/operations-maintenance-system_maintenance.xml
@@ -18,4 +18,5 @@
  <xi:include href="operations-maintenance-update_maintenance.xml"/>
  <xi:include href="operations-maintenance-upgrade_maintenance.xml"/>
  <xi:include href="operations-maintenance-deploy-ptf.xml"/>
+ <xi:include href="operations-maintenance-database_maintenance.xml"/>
 </chapter>

--- a/xml/soc-operations-maintenance.xml
+++ b/xml/soc-operations-maintenance.xml
@@ -2027,4 +2027,39 @@
     </procedure>
   </section>
   <xi:include href="networking-octavia-maintenance.xml"/>
+  <xi:include href="operations-maintenance-database_maintenance.xml"/>
+  <section xml:id="sec-depl-maintenance-fernet-tokens">
+   <title>Rotating Fernet Tokens</title>
+   <para>
+     Fernet tokens should be rotated frequently for security purposes.
+     It is recommended to setup this task as a cron job in
+     <literal>/etc/cron.weekly/openstack-keystone-fernet</literal>
+     on the keystone server designated as a master node in a highly
+     available setup with the following content:
+   </para>
+   <screen>
+  #!/bin/bash
+  su keystone -s /bin/bash -c "keystone-manage fernet_rotate"
+
+  /usr/bin/keystone-fernet-keys-push.sh 192.168.81.168; /usr/bin/keystone-fernet-keys-push.sh 192.168.81.169;
+   </screen>
+   <para>
+     The IP addresses in the above example, i.e. 192.168.81.168 and
+     192.168.81.169 are the IP addresses of the other two nodes of a
+     three-node cluster. Be sure to use the correct IP addresses
+     when configuring the cron job. Note that if the master node is offline
+     and a new master is elected, the cron job will need to be removed from
+     the previous master node and then re-created on the new master node.
+     Do not run the fernet_rotate cron job on multiple nodes.
+   </para>
+   <para>
+     For a non-HA setup, the cron job should be configured at
+    <literal>/etc/cron.weekly/openstack-keystone-fernet</literal>
+     on the keystone server as follows:
+   </para>
+   <screen>
+  #!/bin/bash
+  su keystone -s /bin/bash -c "keystone-manage fernet_rotate"
+   </screen>
+  </section>
 </chapter>


### PR DESCRIPTION
![soc-9876-6](https://user-images.githubusercontent.com/23247873/110140468-fb4bb880-7d88-11eb-948b-aab70f86602f.png)

Crowbar on the left with the Fernet instructions. CLM on the right, as Fernet rotating is addressed elsewhere in the docs.