### PR TITLE
Use suse2022-ns stylesheets for SOC 9

### DIFF
--- a/DC-rhel-installation
+++ b/DC-rhel-installation
@@ -12,4 +12,4 @@ PROFOS="sles"
 PROFVENDOR="suse"
 
 ## Stylesheet location
-STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2021-ns"
+STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2022-ns"

--- a/DC-suse-openstack-cloud-clm-all
+++ b/DC-suse-openstack-cloud-clm-all
@@ -12,4 +12,4 @@ PROFOS="sles"
 PROFVENDOR="suse"
 
 ## Stylesheet location
-STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2021-ns"
+STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2022-ns"

--- a/DC-suse-openstack-cloud-crowbar-all
+++ b/DC-suse-openstack-cloud-crowbar-all
@@ -12,4 +12,4 @@ PROFOS="sles"
 PROFVENDOR="suse-crow"
 
 ## Stylesheet location
-STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2021-ns"
+STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2022-ns"

--- a/DC-suse-openstack-cloud-crowbar-deployment
+++ b/DC-suse-openstack-cloud-crowbar-deployment
@@ -12,7 +12,7 @@ PROFOS="sles"
 PROFVENDOR="suse-crow"
 
 ## Stylesheet location
-STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2021-ns"
+STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2022-ns"
 
 ## Sort the glossary
 XSLTPARAM="--param glossary.sort=1"

--- a/DC-suse-openstack-cloud-crowbar-operations
+++ b/DC-suse-openstack-cloud-crowbar-operations
@@ -12,4 +12,4 @@ PROFOS="sles"
 PROFVENDOR="suse-crow"
 
 ## Stylesheet location
-STYLEROOT=/usr/share/xml/docbook/stylesheet/suse2021-ns
+STYLEROOT=/usr/share/xml/docbook/stylesheet/suse2022-ns

--- a/DC-suse-openstack-cloud-deployment
+++ b/DC-suse-openstack-cloud-deployment
@@ -12,4 +12,4 @@ PROFOS="sles"
 PROFVENDOR="suse"
 
 ## Stylesheet location
-STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2021-ns"
+STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2022-ns"

--- a/DC-suse-openstack-cloud-operations
+++ b/DC-suse-openstack-cloud-operations
@@ -12,4 +12,4 @@ PROFOS="sles"
 PROFVENDOR="suse"
 
 ## Stylesheet location
-STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2021-ns"
+STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2022-ns"

--- a/DC-suse-openstack-cloud-poc
+++ b/DC-suse-openstack-cloud-poc
@@ -17,4 +17,4 @@ PROFOS="sles"
 PROFVENDOR="suse"
 
 ## stylesheet location
-STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2021-ns"
+STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2022-ns"

--- a/DC-suse-openstack-cloud-poc-crowbar
+++ b/DC-suse-openstack-cloud-poc-crowbar
@@ -12,4 +12,4 @@ PROFOS="sles"
 PROFVENDOR="suse-crow"
 
 ## Stylesheet location
-STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2021-ns"
+STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2022-ns"

--- a/DC-suse-openstack-cloud-security
+++ b/DC-suse-openstack-cloud-security
@@ -12,4 +12,4 @@ PROFOS="sles"
 PROFVENDOR="suse"
 
 ## Stylesheet location
-STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2021-ns"
+STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2022-ns"

--- a/DC-suse-openstack-cloud-supplement
+++ b/DC-suse-openstack-cloud-supplement
@@ -12,4 +12,4 @@ PROFOS="sles"
 PROFVENDOR="suse"
 
 ## Stylesheet location
-STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2021-ns"
+STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2022-ns"


### PR DESCRIPTION
# Problem

The current SOC 9 HTML have some issues regarding SEO. The old stylesheets (suse2021-ns) doesn't support them and won't get an update.

# Solution
This PR doesn't have any content changes. It only changes the DC files and switch to our new layout (suse2022-ns).
