### PR TITLE
Use old 2013-ns stylesheet to build old DB4 sources

### DIFF
--- a/DC-suse-openstack-cloud-crowbar-all
+++ b/DC-suse-openstack-cloud-crowbar-all
@@ -12,6 +12,6 @@ PROFOS="sles"
 PROFVENDOR="suse-crow"
 
 ## Stylesheet location
-STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2021-ns"
+STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2013-ns"
 # Schema URL
 DOCBOOK5_RNG_URI="http://docbook.org/xml/5.1/rng/docbookxi.rng"

--- a/DC-suse-openstack-cloud-deployment
+++ b/DC-suse-openstack-cloud-deployment
@@ -12,7 +12,7 @@ PROFOS="sles"
 PROFVENDOR="suse-crow"
 
 ## Stylesheet location
-STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2021-ns"
+STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2013-ns"
 
 ### Sort the glossary
 XSLTPARAM="--param glossary.sort=1"

--- a/DC-suse-openstack-cloud-socmmsoperator
+++ b/DC-suse-openstack-cloud-socmmsoperator
@@ -1,5 +1,5 @@
 MAIN=MAIN.msoperator.xml
-STYLEROOT=/usr/share/xml/docbook/stylesheet/suse2021-ns
+STYLEROOT=/usr/share/xml/docbook/stylesheet/suse2013-ns
 PROFVENDOR="suse-crow"
 ROOTID=book-socmmsoperator
 # Schema URL

--- a/DC-suse-openstack-cloud-socmosoperator
+++ b/DC-suse-openstack-cloud-socmosoperator
@@ -1,5 +1,5 @@
 MAIN=MAIN.osoperator.xml
-STYLEROOT=/usr/share/xml/docbook/stylesheet/suse2021-ns
+STYLEROOT=/usr/share/xml/docbook/stylesheet/suse2013-ns
 PROFVENDOR="suse-crow"
 ROOTID=book-socmosoperator
 # Schema URL

--- a/DC-suse-openstack-cloud-socmoverview
+++ b/DC-suse-openstack-cloud-socmoverview
@@ -1,5 +1,5 @@
 MAIN=MAIN.overview.xml
-STYLEROOT=/usr/share/xml/docbook/stylesheet/suse2021-ns
+STYLEROOT=/usr/share/xml/docbook/stylesheet/suse2013-ns
 PROFVENDOR="suse-crow"
 ROOTID=book-socmoverview
 # Schema URL


### PR DESCRIPTION
When I tried to build SOC8, it failed. It was due to that our newer stylesheets requires DocBook 5, but some SOC8 sources uses still DocBook 4.

This PR changes the new stylesheets to the suse2013-ns stylesheets which supports DocBook 4. No content changes.