### PR TITLE
Move Monasca to just after keystone in deployment order (SOC-11525)

### DIFF
--- a/xml/depl_nodes.xml
+++ b/xml/depl_nodes.xml
@@ -73,6 +73,12 @@
     <xref linkend="sec-depl-ostack-keystone" xrefstyle="select:title nopage"/>
    </para>
   </listitem>
+<!-- monasca -->
+  <listitem>
+   <para>
+    <xref linkend="sec-depl-ostack-monasca" xrefstyle="select:title nopage"/>
+   </para>
+  </listitem>
   <listitem>
 <!-- swift -->
    <para>
@@ -91,7 +97,7 @@
     <xref linkend="sec-depl-ostack-cinder" xrefstyle="select:title nopage"/>
    </para>
   </listitem>
-<!-- Neutrum -->
+<!-- Neutron -->
   <listitem>
    <para>
     <xref linkend="sec-depl-ostack-neutron" xrefstyle="select:title nopage"/>
@@ -137,12 +143,6 @@
   <listitem>
    <para>
     <xref linkend="sec-depl-ostack-magnum" xrefstyle="select:title nopage"/>
-   </para>
-  </listitem>
-<!-- monasca -->
-  <listitem>
-   <para>
-    <xref linkend="sec-depl-ostack-monasca" xrefstyle="select:title nopage"/>
    </para>
   </listitem>
 <!-- lbaas -->
@@ -2290,6 +2290,850 @@ and admins can see the available options in the barclamp -->
    </sect3>
   </sect2>
 
+ </sect1>
+ <sect1 xml:id="sec-depl-ostack-monasca">
+  <title>Deploying &o_monitor; (Optional)</title>
+
+  <para>
+   &o_monitor; is an open-source monitoring-as-a-service solution that
+   integrates with &ostack;. &o_monitor; is designed for scalability, high
+   performance, and fault tolerance.
+  </para>
+
+  <para>
+   Accessing the <guimenu>Raw</guimenu> interface is not required for
+   day-to-day operation. But as not all &o_monitor; settings are exposed in the
+   &barcl; graphical interface (for example, various performance tuneables), it
+   is recommended to configure &o_monitor; in the <guimenu>Raw</guimenu>
+   mode. Below are the options that can be configured via the
+   <guimenu>Raw</guimenu> interface of the &o_monitor; &barcl;.
+  </para>
+
+  <figure>
+   <title>The &o_monitor; &barcl; Raw Mode</title>
+   <mediaobject>
+    <imageobject role="fo">
+     <imagedata fileref="depl_barclamp_monasca_raw.png" width="100%" format="png"/>
+    </imageobject>
+    <imageobject role="html">
+     <imagedata fileref="depl_barclamp_monasca_raw.png" width="75%" format="png"/>
+    </imageobject>
+   </mediaobject>
+  </figure>
+
+  <bridgehead renderas="sect3"><guimenu>agent: settings for openstack-monasca-agent</guimenu>
+  </bridgehead>
+
+  <variablelist>
+   <varlistentry>
+    <term>keystone</term>
+    <listitem>
+     <para>
+      Contains &o_ident; credentials that the agents use to send metrics. Do
+      not change these options, as they are configured by &crow;.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term>insecure</term>
+    <listitem>
+     <para>
+      Specifies whether SSL certificates are verified when communicating with
+      &o_ident;. If set to <literal>false</literal>, the
+      <literal>ca_file</literal> option must be specified.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term>ca_file</term>
+    <listitem>
+     <para>
+      Specifies the location of a CA certificate that is used for verifying
+      &o_ident;'s SSL certificate.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term>log_dir</term>
+    <listitem>
+     <para>
+      Path for storing log files. The specified path must exist. Do not change
+      the default <filename>/var/log/monasca-agent</filename> path.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term>log_level</term>
+    <listitem>
+     <para>
+      Agent's log level. Limits log messages to the specified level and above.
+      The following levels are available: Error, Warning, Info (default), and
+      Debug.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term>check_frequency</term>
+    <listitem>
+     <para>
+      Interval in seconds between running agents' checks.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term>num_collector_threads</term>
+    <listitem>
+     <para>
+      Number of simultaneous collector threads to run. This refers to the
+      maximum number of different collector plug-ins (for example,
+      <literal>http_check</literal>) that are allowed to run simultaneously. The
+      default value <literal>1</literal> means that plug-ins are run
+      sequentially.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term>pool_full_max_retries</term>
+    <listitem>
+     <para>
+      If a problem with the results from multiple plug-ins results blocks the
+      entire thread pool (as specified by the
+      <systemitem>num_collector_threads</systemitem> parameter), the collector
+      exits, so it can be restarted by the
+      <systemitem>supervisord</systemitem>. The parameter
+      <systemitem>pool_full_max_retries</systemitem> specifies when this event
+      occurs. The collector exits when the defined number of consecutive
+      collection cycles have ended with the thread pool completely full.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term>plugin_collect_time_warn</term>
+    <listitem>
+     <para>
+      Upper limit in seconds for any collection plug-in's run time. A warning
+      is logged if a plug-in runs longer than the specified limit.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term>max_measurement_buffer_size</term>
+    <listitem>
+     <para>
+      Maximum number of measurements to buffer locally if the &o_monitor; API
+      is unreachable. Measurements will be dropped in batches, if the API is
+      still unreachable after the specified number of messages are buffered.
+      The default <literal>-1</literal> value indicates unlimited buffering.
+      Note that a large buffer increases the agent's memory usage.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term>backlog_send_rate</term>
+    <listitem>
+     <para>
+      Maximum number of measurements to send when the local measurement buffer
+      is flushed.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term>amplifier</term>
+    <listitem>
+     <para>
+      Number of extra dimensions to add to metrics sent to the &o_monitor; API.
+      This option is intended for load testing purposes only. Do not enable the
+      option in production! The default <literal>0</literal> value disables the
+      addition of dimensions.
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+
+  <bridgehead renderas="sect3"><guimenu>log_agent: settings for openstack-monasca-log-agent</guimenu>
+  </bridgehead>
+
+  <variablelist>
+   <varlistentry>
+    <term>max_data_size_kb</term>
+    <listitem>
+     <para>
+      Maximum payload size in kilobytes for a request sent to the &o_monitor;
+      log API.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term>num_of_logs</term>
+    <listitem>
+     <para>
+      Maximum number of log entries the log agent sends to the &o_monitor; log
+      API in a single request. Reducing the number increases performance.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term>elapsed_time_sec</term>
+    <listitem>
+     <para>
+      Time interval in seconds between sending logs to the &o_monitor; log API.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term>delay</term>
+    <listitem>
+     <para>
+      Interval in seconds for checking whether
+      <literal>elapsed_time_sec</literal> has been reached.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term>keystone</term>
+    <listitem>
+     <para>
+      &o_ident; credentials the log agents use to send logs to the &o_monitor;
+      log API. Do not change this option manually, as it is configured by
+      &crow;.
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+
+  <bridgehead renderas="sect3"><guimenu>api: Settings for openstack-monasca-api</guimenu>
+  </bridgehead>
+
+  <variablelist>
+   <varlistentry>
+    <term>bind_host</term>
+    <listitem>
+     <para>
+      Interfaces <literal>monasca-api</literal> listens on. Do not change this
+      option, as it is configured by &crow;.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term>processes</term>
+    <listitem>
+     <para>
+      Number of processes to spawn.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term>threads</term>
+    <listitem>
+     <para>
+      Number of WSGI worker threads to spawn.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term>log_level</term>
+    <listitem>
+     <para>
+      Log level for <systemitem>openstack-monasca-api</systemitem>. Limits log
+      messages to the specified level and above. The following levels are
+      available: Critical, Error, Warning, Info (default), Debug, and Trace.
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+
+  <bridgehead renderas="sect3"><guimenu>elasticsearch: server-side settings for elasticsearch</guimenu>
+  </bridgehead>
+
+  <variablelist>
+   <varlistentry>
+    <term>repo_dir</term>
+    <listitem>
+     <para>
+      List of directories for storing &elasticsearch; snapshots. Must be created
+      manually and be writeable by the
+      <systemitem
+          class="username">elasticsearch</systemitem> user.
+      Must contain at least one entry in order for the snapshot functionality
+      to work.
+     </para>
+     <variablelist>
+      <varlistentry>
+       <term>heap_size</term>
+       <listitem>
+        <para>
+         Sets the heap size. We recommend setting heap size at 50% of the
+         available memory, but not more than 31 GB. The default of 4 GB is
+         likely too small and should be increased if possible.
+        </para>
+       </listitem>
+      </varlistentry>
+      <varlistentry>
+       <term>limit_memlock</term>
+       <listitem>
+        <para>
+         The maximum size that may be locked into memory in bytes
+        </para>
+       </listitem>
+      </varlistentry>
+      <varlistentry>
+       <term>limit_nofile</term>
+       <listitem>
+        <para>
+         The maximum number of open file descriptors
+        </para>
+       </listitem>
+      </varlistentry>
+      <varlistentry>
+       <term>limit_nproc</term>
+       <listitem>
+        <para>
+         The maximum number of processes
+        </para>
+       </listitem>
+      </varlistentry>
+      <varlistentry>
+       <term>vm_max_map_count</term>
+       <listitem>
+        <para>
+         The maximum number of memory map areas a process may have.
+        </para>
+       </listitem>
+      </varlistentry>
+     </variablelist>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+  <para>
+   For instructions on creating an &elasticsearch; snapshot, see
+   <xref linkend="backup-recovery"/>.
+  </para>
+
+  <bridgehead renderas="sect3"><guimenu>elasticsearch_curator: settings for
+    elastisearch-curator</guimenu>
+  </bridgehead>
+
+  <para>
+   <systemitem>elasticsearch-curator</systemitem> removes old and large
+   elasticsearch indices. The settings below determine its behavior.
+  </para>
+
+  <variablelist>
+   <varlistentry>
+    <term>delete_after_days</term>
+    <listitem>
+     <para>
+      Time threshold for deleting indices. Indices older the specified number
+      of days are deleted. This parameter is unset by default, so indices are
+      kept indefinitely.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term>delete_after_size</term>
+    <listitem>
+     <para>
+      Maximum size in megabytes of indices. Indices larger than the specified
+      size are deleted. This parameter is unset by default, so indices are kept
+      irrespective of their size.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term>delete_exclude_index</term>
+    <listitem>
+     <para>
+      List of indices to exclude from
+      <systemitem>elasticsearch-curator</systemitem> runs. By default, only the
+      <filename>.kibana</filename> files are excluded.
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+
+  <bridgehead renderas="sect3"><guimenu>kafka: tunables for
+Kafka</guimenu>
+  </bridgehead>
+
+  <variablelist>
+   <varlistentry>
+    <term>log_retention_hours</term>
+    <listitem>
+     <para>
+      Number of hours for retaining log segments in Kafka's on-disk log.
+      Messages older than the specified value are dropped.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term>log_retention_bytes</term>
+    <listitem>
+     <para>
+      Maximum size for Kafka's on-disk log in bytes. If the log grows beyond
+      this size, the oldest log segments are dropped.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term>topics</term>
+    <listitem>
+     <para>
+      list of topics
+     </para>
+     <itemizedlist>
+      <listitem>
+       <para>
+        metrics
+       </para>
+      </listitem>
+      <listitem>
+       <para>
+        events
+       </para>
+      </listitem>
+      <listitem>
+       <para>
+        alarm-state-transitions
+       </para>
+      </listitem>
+      <listitem>
+       <para>
+        alarm-notifications
+       </para>
+      </listitem>
+      <listitem>
+       <para>
+        retry-notifications
+       </para>
+      </listitem>
+      <listitem>
+       <para>
+        60-seconds-notifications
+       </para>
+      </listitem>
+      <listitem>
+       <para>
+        log
+       </para>
+      </listitem>
+      <listitem>
+       <para>
+        transformed-log
+       </para>
+      </listitem>
+     </itemizedlist>
+     <para>
+      The following are options of every topic:
+     </para>
+     <variablelist>
+      <varlistentry>
+       <term>replicas</term>
+       <listitem>
+        <para>
+         Controls how many servers replicate each message that is written
+        </para>
+       </listitem>
+      </varlistentry>
+      <varlistentry>
+       <term>partitions</term>
+       <listitem>
+        <para>
+         Controls how many logs the topic is sharded into
+        </para>
+       </listitem>
+      </varlistentry>
+      <varlistentry>
+       <term>config_options</term>
+       <listitem>
+        <para>
+         Map of configuration options is described in the <link
+         xlink:href="https://kafka.apache.org/documentation/#topicconfigs">Apache
+         Kafka documentation</link>
+        </para>
+       </listitem>
+      </varlistentry>
+     </variablelist>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+  <para>
+   These parameters only affect first time installations. Parameters may be
+   changed after installation with scripts available from <link xlink:href="https://kafka.apache.org/documentation/#basic_ops">Apache Kafka</link>.
+  </para>
+  <para>
+   Kafka does not support reducing the number of partitions for a topic.
+  </para>
+
+  <bridgehead renderas="sect3"><guimenu>notification:</guimenu>
+  </bridgehead>
+
+  <variablelist>
+   <varlistentry>
+    <term>email_enabled</term>
+    <listitem>
+     <para>
+      Enable or disable email alarm notifications.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term>email_smtp_host</term>
+    <listitem>
+     <para>
+      SMTP smarthost for sending alarm notifications.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term>email_smtp_port</term>
+    <listitem>
+     <para>
+      Port for the SMTP smarthost.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term>email_smtp_user</term>
+    <listitem>
+     <para>
+      User name for authenticating against the smarthost.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term>email_smtp_password</term>
+    <listitem>
+     <para>
+      Password for authenticating against the smarthost.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term>email_smtp_from_address</term>
+    <listitem>
+     <para>
+      Sender address for alarm notifications.
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+
+  <bridgehead renderas="sect3"><guimenu>master: configuration for
+monasca-installer on the &crow; node</guimenu>
+  </bridgehead>
+
+  <variablelist>
+   <varlistentry>
+    <term>influxdb_retention_policy</term>
+    <listitem>
+     <para>
+      Number of days to keep metrics records in influxdb.
+     </para>
+     <para>
+      For an overview of all supported values, see
+      <link
+         xlink:href="https://docs.influxdata.com/influxdb/v1.1/query_language/database_management/#create-retention-policies-with-create-retention-policy"></link>.
+     </para>
+<!--taroth/dpopov 2017-05-15: as the installation chapter has been removed
+       from both SOC Monitoring Operator Guides, there's no internal information
+       we can point to for now, that's why we need to point to the URl above
+      for now-->
+    </listitem>
+   </varlistentry>
+  </variablelist>
+
+<bridgehead renderas="sect3"><guimenu>monasca: settings for libvirt and &ceph;
+monitoring</guimenu>
+  </bridgehead>
+  <variablelist>
+   <varlistentry>
+    <term>
+     monitor_libvirt
+    </term>
+    <listitem>
+     <para>
+      The global switch for toggling libvirt monitoring. If set to
+      <parameter>true</parameter>, libvirt metrics will be gathered on all
+      libvirt based &compnode;s. This setting is available in the &crow; UI.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term>
+     monitor_ceph
+    </term>
+    <listitem>
+     <para>
+      The global switch for toggling &ceph; monitoring. If set to
+      <parameter>true</parameter>, &ceph; metrics will be gathered on all
+      &ceph;-based &compnode;s. This setting is available in &crow; UI. If the
+      &ceph; cluster has been set up independently, &crow; ignores this setting.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term>
+     cache_dir
+    </term>
+    <listitem>
+     <para>
+      The directory where monasca-agent will locally cache various metadata
+      about locally running VMs on each &compnode;.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term>
+     customer_metadata
+    </term>
+    <listitem>
+     <para>
+      Specifies the list of instance metadata keys to be included as dimensions
+      with customer metrics. This is useful for providing more information
+      about an instance.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term>
+     disk_collection_period
+    </term>
+    <listitem>
+     <para>
+      Specifies a minimum interval in seconds for collecting disk metrics.
+      Increase this value to reduce I/O load. If the value is lower than the
+      global agent collection period (<option>check_frequency</option>), it
+      will be ignored in favor of the global collection period.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term>
+     max_ping_concurrency
+    </term>
+    <listitem>
+     <para>
+      Specifies the number of ping command processes to run concurrently when
+      determining whether the VM is reachable. This should be set to a value
+      that allows the plugin to finish within the agent's collection period,
+      even if there is a networking issue. For example, if the expected number
+      of VMs per &compnode; is 40 and each VM has one IP address, then the
+      plugin will take at least 40 seconds to do the ping checks in the
+      worst-case scenario where all pings fail (assuming the default timeout of
+      1 second). Increasing <option>max_ping_concurrency</option> allows the
+      plugin to finish faster.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term>
+     metadata
+    </term>
+    <listitem>
+     <para>
+      Specifies the list of &o_comp; side instance metadata keys to be included
+      as dimensions with the cross-tenant metrics for the
+      <guimenu>monasca</guimenu> project. This is useful for providing more
+      information about an instance.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term>
+     nova_refresh
+    </term>
+    <listitem>
+     <para>
+      Specifies the number of seconds between calls to the &o_comp; API to
+      refresh the instance cache. This is helpful for updating VM hostname and
+      pruning deleted instances from the cache. By default, it is set to 14,400
+      seconds (four hours). Set to 0 to refresh every time the Collector runs,
+      or to <parameter>None</parameter> to disable regular refreshes entirely.
+      In this case, the instance cache will only be refreshed when a new
+      instance is detected.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term>
+     ping_check
+    </term>
+    <listitem>
+     <para>
+      Includes the entire ping command (without the IP address, which is
+      automatically appended) to perform a ping check against instances. The
+      <literal>NAMESPACE</literal> keyword is automatically replaced with the
+      appropriate network namespace for the VM being monitored. Set to
+      <parameter>False</parameter> to disable ping checks.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term>
+     vnic_collection_period
+    </term>
+    <listitem>
+     <para>
+      Specifies a minimum interval in seconds for collecting disk metrics.
+      Increase this value to reduce I/O load. If the value is lower than the
+      global agent collection period (<option>check_frequency</option>), it
+      will be ignored in favor of the global collection period.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term>
+     vm_cpu_check_enable
+    </term>
+    <listitem>
+     <para>
+      Toggles the collection of VM CPU metrics. Set to
+      <parameter>true</parameter> to enable.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term>
+     vm_disks_check_enable
+    </term>
+    <listitem>
+     <para>
+      Toggles the collection of VM disk metrics. Set to
+      <parameter>true</parameter> to enable.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term>
+     vm_extended_disks_check_enable
+    </term>
+    <listitem>
+     <para>
+      Toggles the collection of extended disk metrics. Set to
+      <parameter>true</parameter> to enable.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term>
+     vm_network_check_enable
+    </term>
+    <listitem>
+     <para>
+      Toggles the collection of VM network metrics. Set to
+      <parameter>true</parameter> to enable.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term>
+     vm_ping_check_enable
+    </term>
+    <listitem>
+     <para>
+      Toggles ping checks for checking whether a host is alive. Set to
+      <parameter>true</parameter> to enable.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term>
+     vm_probation
+    </term>
+    <listitem>
+     <para>
+      Specifies a period of time (in seconds) in which to suspend metrics from
+      a newly-created VM. This is to prevent quickly-obsolete metrics in an
+      environment with a high amount of instance churn (VMs created and
+      destroyed in rapid succession). The default probation length is 300
+      seconds (5 minutes). Set to 0 to disable VM probation. In this case,
+      metrics are recorded immediately after a VM is created.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term>
+     vnic_collection_period
+    </term>
+    <listitem>
+     <para>
+      Specifies a minimum interval in seconds for collecting VM network
+      metrics. Increase this value to reduce I/O load. If the value is lower
+      than the global agent collection period
+      (<parameter>check_frequency</parameter>), it will be ignored in favor of
+      the global collection period.
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+
+  <bridgehead renderas="sect3"><guimenu>Deployment</guimenu>
+  </bridgehead>
+
+  <para>
+   The &o_monitor; component consists of following roles:
+  </para>
+
+  <variablelist>
+   <varlistentry>
+    <term>monasca-server</term>
+    <listitem>
+     <para>
+      &o_monitor; server-side components that are deployed by &chef;.
+      Currently, this only creates &o_ident; resources required by &o_monitor;,
+      such as users, roles, endpoints, etc. The rest is left to the
+      Ansible-based <systemitem>monasca-installer</systemitem> run by the
+      <systemitem>monasca-master</systemitem> role.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term>monasca-master</term>
+    <listitem>
+     <para>
+      Runs the Ansible-based <systemitem>monasca-installer</systemitem> from
+      the &crow; node. The installer deploys the &o_monitor; server-side
+      components to the node that has the
+      <systemitem>monasca-server</systemitem> role assigned to it. These
+      components are <systemitem>openstack-monasca-api</systemitem>, and
+      <systemitem>openstack-monasca-log-api</systemitem>, as well as all the
+      back-end services they use.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term>monasca-agent</term>
+    <listitem>
+     <para>
+      Deploys <systemitem>openstack-monasca-agent</systemitem> that is
+      responsible for sending metrics to <systemitem>monasca-api</systemitem>
+      on nodes it is assigned to.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term>monasca-log-agent</term>
+    <listitem>
+     <para>
+      Deploys <systemitem>openstack-monasca-log-agent</systemitem> responsible
+      for sending logs to <systemitem>monasca-log-api</systemitem> on nodes it
+      is assigned to.
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+
+  <figure>
+   <title>The &o_monitor; &Barcl;: Node Deployment Example</title>
+   <mediaobject>
+    <imageobject role="fo">
+     <imagedata fileref="depl_barclamp_monasca_node_deployment.png" width="100%" format="png"/>
+    </imageobject>
+    <imageobject role="html">
+     <imagedata fileref="depl_barclamp_monasca_node_deployment.png" width="75%" format="png"/>
+    </imageobject>
+   </mediaobject>
+  </figure>
  </sect1>
  <sect1 xml:id="sec-depl-ostack-swift">
   <title>Deploying &o_objstore; (optional)</title>
@@ -5701,850 +6545,6 @@ openstack router add subnet <replaceable>router2</replaceable> priv-net-sub</scr
     sufficient to deploy it on a cluster.
    </para>
   </sect2>
- </sect1>
- <sect1 xml:id="sec-depl-ostack-monasca">
-  <title>Deploying &o_monitor;</title>
-
-  <para>
-   &o_monitor; is an open-source monitoring-as-a-service solution that
-   integrates with &ostack;. &o_monitor; is designed for scalability, high
-   performance, and fault tolerance.
-  </para>
-
-  <para>
-   Accessing the <guimenu>Raw</guimenu> interface is not required for
-   day-to-day operation. But as not all &o_monitor; settings are exposed in the
-   &barcl; graphical interface (for example, various performance tuneables), it
-   is recommended to configure &o_monitor; in the <guimenu>Raw</guimenu>
-   mode. Below are the options that can be configured via the
-   <guimenu>Raw</guimenu> interface of the &o_monitor; &barcl;.
-  </para>
-
-  <figure>
-   <title>The &o_monitor; &barcl; Raw Mode</title>
-   <mediaobject>
-    <imageobject role="fo">
-     <imagedata fileref="depl_barclamp_monasca_raw.png" width="100%" format="png"/>
-    </imageobject>
-    <imageobject role="html">
-     <imagedata fileref="depl_barclamp_monasca_raw.png" width="75%" format="png"/>
-    </imageobject>
-   </mediaobject>
-  </figure>
-
-  <bridgehead renderas="sect3"><guimenu>agent: settings for openstack-monasca-agent</guimenu>
-  </bridgehead>
-
-  <variablelist>
-   <varlistentry>
-    <term>keystone</term>
-    <listitem>
-     <para>
-      Contains &o_ident; credentials that the agents use to send metrics. Do
-      not change these options, as they are configured by &crow;.
-     </para>
-    </listitem>
-   </varlistentry>
-   <varlistentry>
-    <term>insecure</term>
-    <listitem>
-     <para>
-      Specifies whether SSL certificates are verified when communicating with
-      &o_ident;. If set to <literal>false</literal>, the
-      <literal>ca_file</literal> option must be specified.
-     </para>
-    </listitem>
-   </varlistentry>
-   <varlistentry>
-    <term>ca_file</term>
-    <listitem>
-     <para>
-      Specifies the location of a CA certificate that is used for verifying
-      &o_ident;'s SSL certificate.
-     </para>
-    </listitem>
-   </varlistentry>
-   <varlistentry>
-    <term>log_dir</term>
-    <listitem>
-     <para>
-      Path for storing log files. The specified path must exist. Do not change
-      the default <filename>/var/log/monasca-agent</filename> path.
-     </para>
-    </listitem>
-   </varlistentry>
-   <varlistentry>
-    <term>log_level</term>
-    <listitem>
-     <para>
-      Agent's log level. Limits log messages to the specified level and above.
-      The following levels are available: Error, Warning, Info (default), and
-      Debug.
-     </para>
-    </listitem>
-   </varlistentry>
-   <varlistentry>
-    <term>check_frequency</term>
-    <listitem>
-     <para>
-      Interval in seconds between running agents' checks.
-     </para>
-    </listitem>
-   </varlistentry>
-   <varlistentry>
-    <term>num_collector_threads</term>
-    <listitem>
-     <para>
-      Number of simultaneous collector threads to run. This refers to the
-      maximum number of different collector plug-ins (for example,
-      <literal>http_check</literal>) that are allowed to run simultaneously. The
-      default value <literal>1</literal> means that plug-ins are run
-      sequentially.
-     </para>
-    </listitem>
-   </varlistentry>
-   <varlistentry>
-    <term>pool_full_max_retries</term>
-    <listitem>
-     <para>
-      If a problem with the results from multiple plug-ins results blocks the
-      entire thread pool (as specified by the
-      <systemitem>num_collector_threads</systemitem> parameter), the collector
-      exits, so it can be restarted by the
-      <systemitem>supervisord</systemitem>. The parameter
-      <systemitem>pool_full_max_retries</systemitem> specifies when this event
-      occurs. The collector exits when the defined number of consecutive
-      collection cycles have ended with the thread pool completely full.
-     </para>
-    </listitem>
-   </varlistentry>
-   <varlistentry>
-    <term>plugin_collect_time_warn</term>
-    <listitem>
-     <para>
-      Upper limit in seconds for any collection plug-in's run time. A warning
-      is logged if a plug-in runs longer than the specified limit.
-     </para>
-    </listitem>
-   </varlistentry>
-   <varlistentry>
-    <term>max_measurement_buffer_size</term>
-    <listitem>
-     <para>
-      Maximum number of measurements to buffer locally if the &o_monitor; API
-      is unreachable. Measurements will be dropped in batches, if the API is
-      still unreachable after the specified number of messages are buffered.
-      The default <literal>-1</literal> value indicates unlimited buffering.
-      Note that a large buffer increases the agent's memory usage.
-     </para>
-    </listitem>
-   </varlistentry>
-   <varlistentry>
-    <term>backlog_send_rate</term>
-    <listitem>
-     <para>
-      Maximum number of measurements to send when the local measurement buffer
-      is flushed.
-     </para>
-    </listitem>
-   </varlistentry>
-   <varlistentry>
-    <term>amplifier</term>
-    <listitem>
-     <para>
-      Number of extra dimensions to add to metrics sent to the &o_monitor; API.
-      This option is intended for load testing purposes only. Do not enable the
-      option in production! The default <literal>0</literal> value disables the
-      addition of dimensions.
-     </para>
-    </listitem>
-   </varlistentry>
-  </variablelist>
-
-  <bridgehead renderas="sect3"><guimenu>log_agent: settings for openstack-monasca-log-agent</guimenu>
-  </bridgehead>
-
-  <variablelist>
-   <varlistentry>
-    <term>max_data_size_kb</term>
-    <listitem>
-     <para>
-      Maximum payload size in kilobytes for a request sent to the &o_monitor;
-      log API.
-     </para>
-    </listitem>
-   </varlistentry>
-   <varlistentry>
-    <term>num_of_logs</term>
-    <listitem>
-     <para>
-      Maximum number of log entries the log agent sends to the &o_monitor; log
-      API in a single request. Reducing the number increases performance.
-     </para>
-    </listitem>
-   </varlistentry>
-   <varlistentry>
-    <term>elapsed_time_sec</term>
-    <listitem>
-     <para>
-      Time interval in seconds between sending logs to the &o_monitor; log API.
-     </para>
-    </listitem>
-   </varlistentry>
-   <varlistentry>
-    <term>delay</term>
-    <listitem>
-     <para>
-      Interval in seconds for checking whether
-      <literal>elapsed_time_sec</literal> has been reached.
-     </para>
-    </listitem>
-   </varlistentry>
-   <varlistentry>
-    <term>keystone</term>
-    <listitem>
-     <para>
-      &o_ident; credentials the log agents use to send logs to the &o_monitor;
-      log API. Do not change this option manually, as it is configured by
-      &crow;.
-     </para>
-    </listitem>
-   </varlistentry>
-  </variablelist>
-
-  <bridgehead renderas="sect3"><guimenu>api: Settings for openstack-monasca-api</guimenu>
-  </bridgehead>
-
-  <variablelist>
-   <varlistentry>
-    <term>bind_host</term>
-    <listitem>
-     <para>
-      Interfaces <literal>monasca-api</literal> listens on. Do not change this
-      option, as it is configured by &crow;.
-     </para>
-    </listitem>
-   </varlistentry>
-   <varlistentry>
-    <term>processes</term>
-    <listitem>
-     <para>
-      Number of processes to spawn.
-     </para>
-    </listitem>
-   </varlistentry>
-   <varlistentry>
-    <term>threads</term>
-    <listitem>
-     <para>
-      Number of WSGI worker threads to spawn.
-     </para>
-    </listitem>
-   </varlistentry>
-   <varlistentry>
-    <term>log_level</term>
-    <listitem>
-     <para>
-      Log level for <systemitem>openstack-monasca-api</systemitem>. Limits log
-      messages to the specified level and above. The following levels are
-      available: Critical, Error, Warning, Info (default), Debug, and Trace.
-     </para>
-    </listitem>
-   </varlistentry>
-  </variablelist>
-
-  <bridgehead renderas="sect3"><guimenu>elasticsearch: server-side settings for elasticsearch</guimenu>
-  </bridgehead>
-
-  <variablelist>
-   <varlistentry>
-    <term>repo_dir</term>
-    <listitem>
-     <para>
-      List of directories for storing &elasticsearch; snapshots. Must be created
-      manually and be writeable by the
-      <systemitem
-          class="username">elasticsearch</systemitem> user.
-      Must contain at least one entry in order for the snapshot functionality
-      to work.
-     </para>
-     <variablelist>
-      <varlistentry>
-       <term>heap_size</term>
-       <listitem>
-        <para>
-         Sets the heap size. We recommend setting heap size at 50% of the
-         available memory, but not more than 31 GB. The default of 4 GB is
-         likely too small and should be increased if possible.
-        </para>
-       </listitem>
-      </varlistentry>
-      <varlistentry>
-       <term>limit_memlock</term>
-       <listitem>
-        <para>
-         The maximum size that may be locked into memory in bytes
-        </para>
-       </listitem>
-      </varlistentry>
-      <varlistentry>
-       <term>limit_nofile</term>
-       <listitem>
-        <para>
-         The maximum number of open file descriptors
-        </para>
-       </listitem>
-      </varlistentry>
-      <varlistentry>
-       <term>limit_nproc</term>
-       <listitem>
-        <para>
-         The maximum number of processes
-        </para>
-       </listitem>
-      </varlistentry>
-      <varlistentry>
-       <term>vm_max_map_count</term>
-       <listitem>
-        <para>
-         The maximum number of memory map areas a process may have.
-        </para>
-       </listitem>
-      </varlistentry>
-     </variablelist>
-    </listitem>
-   </varlistentry>
-  </variablelist>
-  <para>
-   For instructions on creating an &elasticsearch; snapshot, see
-   <xref linkend="backup-recovery"/>.
-  </para>
-
-  <bridgehead renderas="sect3"><guimenu>elasticsearch_curator: settings for
-    elastisearch-curator</guimenu>
-  </bridgehead>
-
-  <para>
-   <systemitem>elasticsearch-curator</systemitem> removes old and large
-   elasticsearch indices. The settings below determine its behavior.
-  </para>
-
-  <variablelist>
-   <varlistentry>
-    <term>delete_after_days</term>
-    <listitem>
-     <para>
-      Time threshold for deleting indices. Indices older the specified number
-      of days are deleted. This parameter is unset by default, so indices are
-      kept indefinitely.
-     </para>
-    </listitem>
-   </varlistentry>
-   <varlistentry>
-    <term>delete_after_size</term>
-    <listitem>
-     <para>
-      Maximum size in megabytes of indices. Indices larger than the specified
-      size are deleted. This parameter is unset by default, so indices are kept
-      irrespective of their size.
-     </para>
-    </listitem>
-   </varlistentry>
-   <varlistentry>
-    <term>delete_exclude_index</term>
-    <listitem>
-     <para>
-      List of indices to exclude from
-      <systemitem>elasticsearch-curator</systemitem> runs. By default, only the
-      <filename>.kibana</filename> files are excluded.
-     </para>
-    </listitem>
-   </varlistentry>
-  </variablelist>
-
-  <bridgehead renderas="sect3"><guimenu>kafka: tunables for
-Kafka</guimenu>
-  </bridgehead>
-
-  <variablelist>
-   <varlistentry>
-    <term>log_retention_hours</term>
-    <listitem>
-     <para>
-      Number of hours for retaining log segments in Kafka's on-disk log.
-      Messages older than the specified value are dropped.
-     </para>
-    </listitem>
-   </varlistentry>
-   <varlistentry>
-    <term>log_retention_bytes</term>
-    <listitem>
-     <para>
-      Maximum size for Kafka's on-disk log in bytes. If the log grows beyond
-      this size, the oldest log segments are dropped.
-     </para>
-    </listitem>
-   </varlistentry>
-   <varlistentry>
-    <term>topics</term>
-    <listitem>
-     <para>
-      list of topics
-     </para>
-     <itemizedlist>
-      <listitem>
-       <para>
-        metrics
-       </para>
-      </listitem>
-      <listitem>
-       <para>
-        events
-       </para>
-      </listitem>
-      <listitem>
-       <para>
-        alarm-state-transitions
-       </para>
-      </listitem>
-      <listitem>
-       <para>
-        alarm-notifications
-       </para>
-      </listitem>
-      <listitem>
-       <para>
-        retry-notifications
-       </para>
-      </listitem>
-      <listitem>
-       <para>
-        60-seconds-notifications
-       </para>
-      </listitem>
-      <listitem>
-       <para>
-        log
-       </para>
-      </listitem>
-      <listitem>
-       <para>
-        transformed-log
-       </para>
-      </listitem>
-     </itemizedlist>
-     <para>
-      The following are options of every topic:
-     </para>
-     <variablelist>
-      <varlistentry>
-       <term>replicas</term>
-       <listitem>
-        <para>
-         Controls how many servers replicate each message that is written
-        </para>
-       </listitem>
-      </varlistentry>
-      <varlistentry>
-       <term>partitions</term>
-       <listitem>
-        <para>
-         Controls how many logs the topic is sharded into
-        </para>
-       </listitem>
-      </varlistentry>
-      <varlistentry>
-       <term>config_options</term>
-       <listitem>
-        <para>
-         Map of configuration options is described in the <link
-         xlink:href="https://kafka.apache.org/documentation/#topicconfigs">Apache
-         Kafka documentation</link>
-        </para>
-       </listitem>
-      </varlistentry>
-     </variablelist>
-    </listitem>
-   </varlistentry>
-  </variablelist>
-  <para>
-   These parameters only affect first time installations. Parameters may be
-   changed after installation with scripts available from <link xlink:href="https://kafka.apache.org/documentation/#basic_ops">Apache Kafka</link>.
-  </para>
-  <para>
-   Kafka does not support reducing the number of partitions for a topic.
-  </para>
-
-  <bridgehead renderas="sect3"><guimenu>notification:</guimenu>
-  </bridgehead>
-
-  <variablelist>
-   <varlistentry>
-    <term>email_enabled</term>
-    <listitem>
-     <para>
-      Enable or disable email alarm notifications.
-     </para>
-    </listitem>
-   </varlistentry>
-   <varlistentry>
-    <term>email_smtp_host</term>
-    <listitem>
-     <para>
-      SMTP smarthost for sending alarm notifications.
-     </para>
-    </listitem>
-   </varlistentry>
-   <varlistentry>
-    <term>email_smtp_port</term>
-    <listitem>
-     <para>
-      Port for the SMTP smarthost.
-     </para>
-    </listitem>
-   </varlistentry>
-   <varlistentry>
-    <term>email_smtp_user</term>
-    <listitem>
-     <para>
-      User name for authenticating against the smarthost.
-     </para>
-    </listitem>
-   </varlistentry>
-   <varlistentry>
-    <term>email_smtp_password</term>
-    <listitem>
-     <para>
-      Password for authenticating against the smarthost.
-     </para>
-    </listitem>
-   </varlistentry>
-   <varlistentry>
-    <term>email_smtp_from_address</term>
-    <listitem>
-     <para>
-      Sender address for alarm notifications.
-     </para>
-    </listitem>
-   </varlistentry>
-  </variablelist>
-
-  <bridgehead renderas="sect3"><guimenu>master: configuration for
-monasca-installer on the &crow; node</guimenu>
-  </bridgehead>
-
-  <variablelist>
-   <varlistentry>
-    <term>influxdb_retention_policy</term>
-    <listitem>
-     <para>
-      Number of days to keep metrics records in influxdb.
-     </para>
-     <para>
-      For an overview of all supported values, see
-      <link
-         xlink:href="https://docs.influxdata.com/influxdb/v1.1/query_language/database_management/#create-retention-policies-with-create-retention-policy"></link>.
-     </para>
-<!--taroth/dpopov 2017-05-15: as the installation chapter has been removed
-       from both SOC Monitoring Operator Guides, there's no internal information
-       we can point to for now, that's why we need to point to the URl above
-      for now-->
-    </listitem>
-   </varlistentry>
-  </variablelist>
-
-<bridgehead renderas="sect3"><guimenu>monasca: settings for libvirt and &ceph;
-monitoring</guimenu>
-  </bridgehead>
-  <variablelist>
-   <varlistentry>
-    <term>
-     monitor_libvirt
-    </term>
-    <listitem>
-     <para>
-      The global switch for toggling libvirt monitoring. If set to
-      <parameter>true</parameter>, libvirt metrics will be gathered on all
-      libvirt based &compnode;s. This setting is available in the &crow; UI.
-     </para>
-    </listitem>
-   </varlistentry>
-   <varlistentry>
-    <term>
-     monitor_ceph
-    </term>
-    <listitem>
-     <para>
-      The global switch for toggling &ceph; monitoring. If set to
-      <parameter>true</parameter>, &ceph; metrics will be gathered on all
-      &ceph;-based &compnode;s. This setting is available in &crow; UI. If the
-      &ceph; cluster has been set up independently, &crow; ignores this setting.
-     </para>
-    </listitem>
-   </varlistentry>
-   <varlistentry>
-    <term>
-     cache_dir
-    </term>
-    <listitem>
-     <para>
-      The directory where monasca-agent will locally cache various metadata
-      about locally running VMs on each &compnode;.
-     </para>
-    </listitem>
-   </varlistentry>
-   <varlistentry>
-    <term>
-     customer_metadata
-    </term>
-    <listitem>
-     <para>
-      Specifies the list of instance metadata keys to be included as dimensions
-      with customer metrics. This is useful for providing more information
-      about an instance.
-     </para>
-    </listitem>
-   </varlistentry>
-   <varlistentry>
-    <term>
-     disk_collection_period
-    </term>
-    <listitem>
-     <para>
-      Specifies a minimum interval in seconds for collecting disk metrics.
-      Increase this value to reduce I/O load. If the value is lower than the
-      global agent collection period (<option>check_frequency</option>), it
-      will be ignored in favor of the global collection period.
-     </para>
-    </listitem>
-   </varlistentry>
-   <varlistentry>
-    <term>
-     max_ping_concurrency
-    </term>
-    <listitem>
-     <para>
-      Specifies the number of ping command processes to run concurrently when
-      determining whether the VM is reachable. This should be set to a value
-      that allows the plugin to finish within the agent's collection period,
-      even if there is a networking issue. For example, if the expected number
-      of VMs per &compnode; is 40 and each VM has one IP address, then the
-      plugin will take at least 40 seconds to do the ping checks in the
-      worst-case scenario where all pings fail (assuming the default timeout of
-      1 second). Increasing <option>max_ping_concurrency</option> allows the
-      plugin to finish faster.
-     </para>
-    </listitem>
-   </varlistentry>
-   <varlistentry>
-    <term>
-     metadata
-    </term>
-    <listitem>
-     <para>
-      Specifies the list of &o_comp; side instance metadata keys to be included
-      as dimensions with the cross-tenant metrics for the
-      <guimenu>monasca</guimenu> project. This is useful for providing more
-      information about an instance.
-     </para>
-    </listitem>
-   </varlistentry>
-   <varlistentry>
-    <term>
-     nova_refresh
-    </term>
-    <listitem>
-     <para>
-      Specifies the number of seconds between calls to the &o_comp; API to
-      refresh the instance cache. This is helpful for updating VM hostname and
-      pruning deleted instances from the cache. By default, it is set to 14,400
-      seconds (four hours). Set to 0 to refresh every time the Collector runs,
-      or to <parameter>None</parameter> to disable regular refreshes entirely.
-      In this case, the instance cache will only be refreshed when a new
-      instance is detected.
-     </para>
-    </listitem>
-   </varlistentry>
-   <varlistentry>
-    <term>
-     ping_check
-    </term>
-    <listitem>
-     <para>
-      Includes the entire ping command (without the IP address, which is
-      automatically appended) to perform a ping check against instances. The
-      <literal>NAMESPACE</literal> keyword is automatically replaced with the
-      appropriate network namespace for the VM being monitored. Set to
-      <parameter>False</parameter> to disable ping checks.
-     </para>
-    </listitem>
-   </varlistentry>
-   <varlistentry>
-    <term>
-     vnic_collection_period
-    </term>
-    <listitem>
-     <para>
-      Specifies a minimum interval in seconds for collecting disk metrics.
-      Increase this value to reduce I/O load. If the value is lower than the
-      global agent collection period (<option>check_frequency</option>), it
-      will be ignored in favor of the global collection period.
-     </para>
-    </listitem>
-   </varlistentry>
-   <varlistentry>
-    <term>
-     vm_cpu_check_enable
-    </term>
-    <listitem>
-     <para>
-      Toggles the collection of VM CPU metrics. Set to
-      <parameter>true</parameter> to enable.
-     </para>
-    </listitem>
-   </varlistentry>
-   <varlistentry>
-    <term>
-     vm_disks_check_enable
-    </term>
-    <listitem>
-     <para>
-      Toggles the collection of VM disk metrics. Set to
-      <parameter>true</parameter> to enable.
-     </para>
-    </listitem>
-   </varlistentry>
-   <varlistentry>
-    <term>
-     vm_extended_disks_check_enable
-    </term>
-    <listitem>
-     <para>
-      Toggles the collection of extended disk metrics. Set to
-      <parameter>true</parameter> to enable.
-     </para>
-    </listitem>
-   </varlistentry>
-   <varlistentry>
-    <term>
-     vm_network_check_enable
-    </term>
-    <listitem>
-     <para>
-      Toggles the collection of VM network metrics. Set to
-      <parameter>true</parameter> to enable.
-     </para>
-    </listitem>
-   </varlistentry>
-   <varlistentry>
-    <term>
-     vm_ping_check_enable
-    </term>
-    <listitem>
-     <para>
-      Toggles ping checks for checking whether a host is alive. Set to
-      <parameter>true</parameter> to enable.
-     </para>
-    </listitem>
-   </varlistentry>
-   <varlistentry>
-    <term>
-     vm_probation
-    </term>
-    <listitem>
-     <para>
-      Specifies a period of time (in seconds) in which to suspend metrics from
-      a newly-created VM. This is to prevent quickly-obsolete metrics in an
-      environment with a high amount of instance churn (VMs created and
-      destroyed in rapid succession). The default probation length is 300
-      seconds (5 minutes). Set to 0 to disable VM probation. In this case,
-      metrics are recorded immediately after a VM is created.
-     </para>
-    </listitem>
-   </varlistentry>
-   <varlistentry>
-    <term>
-     vnic_collection_period
-    </term>
-    <listitem>
-     <para>
-      Specifies a minimum interval in seconds for collecting VM network
-      metrics. Increase this value to reduce I/O load. If the value is lower
-      than the global agent collection period
-      (<parameter>check_frequency</parameter>), it will be ignored in favor of
-      the global collection period.
-     </para>
-    </listitem>
-   </varlistentry>
-  </variablelist>
-
-  <bridgehead renderas="sect3"><guimenu>Deployment</guimenu>
-  </bridgehead>
-
-  <para>
-   The &o_monitor; component consists of following roles:
-  </para>
-
-  <variablelist>
-   <varlistentry>
-    <term>monasca-server</term>
-    <listitem>
-     <para>
-      &o_monitor; server-side components that are deployed by &chef;.
-      Currently, this only creates &o_ident; resources required by &o_monitor;,
-      such as users, roles, endpoints, etc. The rest is left to the
-      Ansible-based <systemitem>monasca-installer</systemitem> run by the
-      <systemitem>monasca-master</systemitem> role.
-     </para>
-    </listitem>
-   </varlistentry>
-   <varlistentry>
-    <term>monasca-master</term>
-    <listitem>
-     <para>
-      Runs the Ansible-based <systemitem>monasca-installer</systemitem> from
-      the &crow; node. The installer deploys the &o_monitor; server-side
-      components to the node that has the
-      <systemitem>monasca-server</systemitem> role assigned to it. These
-      components are <systemitem>openstack-monasca-api</systemitem>, and
-      <systemitem>openstack-monasca-log-api</systemitem>, as well as all the
-      back-end services they use.
-     </para>
-    </listitem>
-   </varlistentry>
-   <varlistentry>
-    <term>monasca-agent</term>
-    <listitem>
-     <para>
-      Deploys <systemitem>openstack-monasca-agent</systemitem> that is
-      responsible for sending metrics to <systemitem>monasca-api</systemitem>
-      on nodes it is assigned to.
-     </para>
-    </listitem>
-   </varlistentry>
-   <varlistentry>
-    <term>monasca-log-agent</term>
-    <listitem>
-     <para>
-      Deploys <systemitem>openstack-monasca-log-agent</systemitem> responsible
-      for sending logs to <systemitem>monasca-log-api</systemitem> on nodes it
-      is assigned to.
-     </para>
-    </listitem>
-   </varlistentry>
-  </variablelist>
-
-  <figure>
-   <title>The &o_monitor; &Barcl;: Node Deployment Example</title>
-   <mediaobject>
-    <imageobject role="fo">
-     <imagedata fileref="depl_barclamp_monasca_node_deployment.png" width="100%" format="png"/>
-    </imageobject>
-    <imageobject role="html">
-     <imagedata fileref="depl_barclamp_monasca_node_deployment.png" width="75%" format="png"/>
-    </imageobject>
-   </mediaobject>
-  </figure>
  </sect1>
  <sect1 xml:id="sec-depl-ostack-octavia">
   <title>Deploying Octavia</title>


### PR DESCRIPTION
added "(Optional)" to the Monasca deployment and moved it just after keystone per https://bugzilla.suse.com/show_bug.cgi?id=1075325 
[suse-openstack-cloud-crowbar-all_color_en.zip](https://github.com/SUSE-Cloud/doc-cloud/files/6480430/suse-openstack-cloud-crowbar-all_color_en.zip)
