### PR TITLE
Add instructions for checking MySQL cert expiry (SOC-11422)

### DIFF
--- a/xml/security-troubleshooting_tls.xml
+++ b/xml/security-troubleshooting_tls.xml
@@ -104,6 +104,14 @@ ansible-playbook -i hosts/verb_hosts monasca-start.yml</screen>
   <procedure>
    <step>
     <para>
+      Determine if the TLS certificates for MySQL / Percsona have expired.
+    </para>
+    <screen>&prompt.ardana;cd /etc/mysql/
+&prompt.ardana;openssl x509 -noout -enddate -in control-plane-1-mysql-internal-cert.pem
+ Not After : Jul 24 12:24:17 2021 GMT</screen>
+   </step>
+   <step>
+    <para>
      Regenerate the TLS certificates on the deployer.
     </para>
     <screen>&prompt.ardana;cd ~/scratch/ansible/next/hos/ansible


### PR DESCRIPTION
Add instructions for determining if the MySQL/Percona cluster has expired certs
see: https://bugzilla.suse.com/show_bug.cgi?id=1178831

![bz1178831_cloud8](https://user-images.githubusercontent.com/23247873/116295904-73fa4000-a74e-11eb-8660-04a5a0ac1798.png)
