### PR TITLE
Validate with DocBook 5.1 for Cloud 4

### DIFF
--- a/DC-susecloud-admin
+++ b/DC-susecloud-admin
@@ -26,3 +26,5 @@ export DOCCONF=$BASH_SOURCE
 ##do not show remarks directly in the (PDF) text 
 #XSLTPARAM="--param use.xep.annotate.pdf 0"
 
+# Schema URL
+DOCBOOK5_RNG_URI="http://docbook.org/xml/5.1/rng/docbookxi.rng"

--- a/DC-susecloud-all
+++ b/DC-susecloud-all
@@ -24,3 +24,5 @@ PROFOS="sles"
 export DOCCONF=$BASH_SOURCE
 
 #XSLTPARAM="--param hyphenate.verbatim 0"
+# Schema URL
+DOCBOOK5_RNG_URI="http://docbook.org/xml/5.1/rng/docbookxi.rng"

--- a/DC-susecloud-deployment
+++ b/DC-susecloud-deployment
@@ -22,3 +22,5 @@ STYLEROOT="/usr/share/xml/docbook/stylesheet/suse"
 export DOCCONF=$BASH_SOURCE
 
 #XSLTPARAM="--param hyphenate.verbatim 0"
+# Schema URL
+DOCBOOK5_RNG_URI="http://docbook.org/xml/5.1/rng/docbookxi.rng"

--- a/DC-susecloud-user
+++ b/DC-susecloud-user
@@ -25,3 +25,5 @@ export DOCCONF=$BASH_SOURCE
 
 ##do not show remarks directly in the (PDF) text 
 #XSLTPARAM="--param use.xep.annotate.pdf 0"
+# Schema URL
+DOCBOOK5_RNG_URI="http://docbook.org/xml/5.1/rng/docbookxi.rng"


### PR DESCRIPTION
Validating with GeekoDoc would be risky if incompatible changes are introduced.

To mitigate this risk, we validate it with DocBook 5.1. As this product is unsupported anyway, it would be a small price to pay.

This fix makes it easier to build unsupported products.
