### PR TITLE
Add DOCBOOK5_RNG_URI in DC files to validate

### DIFF
--- a/DC-hpe-helion-openstack-clm-all
+++ b/DC-hpe-helion-openstack-clm-all
@@ -13,3 +13,5 @@ PROFVENDOR="hpe"
 
 ## Stylesheet location
 STYLEROOT="/usr/share/xml/docbook/stylesheet/hpe-ns"
+# Schema URL
+DOCBOOK5_RNG_URI="http://docbook.org/xml/5.1/rng/docbookxi.rng"

--- a/DC-hpe-helion-openstack-installation
+++ b/DC-hpe-helion-openstack-installation
@@ -13,3 +13,5 @@ PROFVENDOR="hpe"
 
 ## Stylesheet location
 STYLEROOT="/usr/share/xml/docbook/stylesheet/hpe-ns"
+# Schema URL
+DOCBOOK5_RNG_URI="http://docbook.org/xml/5.1/rng/docbookxi.rng"

--- a/DC-hpe-helion-openstack-migration
+++ b/DC-hpe-helion-openstack-migration
@@ -13,3 +13,5 @@ PROFVENDOR="hpe"
 
 ## Stylesheet location
 STYLEROOT="/usr/share/xml/docbook/stylesheet/hpe-ns"
+# Schema URL
+DOCBOOK5_RNG_URI="http://docbook.org/xml/5.1/rng/docbookxi.rng"

--- a/DC-hpe-helion-openstack-operations
+++ b/DC-hpe-helion-openstack-operations
@@ -13,3 +13,5 @@ PROFVENDOR="hpe"
 
 ## Stylesheet location
 STYLEROOT="/usr/share/xml/docbook/stylesheet/hpe-ns"
+# Schema URL
+DOCBOOK5_RNG_URI="http://docbook.org/xml/5.1/rng/docbookxi.rng"

--- a/DC-hpe-helion-openstack-opsconsole
+++ b/DC-hpe-helion-openstack-opsconsole
@@ -13,3 +13,5 @@ PROFVENDOR="hpe"
 
 ## Stylesheet location
 STYLEROOT="/usr/share/xml/docbook/stylesheet/hpe-ns"
+# Schema URL
+DOCBOOK5_RNG_URI="http://docbook.org/xml/5.1/rng/docbookxi.rng"

--- a/DC-hpe-helion-openstack-planning
+++ b/DC-hpe-helion-openstack-planning
@@ -13,3 +13,6 @@ PROFVENDOR="hpe"
 
 ## Stylesheet location
 STYLEROOT="/usr/share/xml/docbook/stylesheet/hpe-ns"
+
+# Schema URL
+DOCBOOK5_RNG_URI="http://docbook.org/xml/5.1/rng/docbookxi.rng"

--- a/DC-hpe-helion-openstack-security
+++ b/DC-hpe-helion-openstack-security
@@ -13,3 +13,5 @@ PROFVENDOR="hpe"
 
 ## Stylesheet location
 STYLEROOT="/usr/share/xml/docbook/stylesheet/hpe-ns"
+# Schema URL
+DOCBOOK5_RNG_URI="http://docbook.org/xml/5.1/rng/docbookxi.rng"

--- a/DC-hpe-helion-openstack-user
+++ b/DC-hpe-helion-openstack-user
@@ -13,3 +13,5 @@ PROFVENDOR="hpe"
 
 ## Stylesheet location
 STYLEROOT="/usr/share/xml/docbook/stylesheet/hpe-ns"
+# Schema URL
+DOCBOOK5_RNG_URI="http://docbook.org/xml/5.1/rng/docbookxi.rng"

--- a/DC-suse-openstack-cloud-clm-all
+++ b/DC-suse-openstack-cloud-clm-all
@@ -13,3 +13,5 @@ PROFVENDOR="suse"
 
 ## Stylesheet location
 STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2021-ns"
+# Schema URL
+DOCBOOK5_RNG_URI="http://docbook.org/xml/5.1/rng/docbookxi.rng"

--- a/DC-suse-openstack-cloud-crowbar-all
+++ b/DC-suse-openstack-cloud-crowbar-all
@@ -13,3 +13,5 @@ PROFVENDOR="suse-crow"
 
 ## Stylesheet location
 STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2021-ns"
+# Schema URL
+DOCBOOK5_RNG_URI="http://docbook.org/xml/5.1/rng/docbookxi.rng"

--- a/DC-suse-openstack-cloud-deployment
+++ b/DC-suse-openstack-cloud-deployment
@@ -16,3 +16,5 @@ STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2021-ns"
 
 ### Sort the glossary
 XSLTPARAM="--param glossary.sort=1"
+# Schema URL
+DOCBOOK5_RNG_URI="http://docbook.org/xml/5.1/rng/docbookxi.rng"

--- a/DC-suse-openstack-cloud-installation
+++ b/DC-suse-openstack-cloud-installation
@@ -13,3 +13,5 @@ PROFVENDOR="suse"
 
 ## Stylesheet location
 STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2021-ns"
+# Schema URL
+DOCBOOK5_RNG_URI="http://docbook.org/xml/5.1/rng/docbookxi.rng"

--- a/DC-suse-openstack-cloud-operations
+++ b/DC-suse-openstack-cloud-operations
@@ -13,3 +13,5 @@ PROFVENDOR="suse"
 
 ## Stylesheet location
 STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2021-ns"
+# Schema URL
+DOCBOOK5_RNG_URI="http://docbook.org/xml/5.1/rng/docbookxi.rng"

--- a/DC-suse-openstack-cloud-opsconsole
+++ b/DC-suse-openstack-cloud-opsconsole
@@ -13,3 +13,5 @@ PROFVENDOR="suse"
 
 ## Stylesheet location
 STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2021-ns"
+# Schema URL
+DOCBOOK5_RNG_URI="http://docbook.org/xml/5.1/rng/docbookxi.rng"

--- a/DC-suse-openstack-cloud-planning
+++ b/DC-suse-openstack-cloud-planning
@@ -13,3 +13,5 @@ PROFVENDOR="suse"
 
 ## Stylesheet location
 STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2021-ns"
+# Schema URL
+DOCBOOK5_RNG_URI="http://docbook.org/xml/5.1/rng/docbookxi.rng"

--- a/DC-suse-openstack-cloud-security
+++ b/DC-suse-openstack-cloud-security
@@ -13,3 +13,5 @@ PROFVENDOR="suse"
 
 ## Stylesheet location
 STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2021-ns"
+# Schema URL
+DOCBOOK5_RNG_URI="http://docbook.org/xml/5.1/rng/docbookxi.rng"

--- a/DC-suse-openstack-cloud-socmmsoperator
+++ b/DC-suse-openstack-cloud-socmmsoperator
@@ -2,3 +2,5 @@ MAIN=MAIN.msoperator.xml
 STYLEROOT=/usr/share/xml/docbook/stylesheet/suse2021-ns
 PROFVENDOR="suse-crow"
 ROOTID=book-socmmsoperator
+# Schema URL
+DOCBOOK5_RNG_URI="http://docbook.org/xml/5.1/rng/docbookxi.rng"

--- a/DC-suse-openstack-cloud-socmosoperator
+++ b/DC-suse-openstack-cloud-socmosoperator
@@ -2,3 +2,5 @@ MAIN=MAIN.osoperator.xml
 STYLEROOT=/usr/share/xml/docbook/stylesheet/suse2021-ns
 PROFVENDOR="suse-crow"
 ROOTID=book-socmosoperator
+# Schema URL
+DOCBOOK5_RNG_URI="http://docbook.org/xml/5.1/rng/docbookxi.rng"

--- a/DC-suse-openstack-cloud-socmoverview
+++ b/DC-suse-openstack-cloud-socmoverview
@@ -2,3 +2,5 @@ MAIN=MAIN.overview.xml
 STYLEROOT=/usr/share/xml/docbook/stylesheet/suse2021-ns
 PROFVENDOR="suse-crow"
 ROOTID=book-socmoverview
+# Schema URL
+DOCBOOK5_RNG_URI="http://docbook.org/xml/5.1/rng/docbookxi.rng"

--- a/DC-suse-openstack-cloud-supplement
+++ b/DC-suse-openstack-cloud-supplement
@@ -13,3 +13,5 @@ PROFVENDOR="suse-crow"
 
 ## Stylesheet location
 STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2021-ns"
+# Schema URL
+DOCBOOK5_RNG_URI="http://docbook.org/xml/5.1/rng/docbookxi.rng"

--- a/DC-suse-openstack-cloud-upstream-admin
+++ b/DC-suse-openstack-cloud-upstream-admin
@@ -13,3 +13,5 @@ PROFVENDOR="suse-crow"
 
 ## Stylesheet location
 STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2021-ns"
+# Schema URL
+DOCBOOK5_RNG_URI="http://docbook.org/xml/5.1/rng/docbookxi.rng"

--- a/DC-suse-openstack-cloud-upstream-user
+++ b/DC-suse-openstack-cloud-upstream-user
@@ -13,3 +13,5 @@ PROFVENDOR="suse-crow"
 
 ## Stylesheet location
 STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2021-ns"
+# Schema URL
+DOCBOOK5_RNG_URI="http://docbook.org/xml/5.1/rng/docbookxi.rng"

--- a/DC-suse-openstack-cloud-user
+++ b/DC-suse-openstack-cloud-user
@@ -13,3 +13,5 @@ PROFVENDOR="suse"
 
 ## Stylesheet location
 STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2021-ns"
+# Schema URL
+DOCBOOK5_RNG_URI="http://docbook.org/xml/5.1/rng/docbookxi.rng"


### PR DESCRIPTION
Some guides did not validate with GeekoDoc. As SOC 8 is now unsupported, it doesn't make sense to go through all the files and change them.

To be able to build and publish them on docserv on last time, we need to ensure we validate with DocBook 5.1. This PR make this happen.