### PR TITLE
Change suse stylesheets for SOC 8

### DIFF
--- a/DC-suse-openstack-cloud-clm-all
+++ b/DC-suse-openstack-cloud-clm-all
@@ -12,6 +12,6 @@ PROFOS="sles"
 PROFVENDOR="suse"
 
 ## Stylesheet location
-STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2021-ns"
+STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2022-ns"
 # Schema URL
 DOCBOOK5_RNG_URI="http://docbook.org/xml/5.1/rng/docbookxi.rng"

--- a/DC-suse-openstack-cloud-installation
+++ b/DC-suse-openstack-cloud-installation
@@ -12,6 +12,6 @@ PROFOS="sles"
 PROFVENDOR="suse"
 
 ## Stylesheet location
-STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2021-ns"
+STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2022-ns"
 # Schema URL
 DOCBOOK5_RNG_URI="http://docbook.org/xml/5.1/rng/docbookxi.rng"

--- a/DC-suse-openstack-cloud-operations
+++ b/DC-suse-openstack-cloud-operations
@@ -12,6 +12,6 @@ PROFOS="sles"
 PROFVENDOR="suse"
 
 ## Stylesheet location
-STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2021-ns"
+STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2022-ns"
 # Schema URL
 DOCBOOK5_RNG_URI="http://docbook.org/xml/5.1/rng/docbookxi.rng"

--- a/DC-suse-openstack-cloud-opsconsole
+++ b/DC-suse-openstack-cloud-opsconsole
@@ -12,6 +12,6 @@ PROFOS="sles"
 PROFVENDOR="suse"
 
 ## Stylesheet location
-STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2021-ns"
+STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2022-ns"
 # Schema URL
 DOCBOOK5_RNG_URI="http://docbook.org/xml/5.1/rng/docbookxi.rng"

--- a/DC-suse-openstack-cloud-planning
+++ b/DC-suse-openstack-cloud-planning
@@ -12,6 +12,6 @@ PROFOS="sles"
 PROFVENDOR="suse"
 
 ## Stylesheet location
-STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2021-ns"
+STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2022-ns"
 # Schema URL
 DOCBOOK5_RNG_URI="http://docbook.org/xml/5.1/rng/docbookxi.rng"

--- a/DC-suse-openstack-cloud-security
+++ b/DC-suse-openstack-cloud-security
@@ -12,6 +12,6 @@ PROFOS="sles"
 PROFVENDOR="suse"
 
 ## Stylesheet location
-STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2021-ns"
+STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2022-ns"
 # Schema URL
 DOCBOOK5_RNG_URI="http://docbook.org/xml/5.1/rng/docbookxi.rng"

--- a/DC-suse-openstack-cloud-supplement
+++ b/DC-suse-openstack-cloud-supplement
@@ -12,6 +12,6 @@ PROFOS="sles"
 PROFVENDOR="suse-crow"
 
 ## Stylesheet location
-STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2021-ns"
+STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2022-ns"
 # Schema URL
 DOCBOOK5_RNG_URI="http://docbook.org/xml/5.1/rng/docbookxi.rng"

--- a/DC-suse-openstack-cloud-upstream-admin
+++ b/DC-suse-openstack-cloud-upstream-admin
@@ -12,6 +12,6 @@ PROFOS="sles"
 PROFVENDOR="suse-crow"
 
 ## Stylesheet location
-STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2021-ns"
+STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2022-ns"
 # Schema URL
 DOCBOOK5_RNG_URI="http://docbook.org/xml/5.1/rng/docbookxi.rng"

--- a/DC-suse-openstack-cloud-upstream-user
+++ b/DC-suse-openstack-cloud-upstream-user
@@ -12,6 +12,6 @@ PROFOS="sles"
 PROFVENDOR="suse-crow"
 
 ## Stylesheet location
-STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2021-ns"
+STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2022-ns"
 # Schema URL
 DOCBOOK5_RNG_URI="http://docbook.org/xml/5.1/rng/docbookxi.rng"

--- a/DC-suse-openstack-cloud-user
+++ b/DC-suse-openstack-cloud-user
@@ -12,6 +12,6 @@ PROFOS="sles"
 PROFVENDOR="suse"
 
 ## Stylesheet location
-STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2021-ns"
+STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2022-ns"
 # Schema URL
 DOCBOOK5_RNG_URI="http://docbook.org/xml/5.1/rng/docbookxi.rng"


### PR DESCRIPTION
# Problem

The current SOC 8 HTML have some issues regarding SEO. The old stylesheets (suse2021-ns) doesn't support them and won't get an update.

# Solution
This PR doesn't have any content changes. It only changes the DC files and switch to our new layout (suse2022-ns).
